### PR TITLE
[Scheme] Add initial frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ makefile
 zeta
 cplush
 cjs
+cscheme
 *.dSYM

--- a/makefile.in
+++ b/makefile.in
@@ -8,9 +8,9 @@ PKGS_DIR=\"$(shell pwd)/packages/\"
 # Add a preprocessor definition for the packages directory
 CXXFLAGS:=${CXXFLAGS} -DPKGS_DIR="${PKGS_DIR}"
 
-all: zeta cplush plush-pkg cjs
+all: zeta cplush plush-pkg cjs cscheme
 
-test: zeta cplush plush-pkg
+test: zeta cplush plush-pkg cscheme
 	# Core zetavm tests
 	./$(ZETA_BIN) --test
 	./$(ZETA_BIN) tests/vm/ex_loop_cnt.zim
@@ -47,6 +47,8 @@ test: zeta cplush plush-pkg
 	# Check that source position is reported on errors
 	./$(ZETA_BIN) tests/plush/assert.pls | grep --quiet "3:1"
 	./$(ZETA_BIN) tests/plush/call_site_pos.pls | grep --quiet "call_site_pos.pls@8:"
+	# cscheme tests
+	./$(CSCHEME_BIN) --test
 
 clean:
 	rm -rf *.o *.dSYM $(ZETA_BIN) $(CPLUSH_BIN) $(CJS_BIN) config.status config.log
@@ -100,3 +102,17 @@ js/main.cpp
 
 cjs: js/*.cpp js/*.h
 	$(CXX) $(CXXFLAGS) -o $(CJS_BIN) $(CJS_SRCS)
+
+##############################################################################
+# Scheme compiler
+##############################################################################
+
+CSCHEME_BIN=cscheme
+
+CSCHEME_SRCS=       \
+scheme/parser.cpp   \
+scheme/codegen.cpp  \
+scheme/main.cpp     \
+
+cscheme: scheme/*.cpp scheme/*.h
+	$(CXX) $(CXXFLAGS) -o $(CSCHEME_BIN) $(CSCHEME_SRCS)

--- a/scheme/codegen.cpp
+++ b/scheme/codegen.cpp
@@ -1,0 +1,14 @@
+#include <cassert>
+#include <vector>
+#include <string>
+#include <iostream>
+#include "codegen.h"
+
+/**
+Generate code for a code unit
+*/
+std::string genProgram(std::unique_ptr<Program> value)
+{
+    // TODO: Everything.
+    return "";
+} 

--- a/scheme/codegen.h
+++ b/scheme/codegen.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include "parser.h"
+
+std::string genProgram(std::unique_ptr<Program> val);
+

--- a/scheme/main.cpp
+++ b/scheme/main.cpp
@@ -1,0 +1,47 @@
+#include <cassert>
+#include <cstring>
+#include <iostream>
+#include <exception>
+#include "parser.h"
+#include "codegen.h"
+
+int main(int argc, char** argv)
+{
+    try
+    {
+        // If we are in test mode
+        if (argc == 2 && strcmp(argv[1], "--test") == 0)
+        {
+            testParser();
+            return 0;
+        }
+
+        if (argc == 2)
+        {
+            auto srcFile = argv[1];
+
+            // Parse the source file
+            auto srcUnit = parseFile(srcFile);
+
+            // Generate a code string
+            auto codeStr = genProgram(std::move(srcUnit));
+
+            // Output the string to standard output
+            std::cout << codeStr;
+
+            return 0;
+        }
+
+        std::cout << "unrecognized options" << std::endl;
+        std::cout << "usage: " << argv[0] << " <in_file> <out_file>" << std::endl;
+        return -1;
+    }
+
+    catch (ParseError& e)
+    {
+        std::cerr << e.toString() << std::endl;
+        return -1;
+    }
+
+    return 0;
+}

