### PR TITLE
Floating number support - Part 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ cplush
 cjs
 cscheme
 *.dSYM
+
+# Retarded IDE metadata
+.idea

--- a/tests/vm/ex_ret_float.zim
+++ b/tests/vm/ex_ret_float.zim
@@ -9,8 +9,8 @@
         entry: {
             name: "main_entry",
             instrs: [
-                { op: "push", val: 1.0 },
-                { op: "push", val: 2.0 },
+                { op: "push", val: 1.0f },
+                { op: "push", val: 2.0f },
                 { op: "add_f" },
                 { op: "ret" }
             ]

--- a/tests/vm/ex_ret_float.zim
+++ b/tests/vm/ex_ret_float.zim
@@ -11,7 +11,7 @@
             instrs: [
                 { op: "push", val: 1.0f },
                 { op: "push", val: 2.0f },
-                { op: "add_f" },
+                { op: "add_f32" },
                 { op: "ret" }
             ]
         }

--- a/tests/vm/ex_ret_float.zim
+++ b/tests/vm/ex_ret_float.zim
@@ -1,0 +1,19 @@
+#zeta-image
+
+{
+    # Trivial function returning an integer constant
+    main: {
+        name: "main",
+        num_params: 0,
+        num_locals: 0,
+        entry: {
+            name: "main_entry",
+            instrs: [
+                { op: "push", val: 1.0 },
+                { op: "push", val: 2.0 },
+                { op: "add_f" },
+                { op: "ret" }
+            ]
+        }
+    }
+};

--- a/vm/core.cpp
+++ b/vm/core.cpp
@@ -300,9 +300,9 @@ Object load(std::string pkgPath)
         auto inputObj = Object::newObject();
         inputObj.setField("src_name", String(input.getSrcName()));
         inputObj.setField("src_string", String(input.getInputStr()));
-        inputObj.setField("str_idx", Value(input.getInputIdx()));
-        inputObj.setField("line_no", Value(input.getLineNo()));
-        inputObj.setField("col_no", Value(input.getColNo()));
+        inputObj.setField("str_idx", Value((int64_t)input.getInputIdx()));
+        inputObj.setField("line_no", Value((int64_t)input.getLineNo()));
+        inputObj.setField("col_no", Value((int64_t)input.getColNo()));
 
         std::cout << "Calling parse_input" << std::endl;
 

--- a/vm/interp.cpp
+++ b/vm/interp.cpp
@@ -30,7 +30,7 @@ enum Opcode : uint16_t
 
     // Float operations
 
-    ADD_F,
+    ADD_F32,
 
     // Miscellaneous
     EQ_BOOL,
@@ -261,11 +261,11 @@ __attribute__((always_inline)) int64_t popInt64()
     return (int64_t)val;
 }
 
-__attribute__((always_inline)) float popFloat()
+__attribute__((always_inline)) float popFloat32()
 {
     // TODO: throw RunError if wrong type
     auto val = popVal();
-    assert (val.isFloat());
+    assert (val.isFloat32());
     return (float)val;
 }
 
@@ -469,9 +469,9 @@ void compile(BlockVersion* version)
         //Float ops
         //
 
-        if (op == "add_f")
+        if (op == "add_f32")
         {
-            writeCode(ADD_F);
+            writeCode(ADD_F32);
             continue;
         }
 
@@ -992,10 +992,10 @@ Value execCode()
             // Float operations
             //
 
-            case ADD_F:
+            case ADD_F32:
             {
-                auto arg1 = popFloat();
-                auto arg0 = popFloat();
+                auto arg1 = popFloat32();
+                auto arg0 = popFloat32();
                 pushVal(arg0 + arg1);
             }
             break;

--- a/vm/interp.cpp
+++ b/vm/interp.cpp
@@ -1512,7 +1512,7 @@ Value testRunImage(std::string fileName)
 
 void testInterp()
 {   
-    std::cout << "testing " + testRunImage("tests/vm/ex_ret_float.zim").toString();
+    //std::cout << "testing " + testRunImage("tests/vm/ex_ret_float.zim").toString();
     assert (testRunImage("tests/vm/ex_ret_cst.zim") == Value((int64_t)777));
     assert (testRunImage("tests/vm/ex_ret_float.zim") == Value(3.0f));
     assert (testRunImage("tests/vm/ex_loop_cnt.zim") == Value((int64_t)0));

--- a/vm/interp.cpp
+++ b/vm/interp.cpp
@@ -28,6 +28,10 @@ enum Opcode : uint16_t
     GE_I64,
     EQ_I64,
 
+    // Float operations
+
+    ADD_F,
+
     // Miscellaneous
     EQ_BOOL,
     HAS_TAG,
@@ -257,6 +261,14 @@ __attribute__((always_inline)) int64_t popInt64()
     return (int64_t)val;
 }
 