--- a/scheme/parser.cpp
+++ b/scheme/parser.cpp
@@ -1,0 +1,568 @@
+#include <cassert>
+#include <cstring>
+#include <iostream>
+#include "parser.h"
+
+/// Read an entire file at once
+std::string readFile(std::string fileName)
+{
+    FILE* file = fopen(fileName.c_str(), "r");
+
+    if (!file)
+    {
+        fprintf(stderr, "failed to open file \"%s\"\n", fileName.c_str());
+        exit(-1);
+    }
+
+    // Get the file size in bytes
+    fseek(file, 0, SEEK_END);
+    size_t len = ftell(file);
+    fseek(file, 0, SEEK_SET);
+
+    char* buf = (char*)malloc(len+1);
+
+    // Read into the allocated buffer
+    int read = fread(buf, 1, len, file);
+
+    if (read != len)
+    {
+        printf("failed to read file");
+        assert (false);
+    }
+
+    // Add a null terminator to the string
+    buf[len] = '\0';
+
+    // Close the input file
+    fclose(file);
+
+    return std::string(buf);
+}
+
+Input::Input(std::string str, std::string srcName)
+{
+    this->srcName = srcName;
+    this->inStr = str;
+    this->strIdx = 0;
+    this->lineNo = 1;
+    this->colNo = 1;
+}
+
+Input::~Input()
+{
+}
+
+/// Peek at a character from the input
+char Input::peekCh()
+{
+    if (strIdx >= inStr.length())
+        return '\0';
+
+    return inStr[strIdx];
+}
+
+/// Read a character from the input
+char Input::readCh()
+{
+    char ch = peekCh();
+
+    // Strictly reject invalid input characters
+    if ((ch < 0x20 || ch > 0x7E) &&
+        (ch != '\n' && ch != '\t' && ch != '\r'))
+    {
+        char hexStr[64];
+        sprintf(hexStr, "0x%02X", (int)ch);
+        throw ParseError(
+            *this,
+            "invalid character in input, " + std::string(hexStr)
+        );
+    }
+
+    this->strIdx++;
+
+    if (ch == '\n')
+    {
+        lineNo++;
+        colNo = 1;
+    }
+    else
+    {
+        colNo++;
+    }
+
+    return ch;
+}
+
+/// Test if the end of file has been reached
+bool Input::eof()
+{
+    return peekCh() == '\0';
+}
+
+/// Peek to check if a string is next in the input
+bool Input::next(const std::string& str)
+{
+    size_t idx = 0;
+
+    for (; idx < str.length(); idx++)
+    {
+        if (this->strIdx + idx >= this->inStr.length())
+            return false;
+
+        if (str[idx] != this->inStr[this->strIdx + idx])
+            return false;
+    }
+
+    return true;
+}
+
+/// Try and match a given string in the input
+/// The string is consumed if matched
+bool Input::match(const std::string& str)
+{
+    assert (str.length() > 0);
+
+    if (next(str))
+    {
+        for (size_t i = 0; i < str.length(); ++i)
+            readCh();
+
+        return true;
+    }
+
+    return false;
+}
+
+/// Fail if the input doesn't match a given string
+void Input::expect(const std::string str)
+{
+    if (!match(str))
+    {
+        throw ParseError(*this, "expected to find '" + str + "'");
+    }
+}
+
+/// Consume whitespace and comments
+void Input::eatWS()
+{
+    //std::cout << "entering eatWS" << std::endl;
+
+    // Until the end of the whitespace
+    for (;;)
+    {
+        // If we are at the end of the input, stop
+        if (eof())
+        {
+            return;
+        }
+
+        // Consume whitespace characters
+        if (isspace(peekCh()))
+        {
+            readCh();
+            continue;
+        }
+
+        // If this is a single-line comment
+        if (match("//"))
+        {
+            // Read until and end of line is reached
+            for (;;)
+            {
+                if (eof())
+                    return;
+
+                if (readCh() == '\n')
+                    break;
+            }
+
+            continue;
+        }
+
+        // If this is a multi-line comment
+        if (match("/*"))
+        {
+            // Read until the end of the comment
+            for (;;)
+            {
+                if (eof())
+                {
+                    throw ParseError(
+                        *this,
+                        "end of input in multiline comment"
+                    );
+                }
+
+                if (readCh() == '*' && match("/"))
+                {
+                    break;
+                }
+            }
+
+            continue;
+        }
+
+        // This isn't whitespace, stop
+        break;
+    }
+}
+
+/// Version of next which also eats preceding whitespace
+bool Input::nextWS(const std::string& str)
+{
+    eatWS();
+    return next(str);
+}
+
+/// Version of match which also eats preceding whitespace
+bool Input::matchWS(const std::string& str)
+{
+    eatWS();
+    return match(str);
+}
+
+/// Version of expect which eats preceding whitespace
+void Input::expectWS(const std::string str)
+{
+    eatWS();
+    expect(str);
+}
+
+/// Check whether the given character can start an identifier
+static bool isinitial(char ch)
+{
+    // Is it an alphabetic character
+    if (isalpha(ch))
+    {
+        return true;
+    }
+
+    // Or a "special" initial character
+    switch (ch)
+    {
+        case '!':
+        case '$':
+        case '%':
+        case '&':
+        case '*':
+        case '/':
+        case ':':
+        case '<':
+        case '=':
+        case '>':
+        case '?':
+        case '^':
+        case '_':
+        case '~':
+            return true;
+        default:
+            break;
+    }
+
+    return false;
+}
+
+/// Check whether the given character can follow the start of an identifier
+static bool issubsequent(char ch)
+{
+    // Is it an initial character *or* digit
+    if (isinitial(ch) || isdigit(ch))
+    {
+        return true;
+    }
+
+    // Or a "special" subsequent character
+    switch (ch)
+    {
+        case '+':
+        case '-':
+        case '.':
+        case '@':
+            return true;
+        default:
+            break;
+    }
+
+    return false;
+}
+
+/**
+Parse an identifier string
+*/
+std::string parseIdentStr(Input& input)
+{
+    std::string ident;
+
+    char firstCh = input.peekCh();
+
+    if (!isinitial(firstCh))
+    {
+        throw ParseError(input, "invalid identifier start");
+    }
+
+    for (;;)
+    {
+        // Peek at the next character
+        char ch = input.peekCh();
+
+        if (!issubsequent(ch))
+            break;
+
+        // Consume this character
+        ident += input.readCh();
+    }
+
+    if (ident.size() == 0)
+    {
+        throw ParseError(input, "invalid identifier");
+    }
+
+    return ident;
+}
+
+/**
+Parse an atom
+*/
+std::unique_ptr<Value> parseAtom(Input& input)
+{
+    // Identifier
+    if (isinitial(input.peekCh()))
+    {
+        std::string identStr = parseIdentStr(input);
+        return std::unique_ptr<Identifier>(new Identifier(identStr));
+    }
+
+    throw ParseError(input, "unexpected atom");
+}
+
+/// Forward declaration
+std::unique_ptr<Value> parseSExpr(Input& input);
+
+/**
+Cons the two given values into a new pair
+*/
+std::unique_ptr<Pair> cons(std::unique_ptr<Value> car, std::unique_ptr<Value> cdr)
+{
+    return std::unique_ptr<Pair>(new Pair(std::move(car), std::move(cdr)));
+}
+
+/**
+Pares a pair
+*/
+std::unique_ptr<Value> parseSExprList(Input& input) {
+    if (input.eof())
+    {
+        return nullptr;
+    }
+
+    // Consume whitespace
+    input.eatWS();
+
+    // Check if the paired list is ending
+    if (input.next(")"))
+    {
+        return std::unique_ptr<Pair>(new Pair());
+    }
+
+    // Consume whitespace
+    input.eatWS();
+
+    // Parse the head expression
+    std::unique_ptr<Value> car = parseSExpr(input);
+
+    // Consume whitespace
+    input.eatWS();
+
+    // Parse the tail and cons it with the head
+    return cons(std::move(car), parseSExprList(input));
+}
+
+/**
+ Parse an S-expression
+*/
+std::unique_ptr<Value> parseSExpr(Input& input)
+{
+    // Consume whitespace
+    input.eatWS();
+
+    if (input.eof())
+    {
+        return nullptr;
+    }
+
+    // Parse a paired list
+    if (input.match("("))
+    {
+        std::unique_ptr<Value> pair = parseSExprList(input);
+        if (!input.match(")"))
+        {
+            throw ParseError(
+                        input,
+                        "expected ')'"
+                    );
+        }
+
+        return pair;
+    }
+
+    // Parse a quoted list
+    else if (input.match("\'"))
+    {
+        std::unique_ptr<Identifier> quote(new Identifier("quote"));
+        std::unique_ptr<Pair> empty(new Pair());
+        std::unique_ptr<Value> rest = parseSExpr(input);
+        return cons(std::move(quote), cons(std::move(rest), std::move(empty)));
+    }
+
+    // Parse an atom
+    return parseAtom(input);
+}
+
+/**
+Parse a program from an input object
+*/
+std::unique_ptr<Program> parseProgram(Input& input)
+{
+    // Parse the language directive, if specified
+    if (input.match("#language"))
+    {
+        input.expectWS("\"");
+
+        for (;;)
+        {
+            // If this is the end of the input
+            if (input.eof())
+            {
+                throw ParseError(
+                    input,
+                    "end of input inside package name"
+                );
+            }
+
+            char ch = input.readCh();
+
+            if (ch == '"')
+            {
+                break;
+            }
+        }
+    }
+
+    // Parse the S-expressions that make up a program
+    std::vector<std::unique_ptr<Value>> values;
+    while (!input.eof())
+    {
+        std::unique_ptr<Value> value = parseSExpr(input);
+        if (value)
+        {
+            values.push_back(std::move(value));
+        }
+    }
+
+    return std::unique_ptr<Program>(new Program(values));
+}
+
+/**
+Parse a source string as a unit
+*/
+std::unique_ptr<Program> parseString(const std::string &str, const std::string &srcName)
+{
+    Input input(
+        str,
+        srcName
+    );
+
+    return parseProgram(input);
+}
+
+std::unique_ptr<Program> parseFile(const std::string &fileName)
+{
+    auto fileData = readFile(fileName);
+
+    Input input(
+        fileData,
+        fileName
+    );
+
+    return parseProgram(input);
+}
+
+/// Test that the parsing of a string succeeds
+std::unique_ptr<Program> testParse(const std::string &str, const std::string &expectedStr)
+{
+    std::cout << str << std::endl;
+
+    try
+    {
+        std::unique_ptr<Program> program = parseString(str, "parser_test");
+        std::string actualStr = program->toString();
+        if (actualStr != expectedStr)
+        {
+            std::cerr << "error: '" << actualStr
+                      << "' != '" << expectedStr << "'\n";
+            exit(-1);
+        }
+        return program;
+    }
+
+    catch (std::exception& e)
+    {
+        std::cerr << e.what() << std::endl;
+        exit(-1);
+    }
+}
+
+/// Test that the parsing of a string fails
+void testParseFail(const std::string &str)
+{
+    std::cout << str << std::endl;
+
+    try
+    {
+        auto unit = parseString(str, "parser_fail_test");
+    }
+
+    catch (ParseError e)
+    {
+        return;
+    }
+
+    std::cerr << "parsing did not fail for: " << std::endl;
+    std::cerr << str << std::endl;
+    exit(-1);
+}
+
+/// Test that the parsing of a file succeeds
+std::unique_ptr<Program> testParseFile(const std::string &fileName)
+{
+    std::cout << "parsing image file \"" << fileName << "\"" << std::endl;
+    return parseFile(fileName);
+}
+
+/// Test the functionality of the parser
+void testParser()
+{
+    printf("parser tests\n");
+
+    // Identifiers
+    testParse("foobar", "foobar");
+    testParse("  foo_bar  ", "foo_bar");
+    testParse("lambda", "lambda");
+    testParse("empty?", "empty?");
+    testParse(":foo", ":foo");
+    testParseFail("+bar");
+    testParseFail("7up");
+
+    // Lists
+    testParse("()", "()");
+    testParse("(())", "(())");
+    testParse("(a b c d)", "(a b c d)");
+    testParse("(a (b (c)) d)", "(a (b (c)) d)");
+    testParse("'()", "(quote ())");
+    testParse("'(foo bar)", "(quote (foo bar))");
+    testParse("(define f (lambda (x) x))", "(define f (lambda (x) x))");
+    testParse("(define x y)(define y z)", "(define x y)(define y z)");
+    testParseFail("(x y");
+    testParseFail("((a b)(c (d)");
+    testParseFail("(r s))");
+}