+__attribute__((always_inline)) float popFloat()
+{
+    // TODO: throw RunError if wrong type
+    auto val = popVal();
+    assert (val.isFloat());
+    return (float)val;
+}
+
 __attribute__((always_inline)) String popStr()
 {
     // TODO: throw RunError if wrong type
@@ -450,6 +462,16 @@ void compile(BlockVersion* version)
         if (op == "eq_i64")
         {
             writeCode(EQ_I64);
+            continue;
+        }
+
+        //
+        //Float ops
+        //
+
+        if (op == "add_f")
+        {
+            writeCode(ADD_F);
             continue;
         }
 
@@ -967,6 +989,18 @@ Value execCode()
             break;
 
             //
+            // Float operations
+            //
+
+            case ADD_F:
+            {
+                auto arg1 = popFloat();
+                auto arg0 = popFloat();
+                pushVal(arg0 + arg1);
+            }
+            break;
+
+            //
             // Misc operations
             //
 
@@ -994,7 +1028,7 @@ Value execCode()
             case STR_LEN:
             {
                 auto str = popStr();
-                pushVal(str.length());
+                pushVal((int64_t)str.length());
             }
             break;
 
@@ -1139,7 +1173,7 @@ Value execCode()
             case ARRAY_LEN:
             {
                 auto arr = Array(popVal());
-                pushVal(arr.length());
+                pushVal((int64_t)arr.length());
             }
             break;
 
@@ -1477,10 +1511,12 @@ Value testRunImage(std::string fileName)
 }
 
 void testInterp()
-{
-    assert (testRunImage("tests/vm/ex_ret_cst.zim") == Value(777));
-    assert (testRunImage("tests/vm/ex_loop_cnt.zim") == Value(0));
+{   
+    std::cout << "testing " + testRunImage("tests/vm/ex_ret_float.zim").toString();
+    assert (testRunImage("tests/vm/ex_ret_cst.zim") == Value((int64_t)777));
+    assert (testRunImage("tests/vm/ex_ret_float.zim") == Value(3.0f));
+    assert (testRunImage("tests/vm/ex_loop_cnt.zim") == Value((int64_t)0));
     //assert (testRunImage("tests/vm/ex_image.zim") == Value(10));
-    assert (testRunImage("tests/vm/ex_rec_fact.zim") == Value(5040));
-    assert (testRunImage("tests/vm/ex_fibonacci.zim") == Value(377));
+    assert (testRunImage("tests/vm/ex_rec_fact.zim") == Value((int64_t)5040));
+    assert (testRunImage("tests/vm/ex_fibonacci.zim") == Value((int64_t)377));
 }

--- a/vm/parser.cpp
+++ b/vm/parser.cpp
@@ -1,5 +1,6 @@
 #include <cassert>
 #include <cstring>
+#include <cinttypes>
 #include <string>
 #include <vector>
 #include <iostream>
@@ -243,7 +244,8 @@ Value parseNum(Input& input, bool neg)
             break;
     }
 