--- a/scheme/parser.h
+++ b/scheme/parser.h
@@ -1,0 +1,202 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <unordered_map>
+
+/**
+Represents an input character stream to parse from
+*/
+struct Input
+{
+private:
+
+    /// Input source name
+    std::string srcName;
+
+    /// Input string to be parsed
+    std::string inStr;
+
+    /// Current index in the input string
+    size_t strIdx;
+
+    /// Current line number
+    size_t lineNo;
+
+    /// Current column number
+    size_t colNo;
+
+public:
+
+    Input(std::string str, std::string srcName);
+
+    ~Input();
+
+    /// Peek at a character from the input
+    char peekCh();
+
+    /// Read/consume a character from the input
+    char readCh();
+
+    /// Test if the end of file has been reached
+    bool eof();
+
+    /// Check if a string is next in the input
+    bool next(const std::string& str);
+
+    /// Try and match a given string in the input
+    /// The string is consumed if matched
+    bool match(const std::string& str);
+
+    /// Fail if the input doesn't match a given string
+    void expect(const std::string str);
+
+    /// Consume whitespace and comments
+    void eatWS();
+
+    /// Version of next which also eats preceding whitespace
+    bool nextWS(const std::string& str);
+
+    /// Version of match which also eats preceding whitespace
+    bool matchWS(const std::string& str);
+
+    /// Version of expect which eats preceding whitespace
+    void expectWS(const std::string str);
+
+    std::string getSrcName() const { return srcName; }
+    size_t getLineNo() const { return lineNo; }
+    size_t getColNo() const { return colNo; }
+};
+
+/**
+Parse-time error exception class
+*/
+class ParseError
+{
+private:
+
+    std::string msg;
+
+public:
+
+    ParseError(std::string msg)
+    {
+        this->msg = msg;
+    }
+
+    ParseError(Input& input, std::string msg)
+    {
+        this->msg = (
+            input.getSrcName() + "@" +
+            std::to_string(input.getLineNo()) + ":" +
+            std::to_string(input.getColNo()) + " - " +
+            msg
+        );
+    }
+
+    virtual ~ParseError()
+    {
+    }
+
+    virtual std::string toString() const
+    {
+        return msg;
+    }
+};
+
+/**
+Base class for all Scheme values
+*/
+class Value
+{
+public:
+
+    virtual ~Value() {}
+
+    virtual std::string toString() const = 0;
+};
+
+class Identifier : public Value
+{
+public:
+
+    Identifier(std::string val): val(val) {}
+
+    virtual ~Identifier() {}
+
+    virtual std::string toString() const
+    {
+        return val;
+    }
+
+    std::string val;
+};
+
+class Pair : public Value
+{
+public:
+
+    Pair() : car(nullptr), cdr(nullptr) {}
+
+    Pair(std::unique_ptr<Value> car, std::unique_ptr<Value> cdr)
+        : car(std::move(car)), cdr(std::move(cdr)) {}
+
+    virtual ~Pair() {}
+
+    virtual std::string toString() const
+    {
+        std::string repr = "(";
+        if (car)
+        {
+            repr += car->toString();
+        }
+
+        Value *tail = cdr.get();
+        while (tail)
+        {
+            if (Pair* pair = dynamic_cast<Pair*>(tail))
+            {
+                if (pair->car)
+                {
+                    repr += " " + pair->car->toString();
+                }
+                tail = pair->cdr.get();
+            }
+        }
+
+        repr += ")";
+        return repr;
+    }
+
+    std::unique_ptr<Value> car;
+    std::unique_ptr<Value> cdr;
+};
+
+class Program
+{
+public:
+
+    Program(std::vector<std::unique_ptr<Value>> &newValues)
+    {
+        for (auto &value : newValues)
+            values.push_back(std::move(value));
+    }
+
+    std::string toString() const
+    {
+        std::string repr;
+        for (auto &value : values)
+        {
+            repr += value->toString();
+        }
+        return repr;
+    }
+
+    std::vector<std::unique_ptr<Value>> values;
+};
+
+std::unique_ptr<Program> parseString(const std::string &str, const std::string &srcName);
+
+std::unique_ptr<Program> parseFile(const std::string &fileName);
+
+void testParser();


### PR DESCRIPTION
This patch adds the beginnings of a Scheme frontend.
Currently only S-expressions composed of identifiers
are handled.  With the basic parsing and testing
framework in place new atoms and expressions will be
added incrementally.

The coding style, parsing implementation, and testing
methodology were derived from the Plush implementation.