-    if (input.peek() == '.') {
+    char next = input.peek();
+    if (next == '.' || next == 'e' || next == 'E' || next == 'f' || next == 'F') {
         return parseFloatingPart(input, neg, intVal);
     }
 
@@ -258,20 +260,19 @@ Value parseNum(Input& input, bool neg)
 
 Value parseFloatingPart(Input& input, bool neg, int64_t val)
 {
-    float floatVal = (float)val;
-    input.expect(".");
-    int i = 1;
-    for (;;)
+    char decimal_part[64];
+    sprintf(decimal_part, "%" PRId64, val);
+    int length = strlen(decimal_part);
+    for (int i = 0;;i++)
     {
-        char ch = input.readCh();
-        if (!isdigit(ch))
-            throw ParseError(input, "expected digit");
-        float digit = (float)(ch - '0');
-        floatVal = floatVal + (digit/(10*i++));
-        if (!isdigit(input.peek()))
+        char next = input.peek();
+        if (isdigit(next) || next == 'e' || next == 'E' || next == '.')
+            decimal_part[length + i++] = input.readCh();
+        else 
             break;
     }
     input.expect("f");
+    float floatVal = atof(decimal_part);
     if (neg)
     {
         floatVal *= -1;

--- a/vm/parser.cpp
+++ b/vm/parser.cpp
@@ -220,7 +220,9 @@ void Input::eatWS()
 
 // Forward declaration
 Value parseExpr(Input& input);
+
 Value parseFloatingPart(Input& input, bool neg, int64_t val);
+
 /**
 Parse a decimal integer
 */
@@ -245,7 +247,8 @@ Value parseNum(Input& input, bool neg)
     }
 
     char next = input.peek();
-    if (next == '.' || next == 'e' || next == 'E' || next == 'f' || next == 'F') {
+    if (next == '.' || next == 'e' || next == 'f')
+    {
         return parseFloatingPart(input, neg, intVal);
     }
 
@@ -265,8 +268,10 @@ Value parseFloatingPart(Input& input, bool neg, int64_t val)
     int length = strlen(literal);
     for (int i = 0;;i++)
     {
+        if (i + length >= 64)
+            throw ParseError(input, "float literal is too long");
         char next = input.peek();
-        if (isdigit(next) || next == 'e' || next == 'E' || next == '.')
+        if (isdigit(next) || next == 'e' || next == '.')
             literal[length + i++] = input.readCh();
         else 
             break;

--- a/vm/parser.cpp
+++ b/vm/parser.cpp
@@ -271,6 +271,7 @@ Value parseFloatingPart(Input& input, bool neg, int64_t val)
         if (!isdigit(input.peek()))
             break;
     }
+    input.expect("f");
     if (neg)
     {
         floatVal *= -1;

--- a/vm/parser.cpp
+++ b/vm/parser.cpp
@@ -260,19 +260,19 @@ Value parseNum(Input& input, bool neg)
 
 Value parseFloatingPart(Input& input, bool neg, int64_t val)
 {
-    char decimal_part[64];
-    sprintf(decimal_part, "%" PRId64, val);
-    int length = strlen(decimal_part);
+    char literal[64];
+    sprintf(literal, "%" PRId64, val);
+    int length = strlen(literal);
     for (int i = 0;;i++)
     {
         char next = input.peek();
         if (isdigit(next) || next == 'e' || next == 'E' || next == '.')
-            decimal_part[length + i++] = input.readCh();
+            literal[length + i++] = input.readCh();
         else 
             break;
     }
     input.expect("f");
-    float floatVal = atof(decimal_part);
+    float floatVal = atof(literal);
     if (neg)
     {
         floatVal *= -1;

--- a/vm/runtime.cpp
+++ b/vm/runtime.cpp
@@ -39,6 +39,9 @@ std::string Value::toString() const
         case TAG_INT64:
         return std::to_string(word.int64);
 
+        case TAG_FLOAT32:
+        return std::to_string(word.float32);
+
         case TAG_STRING:
         //return (std::string)*this;
         return "string";
@@ -80,6 +83,12 @@ Value::operator int64_t () const
 {
     assert (tag == TAG_INT64);
     return word.int64;
+}
+
+Value::operator float () const
+{
+    assert (tag == TAG_FLOAT32);
+    return word.float32;
 }
 
 Value::operator refptr () const

--- a/vm/runtime.h
+++ b/vm/runtime.h
@@ -77,7 +77,7 @@ public:
 
     bool isBool() const { return tag == TAG_BOOL; }
     bool isInt64() const { return tag == TAG_INT64; }
-    bool isFloat() const { return tag == TAG_FLOAT32; }
+    bool isFloat32() const { return tag == TAG_FLOAT32; }
     bool isString() const { return tag == TAG_STRING; }
     bool isObject() const { return tag == TAG_OBJECT; }
     bool isArray() const { return tag == TAG_ARRAY; }

--- a/vm/runtime.h
+++ b/vm/runtime.h
@@ -39,8 +39,10 @@ union Word
 {
     Word(refptr p) { ptr = p; }
     Word(int64_t v) { int64 = v; }
+    Word(float v) { float32 = v; }
     Word() {}
 
+    float float32;
     int64_t int64;
     int8_t int8;
     refptr ptr;
@@ -68,12 +70,14 @@ public:
 
     Value() : Value(FALSE.word, FALSE.tag) {}
     Value(int64_t v) : Value(Word(v), TAG_INT64) {}
+    Value(float v) : Value(Word(v), TAG_FLOAT32) {}
     Value(refptr p, Tag t) : Value(Word(p), t) {}
     Value(Word w, Tag t);
     ~Value() {}
 
     bool isBool() const { return tag == TAG_BOOL; }
     bool isInt64() const { return tag == TAG_INT64; }
+    bool isFloat() const { return tag == TAG_FLOAT32; }
     bool isString() const { return tag == TAG_STRING; }
     bool isObject() const { return tag == TAG_OBJECT; }
     bool isArray() const { return tag == TAG_ARRAY; }
@@ -88,6 +92,7 @@ public:
 
     operator bool () const;
     operator int64_t () const;
+    operator float () const;
     operator refptr () const;
     operator std::string () const;
 


### PR DESCRIPTION
I've added basic support for floating numbers into the VM. 
This means that now the parser accepts floating point numbers (that ends with f) and recognize them as floats. I've also added the first float operation, namely add_f. 
I'm creating this pull request mainly because I want to know if I'm on the right direction and I don't want to write a lot of code with no feedback from you. 

While implementing this small part of the feature I had to change some parts of your code, mainly due to the fact that the c++ compiler was not sure if to cast usize_t to int ot float (or similar situations).

I've also created a very simple .zim file that demonstrates the functionality and I added a test in interp.cpp

As I said this is a very first draft, so I'm not sure if I followed your naming conventions properly and your code style. 

(At the very beginning while trying to build everything I was having problems with the schema compiler, I had to delete from my dev branch, I'm not sure what was going wrong)