### PR TITLE
More functionality for floats + Bug fixes

### DIFF
--- a/benchmarks/draw_font.pls
+++ b/benchmarks/draw_font.pls
@@ -1,7 +1,7 @@
 #language "lang/plush/0"
 
 var window = import "core/window";
-assert (window != undef);
+assert (window != undef, "no window");
 assert (typeof window == "object");
 assert ("create_window" in window);
 

--- a/benchmarks/plush_parser.zim
+++ b/benchmarks/plush_parser.zim
@@ -6,8 +6,9 @@ global_obj = { exports: @exports_obj };
 block_5 = {
   instrs: [
     { op:'get_local', idx:0 },
+    { op:'i32_to_f32' },
     { op:'get_local', idx:1 },
-    { op:'add_i32' },
+    { op:'add_f32' },
     { op:'ret' },
   ]
 };
@@ -15,7 +16,7 @@ block_5 = {
 block_4 = {
   instrs: [
     { op:'get_local', idx:1 },
-    { op:'has_tag', tag:'int32' },
+    { op:'has_tag', tag:'float32' },
     { op:'if_true', then:@block_5, else:@block_6 },
   ]
 };
@@ -26,27 +27,117 @@ block_6 = {
   ]
 };
 
-block_2 = {
+block_8 = {
   instrs: [
     { op:'get_local', idx:0 },
-    { op:'has_tag', tag:'int32' },
-    { op:'if_true', then:@block_4, else:@block_8 },
+    { op:'get_local', idx:1 },
+    { op:'add_i32' },
+    { op:'ret' },
   ]
 };
 
 block_7 = {
   instrs: [
-    { op:'jump', to:@block_9 },
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_8, else:@block_9 },
   ]
 };
 
-block_8 = {
+block_9 = {
   instrs: [
-    { op:'jump', to:@block_9 },
+    { op:'jump', to:@block_10 },
+  ]
+};
+
+block_2 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_4, else:@block_11 },
+  ]
+};
+
+block_10 = {
+  instrs: [
+    { op:'jump', to:@block_12 },
   ]
 };
 
 block_11 = {
+  instrs: [
+    { op:'jump', to:@block_12 },
+  ]
+};
+
+block_14 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'add_f32' },
+    { op:'ret' },
+  ]
+};
+
+block_13 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_14, else:@block_15 },
+  ]
+};
+
+block_15 = {
+  instrs: [
+    { op:'jump', to:@block_16 },
+  ]
+};
+
+block_17 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'i32_to_f32' },
+    { op:'add_f32' },
+    { op:'ret' },
+  ]
+};
+
+block_16 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_17, else:@block_18 },
+  ]
+};
+
+block_18 = {
+  instrs: [
+    { op:'jump', to:@block_19 },
+  ]
+};
+
+block_12 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_13, else:@block_20 },
+  ]
+};
+
+block_19 = {
+  instrs: [
+    { op:'jump', to:@block_21 },
+  ]
+};
+
+block_20 = {
+  instrs: [
+    { op:'jump', to:@block_21 },
+  ]
+};
+
+block_23 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
@@ -55,62 +146,62 @@ block_11 = {
   ]
 };
 
-block_10 = {
+block_22 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'has_tag', tag:'string' },
-    { op:'if_true', then:@block_11, else:@block_12 },
+    { op:'if_true', then:@block_23, else:@block_24 },
   ]
 };
 
-block_12 = {
+block_24 = {
   instrs: [
-    { op:'jump', to:@block_13 },
+    { op:'jump', to:@block_25 },
   ]
 };
 
-block_9 = {
+block_21 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'has_tag', tag:'string' },
-    { op:'if_true', then:@block_10, else:@block_14 },
+    { op:'if_true', then:@block_22, else:@block_26 },
   ]
 };
 
-block_13 = {
+block_25 = {
   instrs: [
-    { op:'jump', to:@block_15 },
+    { op:'jump', to:@block_27 },
   ]
 };
 
-block_14 = {
+block_26 = {
   instrs: [
-    { op:'jump', to:@block_15 },
+    { op:'jump', to:@block_27 },
   ]
 };
 
-block_15 = {
+block_27 = {
   instrs: [
     { op:'push', val:$false },
-    { op:'if_true', then:@block_16, else:@block_17 },
+    { op:'if_true', then:@block_28, else:@block_29 },
   ]
 };
 
-block_16 = {
+block_28 = {
   instrs: [
-    { op:'jump', to:@block_18 },
+    { op:'jump', to:@block_30 },
   ]
 };
 
-block_17 = {
+block_29 = {
   instrs: [
     { op:'push', val:'unhandled type in addition' },
     { op:'abort' },
-    { op:'jump', to:@block_18 },
+    { op:'jump', to:@block_30 },
   ]
 };
 
-block_18 = {
+block_30 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
@@ -123,7 +214,31 @@ fun_3 = {
   num_locals:2,
 };
 
-block_22 = {
+block_34 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'i32_to_f32' },
+    { op:'get_local', idx:1 },
+    { op:'sub_f32' },
+    { op:'ret' },
+  ]
+};
+
+block_33 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_34, else:@block_35 },
+  ]
+};
+
+block_35 = {
+  instrs: [
+    { op:'jump', to:@block_36 },
+  ]
+};
+
+block_37 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
@@ -132,186 +247,78 @@ block_22 = {
   ]
 };
 
-block_21 = {
+block_36 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'has_tag', tag:'int32' },
-    { op:'if_true', then:@block_22, else:@block_23 },
+    { op:'if_true', then:@block_37, else:@block_38 },
   ]
-};
-
-block_23 = {
-  instrs: [
-    { op:'jump', to:@block_24 },
-  ]
-};
-
-block_19 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'has_tag', tag:'int32' },
-    { op:'if_true', then:@block_21, else:@block_25 },
-  ]
-};
-
-block_24 = {
-  instrs: [
-    { op:'jump', to:@block_26 },
-  ]
-};
-
-block_25 = {
-  instrs: [
-    { op:'jump', to:@block_26 },
-  ]
-};
-
-block_26 = {
-  instrs: [
-    { op:'push', val:$false },
-    { op:'if_true', then:@block_27, else:@block_28 },
-  ]
-};
-
-block_27 = {
-  instrs: [
-    { op:'jump', to:@block_29 },
-  ]
-};
-
-block_28 = {
-  instrs: [
-    { op:'push', val:'unhandled type in subtraction' },
-    { op:'abort' },
-    { op:'jump', to:@block_29 },
-  ]
-};
-
-block_29 = {
-  instrs: [
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-fun_20 = {
-  entry:@block_19,
-  num_params:2,
-  num_locals:2,
-};
-
-block_32 = {
-  instrs: [
-    { op:'push', val:$false },
-    { op:'ret' },
-  ]
-};
-
-block_33 = {
-  instrs: [
-    { op:'push', val:$true },
-    { op:'ret' },
-  ]
-};
-
-block_30 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'if_true', then:@block_32, else:@block_33 },
-  ]
-};
-
-block_34 = {
-  instrs: [
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-fun_31 = {
-  entry:@block_30,
-  num_params:1,
-  num_locals:1,
 };
 
 block_38 = {
   instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'eq_i32' },
-    { op:'ret' },
+    { op:'jump', to:@block_39 },
   ]
 };
 
-block_37 = {
+block_31 = {
   instrs: [
-    { op:'get_local', idx:1 },
+    { op:'get_local', idx:0 },
     { op:'has_tag', tag:'int32' },
-    { op:'if_true', then:@block_38, else:@block_39 },
+    { op:'if_true', then:@block_33, else:@block_40 },
   ]
 };
 
 block_39 = {
   instrs: [
-    { op:'jump', to:@block_40 },
-  ]
-};
-
-block_35 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'has_tag', tag:'int32' },
-    { op:'if_true', then:@block_37, else:@block_41 },
+    { op:'jump', to:@block_41 },
   ]
 };
 
 block_40 = {
   instrs: [
-    { op:'jump', to:@block_42 },
-  ]
-};
-
-block_41 = {
-  instrs: [
-    { op:'jump', to:@block_42 },
-  ]
-};
-
-block_44 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'eq_str' },
-    { op:'ret' },
+    { op:'jump', to:@block_41 },
   ]
 };
 
 block_43 = {
   instrs: [
+    { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
-    { op:'has_tag', tag:'string' },
-    { op:'if_true', then:@block_44, else:@block_45 },
-  ]
-};
-
-block_45 = {
-  instrs: [
-    { op:'jump', to:@block_46 },
-  ]
-};
-
-block_46 = {
-  instrs: [
-    { op:'push', val:$false },
+    { op:'sub_f32' },
     { op:'ret' },
   ]
 };
 
 block_42 = {
   instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_43, else:@block_44 },
+  ]
+};
+
+block_44 = {
+  instrs: [
+    { op:'jump', to:@block_45 },
+  ]
+};
+
+block_46 = {
+  instrs: [
     { op:'get_local', idx:0 },
-    { op:'has_tag', tag:'string' },
-    { op:'if_true', then:@block_43, else:@block_47 },
+    { op:'get_local', idx:1 },
+    { op:'i32_to_f32' },
+    { op:'sub_f32' },
+    { op:'ret' },
+  ]
+};
+
+block_45 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_46, else:@block_47 },
   ]
 };
 
@@ -321,106 +328,118 @@ block_47 = {
   ]
 };
 
-block_50 = {
+block_41 = {
   instrs: [
     { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'eq_obj' },
-    { op:'ret' },
-  ]
-};
-
-block_49 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'has_tag', tag:'object' },
-    { op:'if_true', then:@block_50, else:@block_51 },
-  ]
-};
-
-block_51 = {
-  instrs: [
-    { op:'jump', to:@block_52 },
-  ]
-};
-
-block_52 = {
-  instrs: [
-    { op:'push', val:$false },
-    { op:'ret' },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_42, else:@block_49 },
   ]
 };
 
 block_48 = {
   instrs: [
-    { op:'get_local', idx:0 },
-    { op:'has_tag', tag:'object' },
-    { op:'if_true', then:@block_49, else:@block_53 },
+    { op:'jump', to:@block_50 },
+  ]
+};
+
+block_49 = {
+  instrs: [
+    { op:'jump', to:@block_50 },
+  ]
+};
+
+block_50 = {
+  instrs: [
+    { op:'push', val:$false },
+    { op:'if_true', then:@block_51, else:@block_52 },
+  ]
+};
+
+block_51 = {
+  instrs: [
+    { op:'jump', to:@block_53 },
+  ]
+};
+
+block_52 = {
+  instrs: [
+    { op:'push', val:'unhandled type in subtraction' },
+    { op:'abort' },
+    { op:'jump', to:@block_53 },
   ]
 };
 
 block_53 = {
   instrs: [
-    { op:'jump', to:@block_54 },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+fun_32 = {
+  entry:@block_31,
+  num_params:2,
+  num_locals:2,
+};
+
+block_57 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'i32_to_f32' },
+    { op:'get_local', idx:1 },
+    { op:'mul_f32' },
+    { op:'ret' },
   ]
 };
 
 block_56 = {
   instrs: [
-    { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
-    { op:'eq_bool' },
-    { op:'ret' },
-  ]
-};
-
-block_55 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'has_tag', tag:'bool' },
-    { op:'if_true', then:@block_56, else:@block_57 },
-  ]
-};
-
-block_57 = {
-  instrs: [
-    { op:'jump', to:@block_58 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_57, else:@block_58 },
   ]
 };
 
 block_58 = {
   instrs: [
-    { op:'push', val:$false },
+    { op:'jump', to:@block_59 },
+  ]
+};
+
+block_60 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'mul_i32' },
     { op:'ret' },
+  ]
+};
+
+block_59 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_60, else:@block_61 },
+  ]
+};
+
+block_61 = {
+  instrs: [
+    { op:'jump', to:@block_62 },
   ]
 };
 
 block_54 = {
   instrs: [
     { op:'get_local', idx:0 },
-    { op:'has_tag', tag:'bool' },
-    { op:'if_true', then:@block_55, else:@block_59 },
-  ]
-};
-
-block_59 = {
-  instrs: [
-    { op:'jump', to:@block_60 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_56, else:@block_63 },
   ]
 };
 
 block_62 = {
   instrs: [
-    { op:'push', val:$true },
-    { op:'ret' },
-  ]
-};
-
-block_61 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'has_tag', tag:'undef' },
-    { op:'if_true', then:@block_62, else:@block_63 },
+    { op:'jump', to:@block_64 },
   ]
 };
 
@@ -430,222 +449,214 @@ block_63 = {
   ]
 };
 
-block_64 = {
-  instrs: [
-    { op:'push', val:$false },
-    { op:'ret' },
-  ]
-};
-
-block_60 = {
+block_66 = {
   instrs: [
     { op:'get_local', idx:0 },
-    { op:'has_tag', tag:'undef' },
-    { op:'if_true', then:@block_61, else:@block_65 },
+    { op:'get_local', idx:1 },
+    { op:'mul_f32' },
+    { op:'ret' },
   ]
 };
 
 block_65 = {
   instrs: [
-    { op:'jump', to:@block_66 },
-  ]
-};
-
-block_66 = {
-  instrs: [
-    { op:'push', val:$false },
-    { op:'if_true', then:@block_67, else:@block_68 },
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_66, else:@block_67 },
   ]
 };
 
 block_67 = {
   instrs: [
-    { op:'jump', to:@block_69 },
-  ]
-};
-
-block_68 = {
-  instrs: [
-    { op:'push', val:'unhandled type in equality comparison' },
-    { op:'abort' },
-    { op:'jump', to:@block_69 },
+    { op:'jump', to:@block_68 },
   ]
 };
 
 block_69 = {
   instrs: [
-    { op:'push', val:$undef },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'i32_to_f32' },
+    { op:'mul_f32' },
     { op:'ret' },
   ]
 };
 
-fun_36 = {
-  entry:@block_35,
-  num_params:2,
-  num_locals:2,
+block_68 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_69, else:@block_70 },
+  ]
 };
 
 block_70 = {
   instrs: [
+    { op:'jump', to:@block_71 },
+  ]
+};
+
+block_64 = {
+  instrs: [
     { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_72, num_args:2 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_65, else:@block_72 },
+  ]
+};
+
+block_71 = {
+  instrs: [
+    { op:'jump', to:@block_73 },
+  ]
+};
+
+block_72 = {
+  instrs: [
+    { op:'jump', to:@block_73 },
   ]
 };
 
 block_73 = {
   instrs: [
     { op:'push', val:$false },
-    { op:'ret' },
+    { op:'if_true', then:@block_74, else:@block_75 },
   ]
 };
 
 block_74 = {
   instrs: [
-    { op:'push', val:$true },
-    { op:'ret' },
-  ]
-};
-
-block_72 = {
-  instrs: [
-    { op:'if_true', then:@block_73, else:@block_74 },
+    { op:'jump', to:@block_76 },
   ]
 };
 
 block_75 = {
+  instrs: [
+    { op:'push', val:'unhandled type in multiplication' },
+    { op:'abort' },
+    { op:'jump', to:@block_76 },
+  ]
+};
+
+block_76 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-fun_71 = {
-  entry:@block_70,
+fun_55 = {
+  entry:@block_54,
   num_params:2,
   num_locals:2,
 };
 
-block_79 = {
+block_80 = {
   instrs: [
     { op:'get_local', idx:0 },
+    { op:'i32_to_f32' },
     { op:'get_local', idx:1 },
-    { op:'le_i32' },
+    { op:'div_f32' },
     { op:'ret' },
   ]
 };
 
-block_78 = {
+block_79 = {
   instrs: [
     { op:'get_local', idx:1 },
-    { op:'has_tag', tag:'int32' },
-    { op:'if_true', then:@block_79, else:@block_80 },
-  ]
-};
-
-block_80 = {
-  instrs: [
-    { op:'jump', to:@block_81 },
-  ]
-};
-
-block_76 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'has_tag', tag:'int32' },
-    { op:'if_true', then:@block_78, else:@block_82 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_80, else:@block_81 },
   ]
 };
 
 block_81 = {
   instrs: [
-    { op:'jump', to:@block_83 },
+    { op:'jump', to:@block_82 },
+  ]
+};
+
+block_83 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'i32_to_f32' },
+    { op:'get_local', idx:1 },
+    { op:'i32_to_f32' },
+    { op:'div_f32' },
+    { op:'ret' },
   ]
 };
 
 block_82 = {
   instrs: [
-    { op:'jump', to:@block_83 },
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_83, else:@block_84 },
+  ]
+};
+
+block_84 = {
+  instrs: [
+    { op:'jump', to:@block_85 },
+  ]
+};
+
+block_77 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_79, else:@block_86 },
   ]
 };
 
 block_85 = {
   instrs: [
-    { op:'get_local', idx:0 },
-    { op:'str_len' },
-    { op:'push', val:1 },
-    { op:'eq_i32' },
-    { op:'if_true', then:@block_86, else:@block_87 },
+    { op:'jump', to:@block_87 },
   ]
 };
 
 block_86 = {
   instrs: [
-    { op:'jump', to:@block_88 },
+    { op:'jump', to:@block_87 },
   ]
 };
 
-block_87 = {
+block_89 = {
   instrs: [
-    { op:'push', val:'rt_le' },
-    { op:'abort' },
-    { op:'jump', to:@block_88 },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'div_f32' },
+    { op:'ret' },
   ]
 };
 
 block_88 = {
   instrs: [
     { op:'get_local', idx:1 },
-    { op:'str_len' },
-    { op:'push', val:1 },
-    { op:'eq_i32' },
+    { op:'has_tag', tag:'float32' },
     { op:'if_true', then:@block_89, else:@block_90 },
-  ]
-};
-
-block_89 = {
-  instrs: [
-    { op:'jump', to:@block_91 },
   ]
 };
 
 block_90 = {
   instrs: [
-    { op:'push', val:'rt_le' },
-    { op:'abort' },
     { op:'jump', to:@block_91 },
-  ]
-};
-
-block_91 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:0 },
-    { op:'get_char_code' },
-    { op:'get_local', idx:1 },
-    { op:'push', val:0 },
-    { op:'get_char_code' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_le' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_92, num_args:2 },
   ]
 };
 
 block_92 = {
   instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'i32_to_f32' },
+    { op:'div_f32' },
     { op:'ret' },
   ]
 };
 
-block_84 = {
+block_91 = {
   instrs: [
     { op:'get_local', idx:1 },
-    { op:'has_tag', tag:'string' },
-    { op:'if_true', then:@block_85, else:@block_93 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_92, else:@block_93 },
   ]
 };
 
@@ -655,11 +666,11 @@ block_93 = {
   ]
 };
 
-block_83 = {
+block_87 = {
   instrs: [
     { op:'get_local', idx:0 },
-    { op:'has_tag', tag:'string' },
-    { op:'if_true', then:@block_84, else:@block_95 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_88, else:@block_95 },
   ]
 };
 
@@ -690,7 +701,7 @@ block_97 = {
 
 block_98 = {
   instrs: [
-    { op:'push', val:'unhandled type in less-than or equal comparison' },
+    { op:'push', val:'unhandled type in division' },
     { op:'abort' },
     { op:'jump', to:@block_99 },
   ]
@@ -703,86 +714,98 @@ block_99 = {
   ]
 };
 
-fun_77 = {
-  entry:@block_76,
+fun_78 = {
+  entry:@block_77,
   num_params:2,
   num_locals:2,
 };
 
-block_103 = {
+block_102 = {
   instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'ge_i32' },
+    { op:'push', val:$false },
     { op:'ret' },
   ]
 };
 
-block_102 = {
+block_103 = {
   instrs: [
-    { op:'get_local', idx:1 },
-    { op:'has_tag', tag:'int32' },
-    { op:'if_true', then:@block_103, else:@block_104 },
-  ]
-};
-
-block_104 = {
-  instrs: [
-    { op:'jump', to:@block_105 },
+    { op:'push', val:$true },
+    { op:'ret' },
   ]
 };
 
 block_100 = {
   instrs: [
     { op:'get_local', idx:0 },
-    { op:'has_tag', tag:'int32' },
-    { op:'if_true', then:@block_102, else:@block_106 },
+    { op:'if_true', then:@block_102, else:@block_103 },
   ]
 };
 
-block_105 = {
+block_104 = {
   instrs: [
-    { op:'jump', to:@block_107 },
+    { op:'push', val:$undef },
+    { op:'ret' },
   ]
 };
 
-block_106 = {
+fun_101 = {
+  entry:@block_100,
+  num_params:1,
+  num_locals:1,
+};
+
+block_108 = {
   instrs: [
-    { op:'jump', to:@block_107 },
+    { op:'get_local', idx:0 },
+    { op:'i32_to_f32' },
+    { op:'get_local', idx:1 },
+    { op:'eq_f32' },
+    { op:'ret' },
+  ]
+};
+
+block_107 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_108, else:@block_109 },
   ]
 };
 
 block_109 = {
   instrs: [
-    { op:'get_local', idx:0 },
-    { op:'str_len' },
-    { op:'push', val:1 },
-    { op:'eq_i32' },
-    { op:'if_true', then:@block_110, else:@block_111 },
-  ]
-};
-
-block_110 = {
-  instrs: [
-    { op:'jump', to:@block_112 },
+    { op:'jump', to:@block_110 },
   ]
 };
 
 block_111 = {
   instrs: [
-    { op:'push', val:'rt_ge' },
-    { op:'abort' },
-    { op:'jump', to:@block_112 },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'eq_i32' },
+    { op:'ret' },
+  ]
+};
+
+block_110 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_111, else:@block_112 },
   ]
 };
 
 block_112 = {
   instrs: [
-    { op:'get_local', idx:1 },
-    { op:'str_len' },
-    { op:'push', val:1 },
-    { op:'eq_i32' },
-    { op:'if_true', then:@block_113, else:@block_114 },
+    { op:'jump', to:@block_113 },
+  ]
+};
+
+block_105 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_107, else:@block_114 },
   ]
 };
 
@@ -794,121 +817,104 @@ block_113 = {
 
 block_114 = {
   instrs: [
-    { op:'push', val:'rt_ge' },
-    { op:'abort' },
     { op:'jump', to:@block_115 },
+  ]
+};
+
+block_117 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'eq_f32' },
+    { op:'ret' },
+  ]
+};
+
+block_116 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_117, else:@block_118 },
+  ]
+};
+
+block_118 = {
+  instrs: [
+    { op:'jump', to:@block_119 },
+  ]
+};
+
+block_120 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'i32_to_f32' },
+    { op:'eq_f32' },
+    { op:'ret' },
+  ]
+};
+
+block_119 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_120, else:@block_121 },
+  ]
+};
+
+block_121 = {
+  instrs: [
+    { op:'jump', to:@block_122 },
   ]
 };
 
 block_115 = {
   instrs: [
     { op:'get_local', idx:0 },
-    { op:'push', val:0 },
-    { op:'get_char_code' },
-    { op:'get_local', idx:1 },
-    { op:'push', val:0 },
-    { op:'get_char_code' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_ge' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_116, num_args:2 },
-  ]
-};
-
-block_116 = {
-  instrs: [
-    { op:'ret' },
-  ]
-};
-
-block_108 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'has_tag', tag:'string' },
-    { op:'if_true', then:@block_109, else:@block_117 },
-  ]
-};
-
-block_117 = {
-  instrs: [
-    { op:'jump', to:@block_118 },
-  ]
-};
-
-block_107 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'has_tag', tag:'string' },
-    { op:'if_true', then:@block_108, else:@block_119 },
-  ]
-};
-
-block_118 = {
-  instrs: [
-    { op:'jump', to:@block_120 },
-  ]
-};
-
-block_119 = {
-  instrs: [
-    { op:'jump', to:@block_120 },
-  ]
-};
-
-block_120 = {
-  instrs: [
-    { op:'push', val:$false },
-    { op:'if_true', then:@block_121, else:@block_122 },
-  ]
-};
-
-block_121 = {
-  instrs: [
-    { op:'jump', to:@block_123 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_116, else:@block_123 },
   ]
 };
 
 block_122 = {
   instrs: [
-    { op:'push', val:'unhandled type in less-than or equal comparison' },
-    { op:'abort' },
-    { op:'jump', to:@block_123 },
+    { op:'jump', to:@block_124 },
   ]
 };
 
 block_123 = {
   instrs: [
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-fun_101 = {
-  entry:@block_100,
-  num_params:2,
-  num_locals:2,
-};
-
-block_127 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'get_local', idx:0 },
-    { op:'has_field' },
-    { op:'ret' },
+    { op:'jump', to:@block_124 },
   ]
 };
 
 block_126 = {
   instrs: [
+    { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
-    { op:'has_tag', tag:'object' },
-    { op:'if_true', then:@block_127, else:@block_128 },
+    { op:'eq_str' },
+    { op:'ret' },
+  ]
+};
+
+block_125 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'string' },
+    { op:'if_true', then:@block_126, else:@block_127 },
+  ]
+};
+
+block_127 = {
+  instrs: [
+    { op:'jump', to:@block_128 },
   ]
 };
 
 block_128 = {
   instrs: [
-    { op:'jump', to:@block_129 },
+    { op:'push', val:$false },
+    { op:'ret' },
   ]
 };
 
@@ -916,96 +922,100 @@ block_124 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'has_tag', tag:'string' },
-    { op:'if_true', then:@block_126, else:@block_130 },
+    { op:'if_true', then:@block_125, else:@block_129 },
   ]
 };
 
 block_129 = {
   instrs: [
-    { op:'jump', to:@block_131 },
-  ]
-};
-
-block_130 = {
-  instrs: [
-    { op:'jump', to:@block_131 },
-  ]
-};
-
-block_131 = {
-  instrs: [
-    { op:'push', val:$false },
-    { op:'if_true', then:@block_132, else:@block_133 },
+    { op:'jump', to:@block_130 },
   ]
 };
 
 block_132 = {
   instrs: [
-    { op:'jump', to:@block_134 },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'eq_obj' },
+    { op:'ret' },
+  ]
+};
+
+block_131 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'object' },
+    { op:'if_true', then:@block_132, else:@block_133 },
   ]
 };
 
 block_133 = {
   instrs: [
-    { op:'push', val:'unhandled type in the \'in\' operator' },
-    { op:'abort' },
     { op:'jump', to:@block_134 },
   ]
 };
 
 block_134 = {
   instrs: [
-    { op:'push', val:$undef },
+    { op:'push', val:$false },
     { op:'ret' },
   ]
 };
 
-fun_125 = {
-  entry:@block_124,
-  num_params:2,
-  num_locals:2,
+block_130 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'object' },
+    { op:'if_true', then:@block_131, else:@block_135 },
+  ]
 };
 
 block_135 = {
   instrs: [
-    { op:'get_local', idx:0 },
-    { op:'has_tag', tag:'object' },
-    { op:'if_true', then:@block_137, else:@block_138 },
-  ]
-};
-
-block_137 = {
-  instrs: [
-    { op:'jump', to:@block_139 },
+    { op:'jump', to:@block_136 },
   ]
 };
 
 block_138 = {
   instrs: [
-    { op:'push', val:'instanceof only applies to objects' },
-    { op:'abort' },
-    { op:'jump', to:@block_139 },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'eq_bool' },
+    { op:'ret' },
+  ]
+};
+
+block_137 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'bool' },
+    { op:'if_true', then:@block_138, else:@block_139 },
   ]
 };
 
 block_139 = {
   instrs: [
-    { op:'get_local', idx:1 },
-    { op:'has_tag', tag:'object' },
-    { op:'if_true', then:@block_140, else:@block_141 },
+    { op:'jump', to:@block_140 },
   ]
 };
 
 block_140 = {
   instrs: [
-    { op:'jump', to:@block_142 },
+    { op:'push', val:$false },
+    { op:'ret' },
+  ]
+};
+
+block_136 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'bool' },
+    { op:'if_true', then:@block_137, else:@block_141 },
   ]
 };
 
 block_141 = {
   instrs: [
-    { op:'push', val:'prototype in instanceof must be an object' },
-    { op:'abort' },
     { op:'jump', to:@block_142 },
   ]
 };
@@ -1019,13 +1029,8 @@ block_144 = {
 
 block_143 = {
   instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'proto' },
-    { op:'get_field' },
-    { op:'set_local', idx:2 },
-    { op:'get_local', idx:2 },
     { op:'get_local', idx:1 },
-    { op:'eq_obj' },
+    { op:'has_tag', tag:'undef' },
     { op:'if_true', then:@block_144, else:@block_145 },
   ]
 };
@@ -1038,17 +1043,7 @@ block_145 = {
 
 block_146 = {
   instrs: [
-    { op:'get_local', idx:2 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_instOf' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_147, num_args:2 },
-  ]
-};
-
-block_147 = {
-  instrs: [
+    { op:'push', val:$false },
     { op:'ret' },
   ]
 };
@@ -1056,143 +1051,133 @@ block_147 = {
 block_142 = {
   instrs: [
     { op:'get_local', idx:0 },
-    { op:'push', val:'proto' },
-    { op:'has_field' },
-    { op:'if_true', then:@block_143, else:@block_148 },
+    { op:'has_tag', tag:'undef' },
+    { op:'if_true', then:@block_143, else:@block_147 },
+  ]
+};
+
+block_147 = {
+  instrs: [
+    { op:'jump', to:@block_148 },
   ]
 };
 
 block_148 = {
   instrs: [
-    { op:'jump', to:@block_149 },
+    { op:'push', val:$false },
+    { op:'if_true', then:@block_149, else:@block_150 },
   ]
 };
 
 block_149 = {
   instrs: [
-    { op:'push', val:$false },
-    { op:'ret' },
+    { op:'jump', to:@block_151 },
   ]
 };
 
-fun_136 = {
-  entry:@block_135,
-  num_params:2,
-  num_locals:3,
-};
-
-block_153 = {
+block_150 = {
   instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'get_field' },
+    { op:'push', val:'unhandled type in equality comparison' },
+    { op:'abort' },
+    { op:'jump', to:@block_151 },
+  ]
+};
+
+block_151 = {
+  instrs: [
+    { op:'push', val:$undef },
     { op:'ret' },
   ]
+};
+
+fun_106 = {
+  entry:@block_105,
+  num_params:2,
+  num_locals:2,
 };
 
 block_152 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
-    { op:'has_field' },
-    { op:'if_true', then:@block_153, else:@block_154 },
-  ]
-};
-
-block_154 = {
-  instrs: [
-    { op:'jump', to:@block_155 },
-  ]
-};
-
-block_156 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'proto' },
-    { op:'get_field' },
-    { op:'set_local', idx:2 },
-    { op:'get_local', idx:2 },
-    { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_157, num_args:2 },
-  ]
-};
-
-block_157 = {
-  instrs: [
-    { op:'ret' },
+    { op:'call', ret_to:@block_154, num_args:2 },
   ]
 };
 
 block_155 = {
   instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'proto' },
-    { op:'has_field' },
-    { op:'if_true', then:@block_156, else:@block_158 },
+    { op:'push', val:$false },
+    { op:'ret' },
   ]
 };
 
-block_158 = {
+block_156 = {
   instrs: [
-    { op:'jump', to:@block_159 },
+    { op:'push', val:$true },
+    { op:'ret' },
   ]
+};
+
+block_154 = {
+  instrs: [
+    { op:'if_true', then:@block_155, else:@block_156 },
+  ]
+};
+
+block_157 = {
+  instrs: [
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+fun_153 = {
+  entry:@block_152,
+  num_params:2,
+  num_locals:2,
 };
 
 block_161 = {
   instrs: [
-    { op:'push', val:'undefined property \"' },
+    { op:'get_local', idx:0 },
+    { op:'i32_to_f32' },
     { op:'get_local', idx:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_add' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_162, num_args:2 },
-  ]
-};
-
-block_162 = {
-  instrs: [
-    { op:'push', val:'\"' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_add' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_163, num_args:2 },
-  ]
-};
-
-block_159 = {
-  instrs: [
-    { op:'push', val:$false },
-    { op:'if_true', then:@block_160, else:@block_161 },
+    { op:'lt_f32' },
+    { op:'ret' },
   ]
 };
 
 block_160 = {
   instrs: [
-    { op:'jump', to:@block_164 },
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_161, else:@block_162 },
   ]
 };
 
-block_163 = {
+block_162 = {
   instrs: [
-    { op:'abort' },
-    { op:'jump', to:@block_164 },
-  ]
-};
-
-block_150 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'has_tag', tag:'object' },
-    { op:'if_true', then:@block_152, else:@block_165 },
+    { op:'jump', to:@block_163 },
   ]
 };
 
 block_164 = {
   instrs: [
-    { op:'jump', to:@block_166 },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'lt_i32' },
+    { op:'ret' },
+  ]
+};
+
+block_163 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_164, else:@block_165 },
   ]
 };
 
@@ -1202,59 +1187,63 @@ block_165 = {
   ]
 };
 
-block_167 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'length' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_168, num_args:2 },
-  ]
-};
-
-block_169 = {
+block_158 = {
   instrs: [
     { op:'get_local', idx:0 },
-    { op:'array_len' },
-    { op:'ret' },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_160, else:@block_167 },
   ]
 };
 
-block_168 = {
+block_166 = {
   instrs: [
-    { op:'if_true', then:@block_169, else:@block_170 },
+    { op:'jump', to:@block_168 },
+  ]
+};
+
+block_167 = {
+  instrs: [
+    { op:'jump', to:@block_168 },
   ]
 };
 
 block_170 = {
   instrs: [
-    { op:'jump', to:@block_171 },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'lt_f32' },
+    { op:'ret' },
+  ]
+};
+
+block_169 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_170, else:@block_171 },
   ]
 };
 
 block_171 = {
   instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'push' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_172, num_args:2 },
+    { op:'jump', to:@block_172 },
   ]
 };
 
 block_173 = {
   instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_push' },
-    { op:'get_field' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'i32_to_f32' },
+    { op:'lt_f32' },
     { op:'ret' },
   ]
 };
 
 block_172 = {
   instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'int32' },
     { op:'if_true', then:@block_173, else:@block_174 },
   ]
 };
@@ -1265,11 +1254,11 @@ block_174 = {
   ]
 };
 
-block_166 = {
+block_168 = {
   instrs: [
     { op:'get_local', idx:0 },
-    { op:'has_tag', tag:'array' },
-    { op:'if_true', then:@block_167, else:@block_176 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_169, else:@block_176 },
   ]
 };
 
@@ -1285,148 +1274,144 @@ block_176 = {
   ]
 };
 
-block_178 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'length' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_179, num_args:2 },
-  ]
-};
-
-block_180 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'str_len' },
-    { op:'ret' },
-  ]
-};
-
-block_179 = {
-  instrs: [
-    { op:'if_true', then:@block_180, else:@block_181 },
-  ]
-};
-
-block_181 = {
-  instrs: [
-    { op:'jump', to:@block_182 },
-  ]
-};
-
 block_177 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'has_tag', tag:'string' },
-    { op:'if_true', then:@block_178, else:@block_183 },
-  ]
-};
-
-block_182 = {
-  instrs: [
-    { op:'jump', to:@block_184 },
-  ]
-};
-
-block_183 = {
-  instrs: [
-    { op:'jump', to:@block_184 },
-  ]
-};
-
-block_186 = {
-  instrs: [
-    { op:'push', val:'unhandled base type in read of property \"' },
-    { op:'get_local', idx:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_add' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_187, num_args:2 },
-  ]
-};
-
-block_187 = {
-  instrs: [
-    { op:'push', val:'\"' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_add' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_188, num_args:2 },
-  ]
-};
-
-block_184 = {
-  instrs: [
-    { op:'push', val:$false },
-    { op:'if_true', then:@block_185, else:@block_186 },
-  ]
-};
-
-block_185 = {
-  instrs: [
-    { op:'jump', to:@block_189 },
-  ]
-};
-
-block_188 = {
-  instrs: [
-    { op:'abort' },
-    { op:'jump', to:@block_189 },
-  ]
-};
-
-block_189 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-fun_151 = {
-  entry:@block_150,
+fun_159 = {
+  entry:@block_158,
   num_params:2,
-  num_locals:3,
+  num_locals:2,
 };
 
-block_192 = {
+block_181 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'i32_to_f32' },
+    { op:'get_local', idx:1 },
+    { op:'le_f32' },
+    { op:'ret' },
+  ]
+};
+
+block_180 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_181, else:@block_182 },
+  ]
+};
+
+block_182 = {
+  instrs: [
+    { op:'jump', to:@block_183 },
+  ]
+};
+
+block_184 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
-    { op:'get_elem' },
+    { op:'le_i32' },
     { op:'ret' },
+  ]
+};
+
+block_183 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_184, else:@block_185 },
+  ]
+};
+
+block_185 = {
+  instrs: [
+    { op:'jump', to:@block_186 },
+  ]
+};
+
+block_178 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_180, else:@block_187 },
+  ]
+};
+
+block_186 = {
+  instrs: [
+    { op:'jump', to:@block_188 },
+  ]
+};
+
+block_187 = {
+  instrs: [
+    { op:'jump', to:@block_188 },
   ]
 };
 
 block_190 = {
   instrs: [
     { op:'get_local', idx:0 },
-    { op:'has_tag', tag:'array' },
-    { op:'if_true', then:@block_192, else:@block_193 },
+    { op:'get_local', idx:1 },
+    { op:'le_f32' },
+    { op:'ret' },
+  ]
+};
+
+block_189 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_190, else:@block_191 },
+  ]
+};
+
+block_191 = {
+  instrs: [
+    { op:'jump', to:@block_192 },
   ]
 };
 
 block_193 = {
   instrs: [
-    { op:'jump', to:@block_194 },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'i32_to_f32' },
+    { op:'le_f32' },
+    { op:'ret' },
   ]
 };
 
-block_195 = {
+block_192 = {
   instrs: [
-    { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
-    { op:'get_char' },
-    { op:'ret' },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_193, else:@block_194 },
   ]
 };
 
 block_194 = {
   instrs: [
+    { op:'jump', to:@block_195 },
+  ]
+};
+
+block_188 = {
+  instrs: [
     { op:'get_local', idx:0 },
-    { op:'has_tag', tag:'string' },
-    { op:'if_true', then:@block_195, else:@block_196 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_189, else:@block_196 },
+  ]
+};
+
+block_195 = {
+  instrs: [
+    { op:'jump', to:@block_197 },
   ]
 };
 
@@ -1436,65 +1421,64 @@ block_196 = {
   ]
 };
 
-block_197 = {
-  instrs: [
-    { op:'push', val:$false },
-    { op:'if_true', then:@block_198, else:@block_199 },
-  ]
-};
-
-block_198 = {
-  instrs: [
-    { op:'jump', to:@block_200 },
-  ]
-};
-
 block_199 = {
   instrs: [
-    { op:'push', val:'unhandled type in getElem' },
-    { op:'abort' },
-    { op:'jump', to:@block_200 },
+    { op:'get_local', idx:0 },
+    { op:'str_len' },
+    { op:'push', val:1 },
+    { op:'eq_i32' },
+    { op:'if_true', then:@block_200, else:@block_201 },
   ]
 };
 
 block_200 = {
   instrs: [
-    { op:'push', val:$undef },
-    { op:'ret' },
+    { op:'jump', to:@block_202 },
   ]
-};
-
-fun_191 = {
-  entry:@block_190,
-  num_params:2,
-  num_locals:2,
 };
 
 block_201 = {
   instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'array_push' },
-    { op:'push', val:$undef },
-    { op:'ret' },
+    { op:'push', val:'rt_le' },
+    { op:'abort' },
+    { op:'jump', to:@block_202 },
   ]
 };
 
-fun_202 = {
-  entry:@block_201,
-  num_params:2,
-  num_locals:2,
+block_202 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'str_len' },
+    { op:'push', val:1 },
+    { op:'eq_i32' },
+    { op:'if_true', then:@block_203, else:@block_204 },
+  ]
+};
+
+block_203 = {
+  instrs: [
+    { op:'jump', to:@block_205 },
+  ]
+};
+
+block_204 = {
+  instrs: [
+    { op:'push', val:'rt_le' },
+    { op:'abort' },
+    { op:'jump', to:@block_205 },
+  ]
 };
 
 block_205 = {
   instrs: [
     { op:'get_local', idx:0 },
+    { op:'push', val:0 },
+    { op:'get_char_code' },
+    { op:'get_local', idx:1 },
+    { op:'push', val:0 },
+    { op:'get_char_code' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'io' },
-    { op:'get_field' },
-    { op:'push', val:'print_str' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'rt_le' },
     { op:'get_field' },
     { op:'call', ret_to:@block_206, num_args:2 },
   ]
@@ -1502,106 +1486,93 @@ block_205 = {
 
 block_206 = {
   instrs: [
-    { op:'call', ret_to:@block_207, num_args:1 },
+    { op:'ret' },
+  ]
+};
+
+block_198 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'string' },
+    { op:'if_true', then:@block_199, else:@block_207 },
   ]
 };
 
 block_207 = {
   instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
+    { op:'jump', to:@block_208 },
   ]
 };
 
-block_203 = {
+block_197 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'has_tag', tag:'string' },
-    { op:'if_true', then:@block_205, else:@block_208 },
+    { op:'if_true', then:@block_198, else:@block_209 },
   ]
 };
 
 block_208 = {
   instrs: [
-    { op:'jump', to:@block_209 },
-  ]
-};
-
-block_210 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'io' },
-    { op:'get_field' },
-    { op:'push', val:'print_int32' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_211, num_args:2 },
-  ]
-};
-
-block_211 = {
-  instrs: [
-    { op:'call', ret_to:@block_212, num_args:1 },
-  ]
-};
-
-block_212 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
+    { op:'jump', to:@block_210 },
   ]
 };
 
 block_209 = {
   instrs: [
-    { op:'get_local', idx:0 },
-    { op:'has_tag', tag:'int32' },
-    { op:'if_true', then:@block_210, else:@block_213 },
+    { op:'jump', to:@block_210 },
+  ]
+};
+
+block_210 = {
+  instrs: [
+    { op:'push', val:$false },
+    { op:'if_true', then:@block_211, else:@block_212 },
+  ]
+};
+
+block_211 = {
+  instrs: [
+    { op:'jump', to:@block_213 },
+  ]
+};
+
+block_212 = {
+  instrs: [
+    { op:'push', val:'unhandled type in less-than or equal comparison' },
+    { op:'abort' },
+    { op:'jump', to:@block_213 },
   ]
 };
 
 block_213 = {
   instrs: [
-    { op:'jump', to:@block_214 },
-  ]
-};
-
-block_214 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:$true },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_215, num_args:2 },
-  ]
-};
-
-block_216 = {
-  instrs: [
-    { op:'push', val:'true' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'output' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_217, num_args:1 },
-  ]
-};
-
-block_217 = {
-  instrs: [
-    { op:'pop' },
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-block_215 = {
+fun_179 = {
+  entry:@block_178,
+  num_params:2,
+  num_locals:2,
+};
+
+block_217 = {
   instrs: [
-    { op:'if_true', then:@block_216, else:@block_218 },
+    { op:'get_local', idx:0 },
+    { op:'i32_to_f32' },
+    { op:'get_local', idx:1 },
+    { op:'gt_f32' },
+    { op:'ret' },
+  ]
+};
+
+block_216 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_217, else:@block_218 },
   ]
 };
 
@@ -1611,38 +1582,40 @@ block_218 = {
   ]
 };
 
-block_219 = {
+block_220 = {
   instrs: [
     { op:'get_local', idx:0 },
-    { op:'push', val:$false },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_220, num_args:2 },
+    { op:'get_local', idx:1 },
+    { op:'gt_i32' },
+    { op:'ret' },
+  ]
+};
+
+block_219 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_220, else:@block_221 },
   ]
 };
 
 block_221 = {
   instrs: [
-    { op:'push', val:'false' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'output' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_222, num_args:1 },
+    { op:'jump', to:@block_222 },
+  ]
+};
+
+block_214 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_216, else:@block_223 },
   ]
 };
 
 block_222 = {
   instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_220 = {
-  instrs: [
-    { op:'if_true', then:@block_221, else:@block_223 },
+    { op:'jump', to:@block_224 },
   ]
 };
 
@@ -1652,62 +1625,1376 @@ block_223 = {
   ]
 };
 
-block_224 = {
+block_226 = {
   instrs: [
-    { op:'push', val:$false },
-    { op:'if_true', then:@block_225, else:@block_226 },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'gt_f32' },
+    { op:'ret' },
   ]
 };
 
 block_225 = {
   instrs: [
-    { op:'jump', to:@block_227 },
-  ]
-};
-
-block_226 = {
-  instrs: [
-    { op:'push', val:'unhandled type in output function' },
-    { op:'abort' },
-    { op:'jump', to:@block_227 },
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_226, else:@block_227 },
   ]
 };
 
 block_227 = {
+  instrs: [
+    { op:'jump', to:@block_228 },
+  ]
+};
+
+block_229 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'i32_to_f32' },
+    { op:'gt_f32' },
+    { op:'ret' },
+  ]
+};
+
+block_228 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_229, else:@block_230 },
+  ]
+};
+
+block_230 = {
+  instrs: [
+    { op:'jump', to:@block_231 },
+  ]
+};
+
+block_224 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_225, else:@block_232 },
+  ]
+};
+
+block_231 = {
+  instrs: [
+    { op:'jump', to:@block_233 },
+  ]
+};
+
+block_232 = {
+  instrs: [
+    { op:'jump', to:@block_233 },
+  ]
+};
+
+block_233 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-fun_204 = {
-  entry:@block_203,
+fun_215 = {
+  entry:@block_214,
+  num_params:2,
+  num_locals:2,
+};
+
+block_237 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'i32_to_f32' },
+    { op:'get_local', idx:1 },
+    { op:'ge_f32' },
+    { op:'ret' },
+  ]
+};
+
+block_236 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_237, else:@block_238 },
+  ]
+};
+
+block_238 = {
+  instrs: [
+    { op:'jump', to:@block_239 },
+  ]
+};
+
+block_240 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'ge_i32' },
+    { op:'ret' },
+  ]
+};
+
+block_239 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_240, else:@block_241 },
+  ]
+};
+
+block_241 = {
+  instrs: [
+    { op:'jump', to:@block_242 },
+  ]
+};
+
+block_234 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_236, else:@block_243 },
+  ]
+};
+
+block_242 = {
+  instrs: [
+    { op:'jump', to:@block_244 },
+  ]
+};
+
+block_243 = {
+  instrs: [
+    { op:'jump', to:@block_244 },
+  ]
+};
+
+block_246 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'ge_f32' },
+    { op:'ret' },
+  ]
+};
+
+block_245 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_246, else:@block_247 },
+  ]
+};
+
+block_247 = {
+  instrs: [
+    { op:'jump', to:@block_248 },
+  ]
+};
+
+block_249 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'i32_to_f32' },
+    { op:'ge_f32' },
+    { op:'ret' },
+  ]
+};
+
+block_248 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_249, else:@block_250 },
+  ]
+};
+
+block_250 = {
+  instrs: [
+    { op:'jump', to:@block_251 },
+  ]
+};
+
+block_244 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_245, else:@block_252 },
+  ]
+};
+
+block_251 = {
+  instrs: [
+    { op:'jump', to:@block_253 },
+  ]
+};
+
+block_252 = {
+  instrs: [
+    { op:'jump', to:@block_253 },
+  ]
+};
+
+block_255 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'str_len' },
+    { op:'push', val:1 },
+    { op:'eq_i32' },
+    { op:'if_true', then:@block_256, else:@block_257 },
+  ]
+};
+
+block_256 = {
+  instrs: [
+    { op:'jump', to:@block_258 },
+  ]
+};
+
+block_257 = {
+  instrs: [
+    { op:'push', val:'rt_ge' },
+    { op:'abort' },
+    { op:'jump', to:@block_258 },
+  ]
+};
+
+block_258 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'str_len' },
+    { op:'push', val:1 },
+    { op:'eq_i32' },
+    { op:'if_true', then:@block_259, else:@block_260 },
+  ]
+};
+
+block_259 = {
+  instrs: [
+    { op:'jump', to:@block_261 },
+  ]
+};
+
+block_260 = {
+  instrs: [
+    { op:'push', val:'rt_ge' },
+    { op:'abort' },
+    { op:'jump', to:@block_261 },
+  ]
+};
+
+block_261 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:0 },
+    { op:'get_char_code' },
+    { op:'get_local', idx:1 },
+    { op:'push', val:0 },
+    { op:'get_char_code' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_ge' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_262, num_args:2 },
+  ]
+};
+
+block_262 = {
+  instrs: [
+    { op:'ret' },
+  ]
+};
+
+block_254 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'string' },
+    { op:'if_true', then:@block_255, else:@block_263 },
+  ]
+};
+
+block_263 = {
+  instrs: [
+    { op:'jump', to:@block_264 },
+  ]
+};
+
+block_253 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'string' },
+    { op:'if_true', then:@block_254, else:@block_265 },
+  ]
+};
+
+block_264 = {
+  instrs: [
+    { op:'jump', to:@block_266 },
+  ]
+};
+
+block_265 = {
+  instrs: [
+    { op:'jump', to:@block_266 },
+  ]
+};
+
+block_266 = {
+  instrs: [
+    { op:'push', val:$false },
+    { op:'if_true', then:@block_267, else:@block_268 },
+  ]
+};
+
+block_267 = {
+  instrs: [
+    { op:'jump', to:@block_269 },
+  ]
+};
+
+block_268 = {
+  instrs: [
+    { op:'push', val:'unhandled type in less-than or equal comparison' },
+    { op:'abort' },
+    { op:'jump', to:@block_269 },
+  ]
+};
+
+block_269 = {
+  instrs: [
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+fun_235 = {
+  entry:@block_234,
+  num_params:2,
+  num_locals:2,
+};
+
+block_273 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'get_local', idx:0 },
+    { op:'has_field' },
+    { op:'ret' },
+  ]
+};
+
+block_272 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'object' },
+    { op:'if_true', then:@block_273, else:@block_274 },
+  ]
+};
+
+block_274 = {
+  instrs: [
+    { op:'jump', to:@block_275 },
+  ]
+};
+
+block_270 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'string' },
+    { op:'if_true', then:@block_272, else:@block_276 },
+  ]
+};
+
+block_275 = {
+  instrs: [
+    { op:'jump', to:@block_277 },
+  ]
+};
+
+block_276 = {
+  instrs: [
+    { op:'jump', to:@block_277 },
+  ]
+};
+
+block_277 = {
+  instrs: [
+    { op:'push', val:$false },
+    { op:'if_true', then:@block_278, else:@block_279 },
+  ]
+};
+
+block_278 = {
+  instrs: [
+    { op:'jump', to:@block_280 },
+  ]
+};
+
+block_279 = {
+  instrs: [
+    { op:'push', val:'unhandled type in the \'in\' operator' },
+    { op:'abort' },
+    { op:'jump', to:@block_280 },
+  ]
+};
+
+block_280 = {
+  instrs: [
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+fun_271 = {
+  entry:@block_270,
+  num_params:2,
+  num_locals:2,
+};
+
+block_281 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'object' },
+    { op:'if_true', then:@block_283, else:@block_284 },
+  ]
+};
+
+block_283 = {
+  instrs: [
+    { op:'jump', to:@block_285 },
+  ]
+};
+
+block_284 = {
+  instrs: [
+    { op:'push', val:'instanceof only applies to objects' },
+    { op:'abort' },
+    { op:'jump', to:@block_285 },
+  ]
+};
+
+block_285 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'object' },
+    { op:'if_true', then:@block_286, else:@block_287 },
+  ]
+};
+
+block_286 = {
+  instrs: [
+    { op:'jump', to:@block_288 },
+  ]
+};
+
+block_287 = {
+  instrs: [
+    { op:'push', val:'prototype in instanceof must be an object' },
+    { op:'abort' },
+    { op:'jump', to:@block_288 },
+  ]
+};
+
+block_290 = {
+  instrs: [
+    { op:'push', val:$true },
+    { op:'ret' },
+  ]
+};
+
+block_289 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:'proto' },
+    { op:'get_field' },
+    { op:'set_local', idx:2 },
+    { op:'get_local', idx:2 },
+    { op:'get_local', idx:1 },
+    { op:'eq_obj' },
+    { op:'if_true', then:@block_290, else:@block_291 },
+  ]
+};
+
+block_291 = {
+  instrs: [
+    { op:'jump', to:@block_292 },
+  ]
+};
+
+block_292 = {
+  instrs: [
+    { op:'get_local', idx:2 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_instOf' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_293, num_args:2 },
+  ]
+};
+
+block_293 = {
+  instrs: [
+    { op:'ret' },
+  ]
+};
+
+block_288 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:'proto' },
+    { op:'has_field' },
+    { op:'if_true', then:@block_289, else:@block_294 },
+  ]
+};
+
+block_294 = {
+  instrs: [
+    { op:'jump', to:@block_295 },
+  ]
+};
+
+block_295 = {
+  instrs: [
+    { op:'push', val:$false },
+    { op:'ret' },
+  ]
+};
+
+fun_282 = {
+  entry:@block_281,
+  num_params:2,
+  num_locals:3,
+};
+
+block_299 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'get_field' },
+    { op:'ret' },
+  ]
+};
+
+block_298 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'has_field' },
+    { op:'if_true', then:@block_299, else:@block_300 },
+  ]
+};
+
+block_300 = {
+  instrs: [
+    { op:'jump', to:@block_301 },
+  ]
+};
+
+block_302 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:'proto' },
+    { op:'get_field' },
+    { op:'set_local', idx:2 },
+    { op:'get_local', idx:2 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_303, num_args:2 },
+  ]
+};
+
+block_303 = {
+  instrs: [
+    { op:'ret' },
+  ]
+};
+
+block_301 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:'proto' },
+    { op:'has_field' },
+    { op:'if_true', then:@block_302, else:@block_304 },
+  ]
+};
+
+block_304 = {
+  instrs: [
+    { op:'jump', to:@block_305 },
+  ]
+};
+
+block_307 = {
+  instrs: [
+    { op:'push', val:'undefined property \"' },
+    { op:'get_local', idx:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_add' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_308, num_args:2 },
+  ]
+};
+
+block_308 = {
+  instrs: [
+    { op:'push', val:'\"' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_add' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_309, num_args:2 },
+  ]
+};
+
+block_305 = {
+  instrs: [
+    { op:'push', val:$false },
+    { op:'if_true', then:@block_306, else:@block_307 },
+  ]
+};
+
+block_306 = {
+  instrs: [
+    { op:'jump', to:@block_310 },
+  ]
+};
+
+block_309 = {
+  instrs: [
+    { op:'abort' },
+    { op:'jump', to:@block_310 },
+  ]
+};
+
+block_296 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'object' },
+    { op:'if_true', then:@block_298, else:@block_311 },
+  ]
+};
+
+block_310 = {
+  instrs: [
+    { op:'jump', to:@block_312 },
+  ]
+};
+
+block_311 = {
+  instrs: [
+    { op:'jump', to:@block_312 },
+  ]
+};
+
+block_313 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'length' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_314, num_args:2 },
+  ]
+};
+
+block_315 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'array_len' },
+    { op:'ret' },
+  ]
+};
+
+block_314 = {
+  instrs: [
+    { op:'if_true', then:@block_315, else:@block_316 },
+  ]
+};
+
+block_316 = {
+  instrs: [
+    { op:'jump', to:@block_317 },
+  ]
+};
+
+block_317 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'push' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_318, num_args:2 },
+  ]
+};
+
+block_319 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_push' },
+    { op:'get_field' },
+    { op:'ret' },
+  ]
+};
+
+block_318 = {
+  instrs: [
+    { op:'if_true', then:@block_319, else:@block_320 },
+  ]
+};
+
+block_320 = {
+  instrs: [
+    { op:'jump', to:@block_321 },
+  ]
+};
+
+block_312 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'array' },
+    { op:'if_true', then:@block_313, else:@block_322 },
+  ]
+};
+
+block_321 = {
+  instrs: [
+    { op:'jump', to:@block_323 },
+  ]
+};
+
+block_322 = {
+  instrs: [
+    { op:'jump', to:@block_323 },
+  ]
+};
+
+block_324 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'length' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_325, num_args:2 },
+  ]
+};
+
+block_326 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'str_len' },
+    { op:'ret' },
+  ]
+};
+
+block_325 = {
+  instrs: [
+    { op:'if_true', then:@block_326, else:@block_327 },
+  ]
+};
+
+block_327 = {
+  instrs: [
+    { op:'jump', to:@block_328 },
+  ]
+};
+
+block_323 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'string' },
+    { op:'if_true', then:@block_324, else:@block_329 },
+  ]
+};
+
+block_328 = {
+  instrs: [
+    { op:'jump', to:@block_330 },
+  ]
+};
+
+block_329 = {
+  instrs: [
+    { op:'jump', to:@block_330 },
+  ]
+};
+
+block_332 = {
+  instrs: [
+    { op:'push', val:'unhandled base type in read of property \"' },
+    { op:'get_local', idx:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_add' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_333, num_args:2 },
+  ]
+};
+
+block_333 = {
+  instrs: [
+    { op:'push', val:'\"' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_add' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_334, num_args:2 },
+  ]
+};
+
+block_330 = {
+  instrs: [
+    { op:'push', val:$false },
+    { op:'if_true', then:@block_331, else:@block_332 },
+  ]
+};
+
+block_331 = {
+  instrs: [
+    { op:'jump', to:@block_335 },
+  ]
+};
+
+block_334 = {
+  instrs: [
+    { op:'abort' },
+    { op:'jump', to:@block_335 },
+  ]
+};
+
+block_335 = {
+  instrs: [
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+fun_297 = {
+  entry:@block_296,
+  num_params:2,
+  num_locals:3,
+};
+
+block_338 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'get_elem' },
+    { op:'ret' },
+  ]
+};
+
+block_336 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'array' },
+    { op:'if_true', then:@block_338, else:@block_339 },
+  ]
+};
+
+block_339 = {
+  instrs: [
+    { op:'jump', to:@block_340 },
+  ]
+};
+
+block_341 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'get_char' },
+    { op:'ret' },
+  ]
+};
+
+block_340 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'string' },
+    { op:'if_true', then:@block_341, else:@block_342 },
+  ]
+};
+
+block_342 = {
+  instrs: [
+    { op:'jump', to:@block_343 },
+  ]
+};
+
+block_343 = {
+  instrs: [
+    { op:'push', val:$false },
+    { op:'if_true', then:@block_344, else:@block_345 },
+  ]
+};
+
+block_344 = {
+  instrs: [
+    { op:'jump', to:@block_346 },
+  ]
+};
+
+block_345 = {
+  instrs: [
+    { op:'push', val:'unhandled type in getElem' },
+    { op:'abort' },
+    { op:'jump', to:@block_346 },
+  ]
+};
+
+block_346 = {
+  instrs: [
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+fun_337 = {
+  entry:@block_336,
+  num_params:2,
+  num_locals:2,
+};
+
+block_347 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'array_push' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+fun_348 = {
+  entry:@block_347,
+  num_params:2,
+  num_locals:2,
+};
+
+block_351 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'io' },
+    { op:'get_field' },
+    { op:'push', val:'print_str' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_352, num_args:2 },
+  ]
+};
+
+block_352 = {
+  instrs: [
+    { op:'call', ret_to:@block_353, num_args:1 },
+  ]
+};
+
+block_353 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_349 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'string' },
+    { op:'if_true', then:@block_351, else:@block_354 },
+  ]
+};
+
+block_354 = {
+  instrs: [
+    { op:'jump', to:@block_355 },
+  ]
+};
+
+block_356 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'io' },
+    { op:'get_field' },
+    { op:'push', val:'print_int32' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_357, num_args:2 },
+  ]
+};
+
+block_357 = {
+  instrs: [
+    { op:'call', ret_to:@block_358, num_args:1 },
+  ]
+};
+
+block_358 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_355 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_356, else:@block_359 },
+  ]
+};
+
+block_359 = {
+  instrs: [
+    { op:'jump', to:@block_360 },
+  ]
+};
+
+block_361 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'io' },
+    { op:'get_field' },
+    { op:'push', val:'print_float32' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_362, num_args:2 },
+  ]
+};
+
+block_362 = {
+  instrs: [
+    { op:'call', ret_to:@block_363, num_args:1 },
+  ]
+};
+
+block_363 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_360 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_361, else:@block_364 },
+  ]
+};
+
+block_364 = {
+  instrs: [
+    { op:'jump', to:@block_365 },
+  ]
+};
+
+block_365 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:$true },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_366, num_args:2 },
+  ]
+};
+
+block_367 = {
+  instrs: [
+    { op:'push', val:'true' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'output' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_368, num_args:1 },
+  ]
+};
+
+block_368 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_366 = {
+  instrs: [
+    { op:'if_true', then:@block_367, else:@block_369 },
+  ]
+};
+
+block_369 = {
+  instrs: [
+    { op:'jump', to:@block_370 },
+  ]
+};
+
+block_370 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:$false },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_371, num_args:2 },
+  ]
+};
+
+block_372 = {
+  instrs: [
+    { op:'push', val:'false' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'output' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_373, num_args:1 },
+  ]
+};
+
+block_373 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_371 = {
+  instrs: [
+    { op:'if_true', then:@block_372, else:@block_374 },
+  ]
+};
+
+block_374 = {
+  instrs: [
+    { op:'jump', to:@block_375 },
+  ]
+};
+
+block_375 = {
+  instrs: [
+    { op:'push', val:$false },
+    { op:'if_true', then:@block_376, else:@block_377 },
+  ]
+};
+
+block_376 = {
+  instrs: [
+    { op:'jump', to:@block_378 },
+  ]
+};
+
+block_377 = {
+  instrs: [
+    { op:'push', val:'unhandled type in output function' },
+    { op:'abort' },
+    { op:'jump', to:@block_378 },
+  ]
+};
+
+block_378 = {
+  instrs: [
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+fun_350 = {
+  entry:@block_349,
   num_params:1,
   num_locals:1,
 };
 
-block_228 = {
+block_381 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'i32_to_f32' },
+    { op:'sin_f32' },
+    { op:'ret' },
+  ]
+};
+
+block_379 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_381, else:@block_382 },
+  ]
+};
+
+block_382 = {
+  instrs: [
+    { op:'jump', to:@block_383 },
+  ]
+};
+
+block_384 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'sin_f32' },
+    { op:'ret' },
+  ]
+};
+
+block_383 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_384, else:@block_385 },
+  ]
+};
+
+block_385 = {
+  instrs: [
+    { op:'jump', to:@block_386 },
+  ]
+};
+
+block_386 = {
+  instrs: [
+    { op:'push', val:$false },
+    { op:'if_true', then:@block_387, else:@block_388 },
+  ]
+};
+
+block_387 = {
+  instrs: [
+    { op:'jump', to:@block_389 },
+  ]
+};
+
+block_388 = {
+  instrs: [
+    { op:'push', val:'unhandled type in sin function' },
+    { op:'abort' },
+    { op:'jump', to:@block_389 },
+  ]
+};
+
+block_389 = {
+  instrs: [
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+fun_380 = {
+  entry:@block_379,
+  num_params:1,
+  num_locals:1,
+};
+
+block_392 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'i32_to_f32' },
+    { op:'sqrt_f32' },
+    { op:'ret' },
+  ]
+};
+
+block_390 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_392, else:@block_393 },
+  ]
+};
+
+block_393 = {
+  instrs: [
+    { op:'jump', to:@block_394 },
+  ]
+};
+
+block_395 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'sqrt_f32' },
+    { op:'ret' },
+  ]
+};
+
+block_394 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_395, else:@block_396 },
+  ]
+};
+
+block_396 = {
+  instrs: [
+    { op:'jump', to:@block_397 },
+  ]
+};
+
+block_397 = {
+  instrs: [
+    { op:'push', val:$false },
+    { op:'if_true', then:@block_398, else:@block_399 },
+  ]
+};
+
+block_398 = {
+  instrs: [
+    { op:'jump', to:@block_400 },
+  ]
+};
+
+block_399 = {
+  instrs: [
+    { op:'push', val:'unhandled type in sin function' },
+    { op:'abort' },
+    { op:'jump', to:@block_400 },
+  ]
+};
+
+block_400 = {
+  instrs: [
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+fun_391 = {
+  entry:@block_390,
+  num_params:1,
+  num_locals:1,
+};
+
+block_401 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'output' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_230, num_args:1 },
+    { op:'call', ret_to:@block_403, num_args:1 },
   ]
 };
 
-block_230 = {
+block_403 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'\x0A' },
     { op:'push', val:@global_obj },
     { op:'push', val:'output' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_231, num_args:1 },
+    { op:'call', ret_to:@block_404, num_args:1 },
   ]
 };
 
-block_231 = {
+block_404 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -1715,13 +3002,13 @@ block_231 = {
   ]
 };
 
-fun_229 = {
-  entry:@block_228,
+fun_402 = {
+  entry:@block_401,
   num_params:1,
   num_locals:1,
 };
 
-block_232 = {
+block_405 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
@@ -1731,24 +3018,24 @@ block_232 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_234, num_args:2 },
+    { op:'call', ret_to:@block_407, num_args:2 },
   ]
 };
 
-block_234 = {
+block_407 = {
   instrs: [
-    { op:'call', ret_to:@block_235, num_args:1 },
+    { op:'call', ret_to:@block_408, num_args:1 },
   ]
 };
 
-block_235 = {
+block_408 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-fun_233 = {
-  entry:@block_232,
+fun_406 = {
+  entry:@block_405,
   num_params:1,
   num_locals:1,
 };
@@ -1761,47 +3048,63 @@ block_0 = {
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_sub' },
-    { op:'push', val:@fun_20 },
+    { op:'push', val:@fun_32 },
+    { op:'set_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_mul' },
+    { op:'push', val:@fun_55 },
+    { op:'set_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_div' },
+    { op:'push', val:@fun_78 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_not' },
-    { op:'push', val:@fun_31 },
-    { op:'set_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'push', val:@fun_36 },
-    { op:'set_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_ne' },
-    { op:'push', val:@fun_71 },
-    { op:'set_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_le' },
-    { op:'push', val:@fun_77 },
-    { op:'set_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_ge' },
     { op:'push', val:@fun_101 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'push', val:@fun_106 },
+    { op:'set_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_ne' },
+    { op:'push', val:@fun_153 },
+    { op:'set_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_lt' },
+    { op:'push', val:@fun_159 },
+    { op:'set_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_le' },
+    { op:'push', val:@fun_179 },
+    { op:'set_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_gt' },
+    { op:'push', val:@fun_215 },
+    { op:'set_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_ge' },
+    { op:'push', val:@fun_235 },
+    { op:'set_field' },
+    { op:'push', val:@global_obj },
     { op:'push', val:'rt_in' },
-    { op:'push', val:@fun_125 },
+    { op:'push', val:@fun_271 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
-    { op:'push', val:@fun_136 },
+    { op:'push', val:@fun_282 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
-    { op:'push', val:@fun_151 },
+    { op:'push', val:@fun_297 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getElem' },
-    { op:'push', val:@fun_191 },
+    { op:'push', val:@fun_337 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_push' },
-    { op:'push', val:@fun_202 },
+    { op:'push', val:@fun_348 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'io' },
@@ -1810,15 +3113,23 @@ block_0 = {
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'output' },
-    { op:'push', val:@fun_204 },
+    { op:'push', val:@fun_350 },
+    { op:'set_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'sin' },
+    { op:'push', val:@fun_380 },
+    { op:'set_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'sqrt' },
+    { op:'push', val:@fun_391 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'print' },
-    { op:'push', val:@fun_229 },
+    { op:'push', val:@fun_402 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'readFile' },
-    { op:'push', val:@fun_233 },
+    { op:'push', val:@fun_406 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'OpInfo' },
@@ -1843,11 +3154,11 @@ block_0 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_sub' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_236, num_args:2 },
+    { op:'call', ret_to:@block_409, num_args:2 },
   ]
 };
 
-block_237 = {
+block_410 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'opList' },
@@ -1858,17 +3169,17 @@ block_237 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_239, num_args:2 },
+    { op:'call', ret_to:@block_412, num_args:2 },
   ]
 };
 
-block_239 = {
+block_412 = {
   instrs: [
-    { op:'call', ret_to:@block_240, num_args:2 },
+    { op:'call', ret_to:@block_413, num_args:2 },
   ]
 };
 
-block_240 = {
+block_413 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -1876,13 +3187,13 @@ block_240 = {
   ]
 };
 
-fun_238 = {
-  entry:@block_237,
+fun_411 = {
+  entry:@block_410,
   num_params:1,
   num_locals:1,
 };
 
-block_236 = {
+block_409 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:0 },
@@ -1905,7 +3216,7 @@ block_236 = {
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
-    { op:'push', val:@fun_238 },
+    { op:'push', val:@fun_411 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'OP_MEMBER' },
@@ -1932,11 +3243,11 @@ block_236 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_241, num_args:1 },
+    { op:'call', ret_to:@block_414, num_args:1 },
   ]
 };
 
-block_241 = {
+block_414 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -1968,11 +3279,11 @@ block_241 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_242, num_args:1 },
+    { op:'call', ret_to:@block_415, num_args:1 },
   ]
 };
 
-block_242 = {
+block_415 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -2000,11 +3311,11 @@ block_242 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_243, num_args:1 },
+    { op:'call', ret_to:@block_416, num_args:1 },
   ]
 };
 
-block_243 = {
+block_416 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -2036,11 +3347,11 @@ block_243 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_244, num_args:1 },
+    { op:'call', ret_to:@block_417, num_args:1 },
   ]
 };
 
-block_244 = {
+block_417 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -2068,11 +3379,11 @@ block_244 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_245, num_args:1 },
+    { op:'call', ret_to:@block_418, num_args:1 },
   ]
 };
 
-block_245 = {
+block_418 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -2104,11 +3415,11 @@ block_245 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_246, num_args:1 },
+    { op:'call', ret_to:@block_419, num_args:1 },
   ]
 };
 
-block_246 = {
+block_419 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -2140,11 +3451,11 @@ block_246 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_247, num_args:1 },
+    { op:'call', ret_to:@block_420, num_args:1 },
   ]
 };
 
-block_247 = {
+block_420 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -2176,11 +3487,11 @@ block_247 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_248, num_args:1 },
+    { op:'call', ret_to:@block_421, num_args:1 },
   ]
 };
 
-block_248 = {
+block_421 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -2208,11 +3519,11 @@ block_248 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_249, num_args:1 },
+    { op:'call', ret_to:@block_422, num_args:1 },
   ]
 };
 
-block_249 = {
+block_422 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -2240,11 +3551,11 @@ block_249 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_250, num_args:1 },
+    { op:'call', ret_to:@block_423, num_args:1 },
   ]
 };
 
-block_250 = {
+block_423 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -2272,11 +3583,11 @@ block_250 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_251, num_args:1 },
+    { op:'call', ret_to:@block_424, num_args:1 },
   ]
 };
 
-block_251 = {
+block_424 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -2300,11 +3611,11 @@ block_251 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_252, num_args:1 },
+    { op:'call', ret_to:@block_425, num_args:1 },
   ]
 };
 
-block_252 = {
+block_425 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -2328,11 +3639,11 @@ block_252 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_253, num_args:1 },
+    { op:'call', ret_to:@block_426, num_args:1 },
   ]
 };
 
-block_253 = {
+block_426 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -2356,11 +3667,11 @@ block_253 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_254, num_args:1 },
+    { op:'call', ret_to:@block_427, num_args:1 },
   ]
 };
 
-block_254 = {
+block_427 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -2384,11 +3695,11 @@ block_254 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_255, num_args:1 },
+    { op:'call', ret_to:@block_428, num_args:1 },
   ]
 };
 
-block_255 = {
+block_428 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -2412,11 +3723,11 @@ block_255 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_256, num_args:1 },
+    { op:'call', ret_to:@block_429, num_args:1 },
   ]
 };
 
-block_256 = {
+block_429 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -2440,11 +3751,11 @@ block_256 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_257, num_args:1 },
+    { op:'call', ret_to:@block_430, num_args:1 },
   ]
 };
 
-block_257 = {
+block_430 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -2468,11 +3779,11 @@ block_257 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_258, num_args:1 },
+    { op:'call', ret_to:@block_431, num_args:1 },
   ]
 };
 
-block_258 = {
+block_431 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -2500,11 +3811,11 @@ block_258 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_259, num_args:1 },
+    { op:'call', ret_to:@block_432, num_args:1 },
   ]
 };
 
-block_259 = {
+block_432 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -2532,11 +3843,11 @@ block_259 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_260, num_args:1 },
+    { op:'call', ret_to:@block_433, num_args:1 },
   ]
 };
 
-block_260 = {
+block_433 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -2568,53 +3879,53 @@ block_260 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_261, num_args:1 },
+    { op:'call', ret_to:@block_434, num_args:1 },
   ]
 };
 
-block_262 = {
+block_435 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:$false },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_ne' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_264, num_args:2 },
+    { op:'call', ret_to:@block_437, num_args:2 },
   ]
 };
 
-block_265 = {
+block_438 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'srcName' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_266, num_args:2 },
+    { op:'call', ret_to:@block_439, num_args:2 },
   ]
 };
 
-block_266 = {
+block_439 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'output' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_267, num_args:1 },
+    { op:'call', ret_to:@block_440, num_args:1 },
   ]
 };
 
-block_267 = {
+block_440 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'@' },
     { op:'push', val:@global_obj },
     { op:'push', val:'output' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_268, num_args:1 },
+    { op:'call', ret_to:@block_441, num_args:1 },
   ]
 };
 
-block_268 = {
+block_441 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -2622,31 +3933,31 @@ block_268 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_269, num_args:2 },
+    { op:'call', ret_to:@block_442, num_args:2 },
   ]
 };
 
-block_269 = {
+block_442 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'output' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_270, num_args:1 },
+    { op:'call', ret_to:@block_443, num_args:1 },
   ]
 };
 
-block_270 = {
+block_443 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:':' },
     { op:'push', val:@global_obj },
     { op:'push', val:'output' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_271, num_args:1 },
+    { op:'call', ret_to:@block_444, num_args:1 },
   ]
 };
 
-block_271 = {
+block_444 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -2654,113 +3965,113 @@ block_271 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_272, num_args:2 },
+    { op:'call', ret_to:@block_445, num_args:2 },
   ]
 };
 
-block_272 = {
+block_445 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'output' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_273, num_args:1 },
+    { op:'call', ret_to:@block_446, num_args:1 },
   ]
 };
 
-block_273 = {
+block_446 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:' - ' },
     { op:'push', val:@global_obj },
     { op:'push', val:'output' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_274, num_args:1 },
+    { op:'call', ret_to:@block_447, num_args:1 },
   ]
 };
 
-block_264 = {
+block_437 = {
   instrs: [
-    { op:'if_true', then:@block_265, else:@block_275 },
+    { op:'if_true', then:@block_438, else:@block_448 },
   ]
 };
 
-block_274 = {
+block_447 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_276 },
+    { op:'jump', to:@block_449 },
   ]
 };
 
-block_275 = {
+block_448 = {
   instrs: [
-    { op:'jump', to:@block_276 },
+    { op:'jump', to:@block_449 },
   ]
 };
 
-block_276 = {
+block_449 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'print' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_277, num_args:1 },
+    { op:'call', ret_to:@block_450, num_args:1 },
   ]
 };
 
-block_277 = {
+block_450 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$false },
-    { op:'if_true', then:@block_278, else:@block_279 },
+    { op:'if_true', then:@block_451, else:@block_452 },
   ]
 };
 
-block_278 = {
+block_451 = {
   instrs: [
-    { op:'jump', to:@block_280 },
+    { op:'jump', to:@block_453 },
   ]
 };
 
-block_279 = {
+block_452 = {
   instrs: [
     { op:'push', val:'assertion failed' },
     { op:'abort' },
-    { op:'jump', to:@block_280 },
+    { op:'jump', to:@block_453 },
   ]
 };
 
-block_280 = {
+block_453 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-fun_263 = {
-  entry:@block_262,
+fun_436 = {
+  entry:@block_435,
   num_params:2,
   num_locals:2,
 };
 
-block_281 = {
+block_454 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:' ' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_287, num_args:2 },
+    { op:'call', ret_to:@block_460, num_args:2 },
   ]
 };
 
-block_287 = {
+block_460 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_286, else:@block_285 },
+    { op:'if_true', then:@block_459, else:@block_458 },
   ]
 };
 
-block_285 = {
+block_458 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -2768,24 +4079,24 @@ block_285 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_288, num_args:2 },
+    { op:'call', ret_to:@block_461, num_args:2 },
   ]
 };
 
-block_288 = {
+block_461 = {
   instrs: [
-    { op:'jump', to:@block_286 },
+    { op:'jump', to:@block_459 },
   ]
 };
 
-block_286 = {
+block_459 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_284, else:@block_283 },
+    { op:'if_true', then:@block_457, else:@block_456 },
   ]
 };
 
-block_283 = {
+block_456 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -2793,47 +4104,47 @@ block_283 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_289, num_args:2 },
+    { op:'call', ret_to:@block_462, num_args:2 },
   ]
 };
 
-block_289 = {
+block_462 = {
   instrs: [
-    { op:'jump', to:@block_284 },
+    { op:'jump', to:@block_457 },
   ]
 };
 
-block_284 = {
+block_457 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-fun_282 = {
-  entry:@block_281,
+fun_455 = {
+  entry:@block_454,
   num_params:1,
   num_locals:1,
 };
 
-block_290 = {
+block_463 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'0' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_ge' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_294, num_args:2 },
+    { op:'call', ret_to:@block_467, num_args:2 },
   ]
 };
 
-block_294 = {
+block_467 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_292, else:@block_293 },
+    { op:'if_true', then:@block_465, else:@block_466 },
   ]
 };
 
-block_292 = {
+block_465 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -2841,47 +4152,47 @@ block_292 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_le' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_295, num_args:2 },
+    { op:'call', ret_to:@block_468, num_args:2 },
   ]
 };
 
-block_295 = {
+block_468 = {
   instrs: [
-    { op:'jump', to:@block_293 },
+    { op:'jump', to:@block_466 },
   ]
 };
 
-block_293 = {
+block_466 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-fun_291 = {
-  entry:@block_290,
+fun_464 = {
+  entry:@block_463,
   num_params:1,
   num_locals:1,
 };
 
-block_296 = {
+block_469 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'a' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_ge' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_302, num_args:2 },
+    { op:'call', ret_to:@block_475, num_args:2 },
   ]
 };
 
-block_302 = {
+block_475 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_300, else:@block_301 },
+    { op:'if_true', then:@block_473, else:@block_474 },
   ]
 };
 
-block_300 = {
+block_473 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -2889,24 +4200,24 @@ block_300 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_le' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_303, num_args:2 },
+    { op:'call', ret_to:@block_476, num_args:2 },
   ]
 };
 
-block_303 = {
+block_476 = {
   instrs: [
-    { op:'jump', to:@block_301 },
+    { op:'jump', to:@block_474 },
   ]
 };
 
-block_301 = {
+block_474 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_299, else:@block_298 },
+    { op:'if_true', then:@block_472, else:@block_471 },
   ]
 };
 
-block_298 = {
+block_471 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -2914,18 +4225,18 @@ block_298 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_ge' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_306, num_args:2 },
+    { op:'call', ret_to:@block_479, num_args:2 },
   ]
 };
 
-block_306 = {
+block_479 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_304, else:@block_305 },
+    { op:'if_true', then:@block_477, else:@block_478 },
   ]
 };
 
-block_304 = {
+block_477 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -2933,53 +4244,53 @@ block_304 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_le' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_307, num_args:2 },
+    { op:'call', ret_to:@block_480, num_args:2 },
   ]
 };
 
-block_307 = {
+block_480 = {
   instrs: [
-    { op:'jump', to:@block_305 },
+    { op:'jump', to:@block_478 },
   ]
 };
 
-block_305 = {
+block_478 = {
   instrs: [
-    { op:'jump', to:@block_299 },
+    { op:'jump', to:@block_472 },
   ]
 };
 
-block_299 = {
+block_472 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-fun_297 = {
-  entry:@block_296,
+fun_470 = {
+  entry:@block_469,
   num_params:1,
   num_locals:1,
 };
 
-block_308 = {
+block_481 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'a' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_ge' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_316, num_args:2 },
+    { op:'call', ret_to:@block_489, num_args:2 },
   ]
 };
 
-block_316 = {
+block_489 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_314, else:@block_315 },
+    { op:'if_true', then:@block_487, else:@block_488 },
   ]
 };
 
-block_314 = {
+block_487 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -2987,24 +4298,24 @@ block_314 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_le' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_317, num_args:2 },
+    { op:'call', ret_to:@block_490, num_args:2 },
   ]
 };
 
-block_317 = {
+block_490 = {
   instrs: [
-    { op:'jump', to:@block_315 },
+    { op:'jump', to:@block_488 },
   ]
 };
 
-block_315 = {
+block_488 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_313, else:@block_312 },
+    { op:'if_true', then:@block_486, else:@block_485 },
   ]
 };
 
-block_312 = {
+block_485 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -3012,18 +4323,18 @@ block_312 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_ge' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_320, num_args:2 },
+    { op:'call', ret_to:@block_493, num_args:2 },
   ]
 };
 
-block_320 = {
+block_493 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_318, else:@block_319 },
+    { op:'if_true', then:@block_491, else:@block_492 },
   ]
 };
 
-block_318 = {
+block_491 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -3031,30 +4342,30 @@ block_318 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_le' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_321, num_args:2 },
+    { op:'call', ret_to:@block_494, num_args:2 },
   ]
 };
 
-block_321 = {
+block_494 = {
   instrs: [
-    { op:'jump', to:@block_319 },
+    { op:'jump', to:@block_492 },
   ]
 };
 
-block_319 = {
+block_492 = {
   instrs: [
-    { op:'jump', to:@block_313 },
+    { op:'jump', to:@block_486 },
   ]
 };
 
-block_313 = {
+block_486 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_311, else:@block_310 },
+    { op:'if_true', then:@block_484, else:@block_483 },
   ]
 };
 
-block_310 = {
+block_483 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -3062,18 +4373,18 @@ block_310 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_ge' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_324, num_args:2 },
+    { op:'call', ret_to:@block_497, num_args:2 },
   ]
 };
 
-block_324 = {
+block_497 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_322, else:@block_323 },
+    { op:'if_true', then:@block_495, else:@block_496 },
   ]
 };
 
-block_322 = {
+block_495 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -3081,35 +4392,35 @@ block_322 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_le' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_325, num_args:2 },
+    { op:'call', ret_to:@block_498, num_args:2 },
   ]
 };
 
-block_325 = {
+block_498 = {
   instrs: [
-    { op:'jump', to:@block_323 },
+    { op:'jump', to:@block_496 },
   ]
 };
 
-block_323 = {
+block_496 = {
   instrs: [
-    { op:'jump', to:@block_311 },
+    { op:'jump', to:@block_484 },
   ]
 };
 
-block_311 = {
+block_484 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-fun_309 = {
-  entry:@block_308,
+fun_482 = {
+  entry:@block_481,
   num_params:1,
   num_locals:1,
 };
 
-block_326 = {
+block_499 = {
   instrs: [
     { op:'push', val:3 },
     { op:'new_object' },
@@ -3120,11 +4431,11 @@ block_326 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_328, num_args:2 },
+    { op:'call', ret_to:@block_501, num_args:2 },
   ]
 };
 
-block_328 = {
+block_501 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:0 },
@@ -3134,11 +4445,11 @@ block_328 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_329, num_args:2 },
+    { op:'call', ret_to:@block_502, num_args:2 },
   ]
 };
 
-block_329 = {
+block_502 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:0 },
@@ -3148,1445 +4459,19 @@ block_329 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_330, num_args:2 },
-  ]
-};
-
-block_330 = {
-  instrs: [
-    { op:'set_field' },
-    { op:'ret' },
-  ]
-};
-
-fun_327 = {
-  entry:@block_326,
-  num_params:1,
-  num_locals:1,
-};
-
-block_331 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'strIdx' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_333, num_args:2 },
-  ]
-};
-
-block_333 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'srcString' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_334, num_args:2 },
-  ]
-};
-
-block_334 = {
-  instrs: [
-    { op:'push', val:'length' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_335, num_args:2 },
-  ]
-};
-
-block_335 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_ge' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_336, num_args:2 },
-  ]
-};
-
-block_337 = {
-  instrs: [
-    { op:'push', val:'\x00' },
-    { op:'ret' },
-  ]
-};
-
-block_336 = {
-  instrs: [
-    { op:'if_true', then:@block_337, else:@block_338 },
-  ]
-};
-
-block_338 = {
-  instrs: [
-    { op:'jump', to:@block_339 },
-  ]
-};
-
-block_339 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'srcString' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_340, num_args:2 },
-  ]
-};
-
-block_340 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'strIdx' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_341, num_args:2 },
-  ]
-};
-
-block_341 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getElem' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_342, num_args:2 },
-  ]
-};
-
-block_342 = {
-  instrs: [
-    { op:'ret' },
-  ]
-};
-
-fun_332 = {
-  entry:@block_331,
-  num_params:1,
-  num_locals:1,
-};
-
-block_343 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'dup', idx:0 },
-    { op:'push', val:'peekCh' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_345, num_args:2 },
-  ]
-};
-
-block_345 = {
-  instrs: [
-    { op:'call', ret_to:@block_346, num_args:1 },
-  ]
-};
-
-block_346 = {
-  instrs: [
-    { op:'set_local', idx:1 },
-    { op:'get_local', idx:0 },
-    { op:'dup', idx:0 },
-    { op:'push', val:'eof' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_347, num_args:2 },
-  ]
-};
-
-block_347 = {
-  instrs: [
-    { op:'call', ret_to:@block_348, num_args:1 },
-  ]
-};
-
-block_348 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_not' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_349, num_args:1 },
-  ]
-};
-
-block_349 = {
-  instrs: [
-    { op:'if_true', then:@block_350, else:@block_351 },
-  ]
-};
-
-block_350 = {
-  instrs: [
-    { op:'jump', to:@block_352 },
-  ]
-};
-
-block_351 = {
-  instrs: [
-    { op:'push', val:'tried to read past end of input' },
-    { op:'abort' },
-    { op:'jump', to:@block_352 },
-  ]
-};
-
-block_352 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'\x1F' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_le' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_357, num_args:2 },
-  ]
-};
-
-block_357 = {
-  instrs: [
-    { op:'dup', idx:0 },
-    { op:'if_true', then:@block_356, else:@block_355 },
-  ]
-};
-
-block_355 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'\x7F' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_ge' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_358, num_args:2 },
-  ]
-};
-
-block_358 = {
-  instrs: [
-    { op:'jump', to:@block_356 },
-  ]
-};
-
-block_356 = {
-  instrs: [
-    { op:'dup', idx:0 },
-    { op:'if_true', then:@block_353, else:@block_354 },
-  ]
-};
-
-block_353 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'\x0A' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_ne' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_363, num_args:2 },
-  ]
-};
-
-block_363 = {
-  instrs: [
-    { op:'dup', idx:0 },
-    { op:'if_true', then:@block_361, else:@block_362 },
-  ]
-};
-
-block_361 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'\x09' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_ne' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_364, num_args:2 },
-  ]
-};
-
-block_364 = {
-  instrs: [
-    { op:'jump', to:@block_362 },
-  ]
-};
-
-block_362 = {
-  instrs: [
-    { op:'dup', idx:0 },
-    { op:'if_true', then:@block_359, else:@block_360 },
-  ]
-};
-
-block_359 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'\x0D' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_ne' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_365, num_args:2 },
-  ]
-};
-
-block_365 = {
-  instrs: [
-    { op:'jump', to:@block_360 },
-  ]
-};
-
-block_360 = {
-  instrs: [
-    { op:'jump', to:@block_354 },
-  ]
-};
-
-block_366 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'invalid character in input' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'parseError' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_367, num_args:2 },
-  ]
-};
-
-block_354 = {
-  instrs: [
-    { op:'if_true', then:@block_366, else:@block_368 },
-  ]
-};
-
-block_367 = {
-  instrs: [
-    { op:'pop' },
-    { op:'jump', to:@block_369 },
-  ]
-};
-
-block_368 = {
-  instrs: [
-    { op:'jump', to:@block_369 },
-  ]
-};
-
-block_369 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'strIdx' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_370, num_args:2 },
-  ]
-};
-
-block_370 = {
-  instrs: [
-    { op:'push', val:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_add' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_371, num_args:2 },
-  ]
-};
-
-block_371 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'strIdx' },
-    { op:'dup', idx:2 },
-    { op:'set_field' },
-    { op:'pop' },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'\x0A' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_372, num_args:2 },
-  ]
-};
-
-block_373 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'lineNo' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_374, num_args:2 },
-  ]
-};
-
-block_374 = {
-  instrs: [
-    { op:'push', val:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_add' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_375, num_args:2 },
-  ]
-};
-
-block_376 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'colNo' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_377, num_args:2 },
-  ]
-};
-
-block_377 = {
-  instrs: [
-    { op:'push', val:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_add' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_378, num_args:2 },
-  ]
-};
-
-block_372 = {
-  instrs: [
-    { op:'if_true', then:@block_373, else:@block_376 },
-  ]
-};
-
-block_375 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'lineNo' },
-    { op:'dup', idx:2 },
-    { op:'set_field' },
-    { op:'pop' },
-    { op:'push', val:1 },
-    { op:'get_local', idx:0 },
-    { op:'push', val:'colNo' },
-    { op:'dup', idx:2 },
-    { op:'set_field' },
-    { op:'pop' },
-    { op:'jump', to:@block_379 },
-  ]
-};
-
-block_378 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'colNo' },
-    { op:'dup', idx:2 },
-    { op:'set_field' },
-    { op:'pop' },
-    { op:'jump', to:@block_379 },
-  ]
-};
-
-block_379 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'ret' },
-  ]
-};
-
-fun_344 = {
-  entry:@block_343,
-  num_params:1,
-  num_locals:2,
-};
-
-block_380 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'dup', idx:0 },
-    { op:'push', val:'peekCh' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_382, num_args:2 },
-  ]
-};
-
-block_382 = {
-  instrs: [
-    { op:'call', ret_to:@block_383, num_args:1 },
-  ]
-};
-
-block_383 = {
-  instrs: [
-    { op:'push', val:'\x00' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_384, num_args:2 },
-  ]
-};
-
-block_384 = {
-  instrs: [
-    { op:'ret' },
-  ]
-};
-
-fun_381 = {
-  entry:@block_380,
-  num_params:1,
-  num_locals:1,
-};
-
-block_385 = {
-  instrs: [
-    { op:'push', val:0 },
-    { op:'set_local', idx:2 },
-    { op:'push', val:$true },
-    { op:'pop' },
-    { op:'jump', to:@block_387 },
-  ]
-};
-
-block_387 = {
-  instrs: [
-    { op:'get_local', idx:2 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'length' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_391, num_args:2 },
-  ]
-};
-
-block_391 = {
-  instrs: [
-    { op:'lt_i32' },
-    { op:'if_true', then:@block_388, else:@block_390 },
-  ]
-};
-
-block_388 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'strIdx' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_392, num_args:2 },
-  ]
-};
-
-block_392 = {
-  instrs: [
-    { op:'get_local', idx:2 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_add' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_393, num_args:2 },
-  ]
-};
-
-block_393 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'srcString' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_394, num_args:2 },
-  ]
-};
-
-block_394 = {
-  instrs: [
-    { op:'push', val:'length' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_395, num_args:2 },
-  ]
-};
-
-block_395 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_ge' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_396, num_args:2 },
-  ]
-};
-
-block_397 = {
-  instrs: [
-    { op:'push', val:$false },
-    { op:'ret' },
-  ]
-};
-
-block_396 = {
-  instrs: [
-    { op:'if_true', then:@block_397, else:@block_398 },
-  ]
-};
-
-block_398 = {
-  instrs: [
-    { op:'jump', to:@block_399 },
-  ]
-};
-
-block_399 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'get_local', idx:2 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getElem' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_400, num_args:2 },
-  ]
-};
-
-block_400 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'srcString' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_401, num_args:2 },
-  ]
-};
-
-block_401 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'strIdx' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_402, num_args:2 },
-  ]
-};
-
-block_402 = {
-  instrs: [
-    { op:'get_local', idx:2 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_add' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_403, num_args:2 },
-  ]
-};
-
-block_403 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getElem' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_404, num_args:2 },
-  ]
-};
-
-block_404 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_ne' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_405, num_args:2 },
-  ]
-};
-
-block_406 = {
-  instrs: [
-    { op:'push', val:$false },
-    { op:'ret' },
-  ]
-};
-
-block_405 = {
-  instrs: [
-    { op:'if_true', then:@block_406, else:@block_407 },
-  ]
-};
-
-block_407 = {
-  instrs: [
-    { op:'jump', to:@block_408 },
-  ]
-};
-
-block_408 = {
-  instrs: [
-    { op:'jump', to:@block_389 },
-  ]
-};
-
-block_389 = {
-  instrs: [
-    { op:'get_local', idx:2 },
-    { op:'push', val:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_add' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_409, num_args:2 },
-  ]
-};
-
-block_409 = {
-  instrs: [
-    { op:'dup', idx:0 },
-    { op:'set_local', idx:2 },
-    { op:'pop' },
-    { op:'jump', to:@block_387 },
-  ]
-};
-
-block_390 = {
-  instrs: [
-    { op:'push', val:$true },
-    { op:'ret' },
-  ]
-};
-
-fun_386 = {
-  entry:@block_385,
-  num_params:2,
-  num_locals:3,
-};
-
-block_410 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'length' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_412, num_args:2 },
-  ]
-};
-
-block_412 = {
-  instrs: [
-    { op:'push', val:0 },
-    { op:'gt_i32' },
-    { op:'if_true', then:@block_413, else:@block_414 },
-  ]
-};
-
-block_413 = {
-  instrs: [
-    { op:'jump', to:@block_415 },
-  ]
-};
-
-block_414 = {
-  instrs: [
-    { op:'push', val:'assertion failed' },
-    { op:'abort' },
-    { op:'jump', to:@block_415 },
-  ]
-};
-
-block_415 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'dup', idx:1 },
-    { op:'push', val:'next' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_416, num_args:2 },
-  ]
-};
-
-block_416 = {
-  instrs: [
-    { op:'call', ret_to:@block_417, num_args:2 },
-  ]
-};
-
-block_418 = {
-  instrs: [
-    { op:'push', val:0 },
-    { op:'set_local', idx:2 },
-    { op:'jump', to:@block_419 },
-  ]
-};
-
-block_419 = {
-  instrs: [
-    { op:'get_local', idx:2 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'length' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_423, num_args:2 },
-  ]
-};
-
-block_423 = {
-  instrs: [
-    { op:'lt_i32' },
-    { op:'if_true', then:@block_420, else:@block_422 },
-  ]
-};
-
-block_420 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'dup', idx:0 },
-    { op:'push', val:'readCh' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_424, num_args:2 },
-  ]
-};
-
-block_424 = {
-  instrs: [
-    { op:'call', ret_to:@block_425, num_args:1 },
-  ]
-};
-
-block_425 = {
-  instrs: [
-    { op:'pop' },
-    { op:'jump', to:@block_421 },
-  ]
-};
-
-block_421 = {
-  instrs: [
-    { op:'get_local', idx:2 },
-    { op:'push', val:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_add' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_426, num_args:2 },
-  ]
-};
-
-block_426 = {
-  instrs: [
-    { op:'dup', idx:0 },
-    { op:'set_local', idx:2 },
-    { op:'pop' },
-    { op:'jump', to:@block_419 },
-  ]
-};
-
-block_422 = {
-  instrs: [
-    { op:'push', val:$true },
-    { op:'ret' },
-  ]
-};
-
-block_417 = {
-  instrs: [
-    { op:'if_true', then:@block_418, else:@block_427 },
-  ]
-};
-
-block_427 = {
-  instrs: [
-    { op:'jump', to:@block_428 },
-  ]
-};
-
-block_428 = {
-  instrs: [
-    { op:'push', val:$false },
-    { op:'ret' },
-  ]
-};
-
-fun_411 = {
-  entry:@block_410,
-  num_params:2,
-  num_locals:3,
-};
-
-block_429 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'dup', idx:1 },
-    { op:'push', val:'match' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_431, num_args:2 },
-  ]
-};
-
-block_431 = {
-  instrs: [
-    { op:'call', ret_to:@block_432, num_args:2 },
-  ]
-};
-
-block_432 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_not' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_433, num_args:1 },
-  ]
-};
-
-block_434 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'expected to find \'' },
-    { op:'get_local', idx:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_add' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_435, num_args:2 },
-  ]
-};
-
-block_435 = {
-  instrs: [
-    { op:'push', val:'\'' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_add' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_436, num_args:2 },
-  ]
-};
-
-block_436 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'parseError' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_437, num_args:2 },
-  ]
-};
-
-block_433 = {
-  instrs: [
-    { op:'if_true', then:@block_434, else:@block_438 },
-  ]
-};
-
-block_437 = {
-  instrs: [
-    { op:'pop' },
-    { op:'jump', to:@block_439 },
-  ]
-};
-
-block_438 = {
-  instrs: [
-    { op:'jump', to:@block_439 },
-  ]
-};
-
-block_439 = {
-  instrs: [
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-fun_430 = {
-  entry:@block_429,
-  num_params:2,
-  num_locals:2,
-};
-
-block_440 = {
-  instrs: [
-    { op:'push', val:$true },
-    { op:'pop' },
-    { op:'jump', to:@block_442 },
-  ]
-};
-
-block_442 = {
-  instrs: [
-    { op:'push', val:$true },
-    { op:'if_true', then:@block_443, else:@block_445 },
-  ]
-};
-
-block_443 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'dup', idx:0 },
-    { op:'push', val:'eof' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_446, num_args:2 },
-  ]
-};
-
-block_446 = {
-  instrs: [
-    { op:'call', ret_to:@block_447, num_args:1 },
-  ]
-};
-
-block_448 = {
-  instrs: [
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_447 = {
-  instrs: [
-    { op:'if_true', then:@block_448, else:@block_449 },
-  ]
-};
-
-block_449 = {
-  instrs: [
-    { op:'jump', to:@block_450 },
-  ]
-};
-
-block_450 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'dup', idx:0 },
-    { op:'push', val:'peekCh' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_451, num_args:2 },
-  ]
-};
-
-block_451 = {
-  instrs: [
-    { op:'call', ret_to:@block_452, num_args:1 },
-  ]
-};
-
-block_452 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'isSpace' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_453, num_args:1 },
-  ]
-};
-
-block_454 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'dup', idx:0 },
-    { op:'push', val:'readCh' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_455, num_args:2 },
-  ]
-};
-
-block_455 = {
-  instrs: [
-    { op:'call', ret_to:@block_456, num_args:1 },
-  ]
-};
-
-block_456 = {
-  instrs: [
-    { op:'pop' },
-    { op:'jump', to:@block_444 },
-  ]
-};
-
-block_453 = {
-  instrs: [
-    { op:'if_true', then:@block_454, else:@block_457 },
-  ]
-};
-
-block_457 = {
-  instrs: [
-    { op:'jump', to:@block_458 },
-  ]
-};
-
-block_458 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'//' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'match' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_459, num_args:2 },
-  ]
-};
-
-block_459 = {
-  instrs: [
-    { op:'call', ret_to:@block_460, num_args:2 },
-  ]
-};
-
-block_461 = {
-  instrs: [
-    { op:'push', val:$true },
-    { op:'pop' },
-    { op:'jump', to:@block_462 },
-  ]
-};
-
-block_462 = {
-  instrs: [
-    { op:'push', val:$true },
-    { op:'if_true', then:@block_463, else:@block_465 },
-  ]
-};
-
-block_463 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'dup', idx:0 },
-    { op:'push', val:'eof' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_466, num_args:2 },
-  ]
-};
-
-block_466 = {
-  instrs: [
-    { op:'call', ret_to:@block_467, num_args:1 },
-  ]
-};
-
-block_468 = {
-  instrs: [
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_467 = {
-  instrs: [
-    { op:'if_true', then:@block_468, else:@block_469 },
-  ]
-};
-
-block_469 = {
-  instrs: [
-    { op:'jump', to:@block_470 },
-  ]
-};
-
-block_470 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'dup', idx:0 },
-    { op:'push', val:'readCh' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_471, num_args:2 },
-  ]
-};
-
-block_471 = {
-  instrs: [
-    { op:'call', ret_to:@block_472, num_args:1 },
-  ]
-};
-
-block_472 = {
-  instrs: [
-    { op:'push', val:'\x0A' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_473, num_args:2 },
-  ]
-};
-
-block_474 = {
-  instrs: [
-    { op:'jump', to:@block_465 },
-  ]
-};
-
-block_473 = {
-  instrs: [
-    { op:'if_true', then:@block_474, else:@block_475 },
-  ]
-};
-
-block_475 = {
-  instrs: [
-    { op:'jump', to:@block_476 },
-  ]
-};
-
-block_476 = {
-  instrs: [
-    { op:'jump', to:@block_464 },
-  ]
-};
-
-block_464 = {
-  instrs: [
-    { op:'push', val:$true },
-    { op:'pop' },
-    { op:'jump', to:@block_462 },
-  ]
-};
-
-block_465 = {
-  instrs: [
-    { op:'jump', to:@block_444 },
-  ]
-};
-
-block_460 = {
-  instrs: [
-    { op:'if_true', then:@block_461, else:@block_477 },
-  ]
-};
-
-block_477 = {
-  instrs: [
-    { op:'jump', to:@block_478 },
-  ]
-};
-
-block_478 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'/*' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'match' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_479, num_args:2 },
-  ]
-};
-
-block_479 = {
-  instrs: [
-    { op:'call', ret_to:@block_480, num_args:2 },
-  ]
-};
-
-block_481 = {
-  instrs: [
-    { op:'push', val:$true },
-    { op:'pop' },
-    { op:'jump', to:@block_482 },
-  ]
-};
-
-block_482 = {
-  instrs: [
-    { op:'push', val:$true },
-    { op:'if_true', then:@block_483, else:@block_485 },
-  ]
-};
-
-block_483 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'dup', idx:0 },
-    { op:'push', val:'eof' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_486, num_args:2 },
-  ]
-};
-
-block_486 = {
-  instrs: [
-    { op:'call', ret_to:@block_487, num_args:1 },
-  ]
-};
-
-block_488 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'end of input in multiline comment' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'parseError' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_489, num_args:2 },
-  ]
-};
-
-block_487 = {
-  instrs: [
-    { op:'if_true', then:@block_488, else:@block_490 },
-  ]
-};
-
-block_489 = {
-  instrs: [
-    { op:'pop' },
-    { op:'jump', to:@block_491 },
-  ]
-};
-
-block_490 = {
-  instrs: [
-    { op:'jump', to:@block_491 },
-  ]
-};
-
-block_491 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'dup', idx:0 },
-    { op:'push', val:'readCh' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_494, num_args:2 },
-  ]
-};
-
-block_494 = {
-  instrs: [
-    { op:'call', ret_to:@block_495, num_args:1 },
-  ]
-};
-
-block_495 = {
-  instrs: [
-    { op:'push', val:'*' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_496, num_args:2 },
-  ]
-};
-
-block_496 = {
-  instrs: [
-    { op:'dup', idx:0 },
-    { op:'if_true', then:@block_492, else:@block_493 },
-  ]
-};
-
-block_492 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:'/' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'match' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_497, num_args:2 },
-  ]
-};
-
-block_497 = {
-  instrs: [
-    { op:'call', ret_to:@block_498, num_args:2 },
-  ]
-};
-
-block_498 = {
-  instrs: [
-    { op:'jump', to:@block_493 },
-  ]
-};
-
-block_499 = {
-  instrs: [
-    { op:'jump', to:@block_485 },
-  ]
-};
-
-block_493 = {
-  instrs: [
-    { op:'if_true', then:@block_499, else:@block_500 },
-  ]
-};
-
-block_500 = {
-  instrs: [
-    { op:'jump', to:@block_501 },
-  ]
-};
-
-block_501 = {
-  instrs: [
-    { op:'jump', to:@block_484 },
-  ]
-};
-
-block_484 = {
-  instrs: [
-    { op:'push', val:$true },
-    { op:'pop' },
-    { op:'jump', to:@block_482 },
-  ]
-};
-
-block_485 = {
-  instrs: [
-    { op:'jump', to:@block_444 },
-  ]
-};
-
-block_480 = {
-  instrs: [
-    { op:'if_true', then:@block_481, else:@block_502 },
-  ]
-};
-
-block_502 = {
-  instrs: [
-    { op:'jump', to:@block_503 },
+    { op:'call', ret_to:@block_503, num_args:2 },
   ]
 };
 
 block_503 = {
   instrs: [
-    { op:'jump', to:@block_445 },
-  ]
-};
-
-block_444 = {
-  instrs: [
-    { op:'push', val:$true },
-    { op:'pop' },
-    { op:'jump', to:@block_442 },
-  ]
-};
-
-block_445 = {
-  instrs: [
-    { op:'push', val:$undef },
+    { op:'set_field' },
     { op:'ret' },
   ]
 };
 
-fun_441 = {
-  entry:@block_440,
+fun_500 = {
+  entry:@block_499,
   num_params:1,
   num_locals:1,
 };
@@ -4594,8 +4479,7 @@ fun_441 = {
 block_504 = {
   instrs: [
     { op:'get_local', idx:0 },
-    { op:'dup', idx:0 },
-    { op:'push', val:'eatWS' },
+    { op:'push', val:'strIdx' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -4605,17 +4489,18 @@ block_504 = {
 
 block_506 = {
   instrs: [
-    { op:'call', ret_to:@block_507, num_args:1 },
+    { op:'get_local', idx:0 },
+    { op:'push', val:'srcString' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_507, num_args:2 },
   ]
 };
 
 block_507 = {
   instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'dup', idx:1 },
-    { op:'push', val:'next' },
+    { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -4625,47 +4510,47 @@ block_507 = {
 
 block_508 = {
   instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_ge' },
+    { op:'get_field' },
     { op:'call', ret_to:@block_509, num_args:2 },
+  ]
+};
+
+block_510 = {
+  instrs: [
+    { op:'push', val:'\x00' },
+    { op:'ret' },
   ]
 };
 
 block_509 = {
   instrs: [
-    { op:'ret' },
+    { op:'if_true', then:@block_510, else:@block_511 },
   ]
 };
 
-fun_505 = {
-  entry:@block_504,
-  num_params:2,
-  num_locals:2,
-};
-
-block_510 = {
+block_511 = {
   instrs: [
-    { op:'get_local', idx:0 },
-    { op:'dup', idx:0 },
-    { op:'push', val:'eatWS' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_512, num_args:2 },
+    { op:'jump', to:@block_512 },
   ]
 };
 
 block_512 = {
   instrs: [
-    { op:'call', ret_to:@block_513, num_args:1 },
+    { op:'get_local', idx:0 },
+    { op:'push', val:'srcString' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_513, num_args:2 },
   ]
 };
 
 block_513 = {
   instrs: [
-    { op:'pop' },
     { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'dup', idx:1 },
-    { op:'push', val:'match' },
+    { op:'push', val:'strIdx' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -4675,6 +4560,9 @@ block_513 = {
 
 block_514 = {
   instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getElem' },
+    { op:'get_field' },
     { op:'call', ret_to:@block_515, num_args:2 },
   ]
 };
@@ -4685,17 +4573,17 @@ block_515 = {
   ]
 };
 
-fun_511 = {
-  entry:@block_510,
-  num_params:2,
-  num_locals:2,
+fun_505 = {
+  entry:@block_504,
+  num_params:1,
+  num_locals:1,
 };
 
 block_516 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'dup', idx:0 },
-    { op:'push', val:'eatWS' },
+    { op:'push', val:'peekCh' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -4711,11 +4599,10 @@ block_518 = {
 
 block_519 = {
   instrs: [
-    { op:'pop' },
+    { op:'set_local', idx:1 },
     { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'dup', idx:1 },
-    { op:'push', val:'expect' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'eof' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -4725,115 +4612,89 @@ block_519 = {
 
 block_520 = {
   instrs: [
-    { op:'call', ret_to:@block_521, num_args:2 },
+    { op:'call', ret_to:@block_521, num_args:1 },
   ]
 };
 
 block_521 = {
   instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_not' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_522, num_args:1 },
   ]
-};
-
-fun_517 = {
-  entry:@block_516,
-  num_params:2,
-  num_locals:2,
 };
 
 block_522 = {
   instrs: [
-    { op:'push', val:0 },
-    { op:'set_local', idx:2 },
-    { op:'push', val:$true },
-    { op:'pop' },
-    { op:'jump', to:@block_524 },
+    { op:'if_true', then:@block_523, else:@block_524 },
+  ]
+};
+
+block_523 = {
+  instrs: [
+    { op:'jump', to:@block_525 },
   ]
 };
 
 block_524 = {
   instrs: [
-    { op:'push', val:$true },
-    { op:'if_true', then:@block_525, else:@block_527 },
+    { op:'push', val:'tried to read past end of input' },
+    { op:'abort' },
+    { op:'jump', to:@block_525 },
   ]
 };
 
 block_525 = {
   instrs: [
-    { op:'get_local', idx:0 },
-    { op:'dup', idx:0 },
-    { op:'push', val:'readCh' },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'\x1F' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'rt_le' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_528, num_args:2 },
-  ]
-};
-
-block_528 = {
-  instrs: [
-    { op:'call', ret_to:@block_529, num_args:1 },
-  ]
-};
-
-block_529 = {
-  instrs: [
-    { op:'set_local', idx:3 },
-    { op:'get_local', idx:3 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'isDigit' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_530, num_args:1 },
+    { op:'call', ret_to:@block_530, num_args:2 },
   ]
 };
 
 block_530 = {
   instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_not' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_531, num_args:1 },
+    { op:'dup', idx:0 },
+    { op:'if_true', then:@block_529, else:@block_528 },
   ]
 };
 
-block_532 = {
+block_528 = {
   instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'expected digit' },
+    { op:'pop' },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'\x7F' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'parseError' },
+    { op:'push', val:'rt_ge' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_533, num_args:2 },
+    { op:'call', ret_to:@block_531, num_args:2 },
   ]
 };
 
 block_531 = {
   instrs: [
-    { op:'if_true', then:@block_532, else:@block_534 },
+    { op:'jump', to:@block_529 },
   ]
 };
 
-block_533 = {
+block_529 = {
+  instrs: [
+    { op:'dup', idx:0 },
+    { op:'if_true', then:@block_526, else:@block_527 },
+  ]
+};
+
+block_526 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_535 },
-  ]
-};
-
-block_534 = {
-  instrs: [
-    { op:'jump', to:@block_535 },
-  ]
-};
-
-block_535 = {
-  instrs: [
-    { op:'push', val:0 },
-    { op:'push', val:1 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'\x0A' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_sub' },
+    { op:'push', val:'rt_ne' },
     { op:'get_field' },
     { op:'call', ret_to:@block_536, num_args:2 },
   ]
@@ -4841,89 +4702,133 @@ block_535 = {
 
 block_536 = {
   instrs: [
-    { op:'set_local', idx:4 },
-    { op:'push', val:'0123456789' },
-    { op:'set_local', idx:5 },
-    { op:'push', val:0 },
-    { op:'set_local', idx:6 },
-    { op:'jump', to:@block_537 },
+    { op:'dup', idx:0 },
+    { op:'if_true', then:@block_534, else:@block_535 },
+  ]
+};
+
+block_534 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'\x09' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_ne' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_537, num_args:2 },
   ]
 };
 
 block_537 = {
   instrs: [
-    { op:'get_local', idx:6 },
-    { op:'get_local', idx:5 },
-    { op:'push', val:'length' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_541, num_args:2 },
+    { op:'jump', to:@block_535 },
   ]
 };
 
-block_541 = {
+block_535 = {
   instrs: [
-    { op:'lt_i32' },
-    { op:'if_true', then:@block_538, else:@block_540 },
+    { op:'dup', idx:0 },
+    { op:'if_true', then:@block_532, else:@block_533 },
+  ]
+};
+
+block_532 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'\x0D' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_ne' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_538, num_args:2 },
   ]
 };
 
 block_538 = {
   instrs: [
-    { op:'get_local', idx:3 },
-    { op:'get_local', idx:5 },
-    { op:'get_local', idx:6 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getElem' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_542, num_args:2 },
+    { op:'jump', to:@block_533 },
   ]
 };
 
-block_542 = {
+block_533 = {
   instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_543, num_args:2 },
-  ]
-};
-
-block_544 = {
-  instrs: [
-    { op:'get_local', idx:6 },
-    { op:'dup', idx:0 },
-    { op:'set_local', idx:4 },
-    { op:'pop' },
-    { op:'jump', to:@block_540 },
-  ]
-};
-
-block_543 = {
-  instrs: [
-    { op:'if_true', then:@block_544, else:@block_545 },
-  ]
-};
-
-block_545 = {
-  instrs: [
-    { op:'jump', to:@block_546 },
-  ]
-};
-
-block_546 = {
-  instrs: [
-    { op:'jump', to:@block_539 },
+    { op:'jump', to:@block_527 },
   ]
 };
 
 block_539 = {
   instrs: [
-    { op:'get_local', idx:6 },
+    { op:'get_local', idx:0 },
+    { op:'push', val:'invalid character in input' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'parseError' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_540, num_args:2 },
+  ]
+};
+
+block_527 = {
+  instrs: [
+    { op:'if_true', then:@block_539, else:@block_541 },
+  ]
+};
+
+block_540 = {
+  instrs: [
+    { op:'pop' },
+    { op:'jump', to:@block_542 },
+  ]
+};
+
+block_541 = {
+  instrs: [
+    { op:'jump', to:@block_542 },
+  ]
+};
+
+block_542 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:'strIdx' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_543, num_args:2 },
+  ]
+};
+
+block_543 = {
+  instrs: [
     { op:'push', val:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_add' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_544, num_args:2 },
+  ]
+};
+
+block_544 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:'strIdx' },
+    { op:'dup', idx:2 },
+    { op:'set_field' },
+    { op:'pop' },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'\x0A' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_545, num_args:2 },
+  ]
+};
+
+block_546 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:'lineNo' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
     { op:'get_field' },
     { op:'call', ret_to:@block_547, num_args:2 },
   ]
@@ -4931,14 +4836,1452 @@ block_539 = {
 
 block_547 = {
   instrs: [
-    { op:'dup', idx:0 },
-    { op:'set_local', idx:6 },
-    { op:'pop' },
-    { op:'jump', to:@block_537 },
+    { op:'push', val:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_add' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_548, num_args:2 },
   ]
 };
 
-block_540 = {
+block_549 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:'colNo' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_550, num_args:2 },
+  ]
+};
+
+block_550 = {
+  instrs: [
+    { op:'push', val:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_add' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_551, num_args:2 },
+  ]
+};
+
+block_545 = {
+  instrs: [
+    { op:'if_true', then:@block_546, else:@block_549 },
+  ]
+};
+
+block_548 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:'lineNo' },
+    { op:'dup', idx:2 },
+    { op:'set_field' },
+    { op:'pop' },
+    { op:'push', val:1 },
+    { op:'get_local', idx:0 },
+    { op:'push', val:'colNo' },
+    { op:'dup', idx:2 },
+    { op:'set_field' },
+    { op:'pop' },
+    { op:'jump', to:@block_552 },
+  ]
+};
+
+block_551 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:'colNo' },
+    { op:'dup', idx:2 },
+    { op:'set_field' },
+    { op:'pop' },
+    { op:'jump', to:@block_552 },
+  ]
+};
+
+block_552 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'ret' },
+  ]
+};
+
+fun_517 = {
+  entry:@block_516,
+  num_params:1,
+  num_locals:2,
+};
+
+block_553 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'dup', idx:0 },
+    { op:'push', val:'peekCh' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_555, num_args:2 },
+  ]
+};
+
+block_555 = {
+  instrs: [
+    { op:'call', ret_to:@block_556, num_args:1 },
+  ]
+};
+
+block_556 = {
+  instrs: [
+    { op:'push', val:'\x00' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_557, num_args:2 },
+  ]
+};
+
+block_557 = {
+  instrs: [
+    { op:'ret' },
+  ]
+};
+
+fun_554 = {
+  entry:@block_553,
+  num_params:1,
+  num_locals:1,
+};
+
+block_558 = {
+  instrs: [
+    { op:'push', val:0 },
+    { op:'set_local', idx:2 },
+    { op:'push', val:$true },
+    { op:'pop' },
+    { op:'jump', to:@block_560 },
+  ]
+};
+
+block_560 = {
+  instrs: [
+    { op:'get_local', idx:2 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'length' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_564, num_args:2 },
+  ]
+};
+
+block_564 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_lt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_565, num_args:2 },
+  ]
+};
+
+block_565 = {
+  instrs: [
+    { op:'if_true', then:@block_561, else:@block_563 },
+  ]
+};
+
+block_561 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:'strIdx' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_566, num_args:2 },
+  ]
+};
+
+block_566 = {
+  instrs: [
+    { op:'get_local', idx:2 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_add' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_567, num_args:2 },
+  ]
+};
+
+block_567 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:'srcString' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_568, num_args:2 },
+  ]
+};
+
+block_568 = {
+  instrs: [
+    { op:'push', val:'length' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_569, num_args:2 },
+  ]
+};
+
+block_569 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_ge' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_570, num_args:2 },
+  ]
+};
+
+block_571 = {
+  instrs: [
+    { op:'push', val:$false },
+    { op:'ret' },
+  ]
+};
+
+block_570 = {
+  instrs: [
+    { op:'if_true', then:@block_571, else:@block_572 },
+  ]
+};
+
+block_572 = {
+  instrs: [
+    { op:'jump', to:@block_573 },
+  ]
+};
+
+block_573 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'get_local', idx:2 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getElem' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_574, num_args:2 },
+  ]
+};
+
+block_574 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:'srcString' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_575, num_args:2 },
+  ]
+};
+
+block_575 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:'strIdx' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_576, num_args:2 },
+  ]
+};
+
+block_576 = {
+  instrs: [
+    { op:'get_local', idx:2 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_add' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_577, num_args:2 },
+  ]
+};
+
+block_577 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getElem' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_578, num_args:2 },
+  ]
+};
+
+block_578 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_ne' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_579, num_args:2 },
+  ]
+};
+
+block_580 = {
+  instrs: [
+    { op:'push', val:$false },
+    { op:'ret' },
+  ]
+};
+
+block_579 = {
+  instrs: [
+    { op:'if_true', then:@block_580, else:@block_581 },
+  ]
+};
+
+block_581 = {
+  instrs: [
+    { op:'jump', to:@block_582 },
+  ]
+};
+
+block_582 = {
+  instrs: [
+    { op:'jump', to:@block_562 },
+  ]
+};
+
+block_562 = {
+  instrs: [
+    { op:'get_local', idx:2 },
+    { op:'push', val:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_add' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_583, num_args:2 },
+  ]
+};
+
+block_583 = {
+  instrs: [
+    { op:'dup', idx:0 },
+    { op:'set_local', idx:2 },
+    { op:'pop' },
+    { op:'jump', to:@block_560 },
+  ]
+};
+
+block_563 = {
+  instrs: [
+    { op:'push', val:$true },
+    { op:'ret' },
+  ]
+};
+
+fun_559 = {
+  entry:@block_558,
+  num_params:2,
+  num_locals:3,
+};
+
+block_584 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'length' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_586, num_args:2 },
+  ]
+};
+
+block_586 = {
+  instrs: [
+    { op:'push', val:0 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_gt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_587, num_args:2 },
+  ]
+};
+
+block_587 = {
+  instrs: [
+    { op:'if_true', then:@block_588, else:@block_589 },
+  ]
+};
+
+block_588 = {
+  instrs: [
+    { op:'jump', to:@block_590 },
+  ]
+};
+
+block_589 = {
+  instrs: [
+    { op:'push', val:'assertion failed' },
+    { op:'abort' },
+    { op:'jump', to:@block_590 },
+  ]
+};
+
+block_590 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'dup', idx:1 },
+    { op:'push', val:'next' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_591, num_args:2 },
+  ]
+};
+
+block_591 = {
+  instrs: [
+    { op:'call', ret_to:@block_592, num_args:2 },
+  ]
+};
+
+block_593 = {
+  instrs: [
+    { op:'push', val:0 },
+    { op:'set_local', idx:2 },
+    { op:'jump', to:@block_594 },
+  ]
+};
+
+block_594 = {
+  instrs: [
+    { op:'get_local', idx:2 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'length' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_598, num_args:2 },
+  ]
+};
+
+block_598 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_lt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_599, num_args:2 },
+  ]
+};
+
+block_599 = {
+  instrs: [
+    { op:'if_true', then:@block_595, else:@block_597 },
+  ]
+};
+
+block_595 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'dup', idx:0 },
+    { op:'push', val:'readCh' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_600, num_args:2 },
+  ]
+};
+
+block_600 = {
+  instrs: [
+    { op:'call', ret_to:@block_601, num_args:1 },
+  ]
+};
+
+block_601 = {
+  instrs: [
+    { op:'pop' },
+    { op:'jump', to:@block_596 },
+  ]
+};
+
+block_596 = {
+  instrs: [
+    { op:'get_local', idx:2 },
+    { op:'push', val:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_add' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_602, num_args:2 },
+  ]
+};
+
+block_602 = {
+  instrs: [
+    { op:'dup', idx:0 },
+    { op:'set_local', idx:2 },
+    { op:'pop' },
+    { op:'jump', to:@block_594 },
+  ]
+};
+
+block_597 = {
+  instrs: [
+    { op:'push', val:$true },
+    { op:'ret' },
+  ]
+};
+
+block_592 = {
+  instrs: [
+    { op:'if_true', then:@block_593, else:@block_603 },
+  ]
+};
+
+block_603 = {
+  instrs: [
+    { op:'jump', to:@block_604 },
+  ]
+};
+
+block_604 = {
+  instrs: [
+    { op:'push', val:$false },
+    { op:'ret' },
+  ]
+};
+
+fun_585 = {
+  entry:@block_584,
+  num_params:2,
+  num_locals:3,
+};
+
+block_605 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'dup', idx:1 },
+    { op:'push', val:'match' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_607, num_args:2 },
+  ]
+};
+
+block_607 = {
+  instrs: [
+    { op:'call', ret_to:@block_608, num_args:2 },
+  ]
+};
+
+block_608 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_not' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_609, num_args:1 },
+  ]
+};
+
+block_610 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:'expected to find \'' },
+    { op:'get_local', idx:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_add' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_611, num_args:2 },
+  ]
+};
+
+block_611 = {
+  instrs: [
+    { op:'push', val:'\'' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_add' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_612, num_args:2 },
+  ]
+};
+
+block_612 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'parseError' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_613, num_args:2 },
+  ]
+};
+
+block_609 = {
+  instrs: [
+    { op:'if_true', then:@block_610, else:@block_614 },
+  ]
+};
+
+block_613 = {
+  instrs: [
+    { op:'pop' },
+    { op:'jump', to:@block_615 },
+  ]
+};
+
+block_614 = {
+  instrs: [
+    { op:'jump', to:@block_615 },
+  ]
+};
+
+block_615 = {
+  instrs: [
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+fun_606 = {
+  entry:@block_605,
+  num_params:2,
+  num_locals:2,
+};
+
+block_616 = {
+  instrs: [
+    { op:'push', val:$true },
+    { op:'pop' },
+    { op:'jump', to:@block_618 },
+  ]
+};
+
+block_618 = {
+  instrs: [
+    { op:'push', val:$true },
+    { op:'if_true', then:@block_619, else:@block_621 },
+  ]
+};
+
+block_619 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'dup', idx:0 },
+    { op:'push', val:'eof' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_622, num_args:2 },
+  ]
+};
+
+block_622 = {
+  instrs: [
+    { op:'call', ret_to:@block_623, num_args:1 },
+  ]
+};
+
+block_624 = {
+  instrs: [
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_623 = {
+  instrs: [
+    { op:'if_true', then:@block_624, else:@block_625 },
+  ]
+};
+
+block_625 = {
+  instrs: [
+    { op:'jump', to:@block_626 },
+  ]
+};
+
+block_626 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'dup', idx:0 },
+    { op:'push', val:'peekCh' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_627, num_args:2 },
+  ]
+};
+
+block_627 = {
+  instrs: [
+    { op:'call', ret_to:@block_628, num_args:1 },
+  ]
+};
+
+block_628 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'isSpace' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_629, num_args:1 },
+  ]
+};
+
+block_630 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'dup', idx:0 },
+    { op:'push', val:'readCh' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_631, num_args:2 },
+  ]
+};
+
+block_631 = {
+  instrs: [
+    { op:'call', ret_to:@block_632, num_args:1 },
+  ]
+};
+
+block_632 = {
+  instrs: [
+    { op:'pop' },
+    { op:'jump', to:@block_620 },
+  ]
+};
+
+block_629 = {
+  instrs: [
+    { op:'if_true', then:@block_630, else:@block_633 },
+  ]
+};
+
+block_633 = {
+  instrs: [
+    { op:'jump', to:@block_634 },
+  ]
+};
+
+block_634 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:'//' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'match' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_635, num_args:2 },
+  ]
+};
+
+block_635 = {
+  instrs: [
+    { op:'call', ret_to:@block_636, num_args:2 },
+  ]
+};
+
+block_637 = {
+  instrs: [
+    { op:'push', val:$true },
+    { op:'pop' },
+    { op:'jump', to:@block_638 },
+  ]
+};
+
+block_638 = {
+  instrs: [
+    { op:'push', val:$true },
+    { op:'if_true', then:@block_639, else:@block_641 },
+  ]
+};
+
+block_639 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'dup', idx:0 },
+    { op:'push', val:'eof' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_642, num_args:2 },
+  ]
+};
+
+block_642 = {
+  instrs: [
+    { op:'call', ret_to:@block_643, num_args:1 },
+  ]
+};
+
+block_644 = {
+  instrs: [
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_643 = {
+  instrs: [
+    { op:'if_true', then:@block_644, else:@block_645 },
+  ]
+};
+
+block_645 = {
+  instrs: [
+    { op:'jump', to:@block_646 },
+  ]
+};
+
+block_646 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'dup', idx:0 },
+    { op:'push', val:'readCh' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_647, num_args:2 },
+  ]
+};
+
+block_647 = {
+  instrs: [
+    { op:'call', ret_to:@block_648, num_args:1 },
+  ]
+};
+
+block_648 = {
+  instrs: [
+    { op:'push', val:'\x0A' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_649, num_args:2 },
+  ]
+};
+
+block_650 = {
+  instrs: [
+    { op:'jump', to:@block_641 },
+  ]
+};
+
+block_649 = {
+  instrs: [
+    { op:'if_true', then:@block_650, else:@block_651 },
+  ]
+};
+
+block_651 = {
+  instrs: [
+    { op:'jump', to:@block_652 },
+  ]
+};
+
+block_652 = {
+  instrs: [
+    { op:'jump', to:@block_640 },
+  ]
+};
+
+block_640 = {
+  instrs: [
+    { op:'push', val:$true },
+    { op:'pop' },
+    { op:'jump', to:@block_638 },
+  ]
+};
+
+block_641 = {
+  instrs: [
+    { op:'jump', to:@block_620 },
+  ]
+};
+
+block_636 = {
+  instrs: [
+    { op:'if_true', then:@block_637, else:@block_653 },
+  ]
+};
+
+block_653 = {
+  instrs: [
+    { op:'jump', to:@block_654 },
+  ]
+};
+
+block_654 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:'/*' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'match' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_655, num_args:2 },
+  ]
+};
+
+block_655 = {
+  instrs: [
+    { op:'call', ret_to:@block_656, num_args:2 },
+  ]
+};
+
+block_657 = {
+  instrs: [
+    { op:'push', val:$true },
+    { op:'pop' },
+    { op:'jump', to:@block_658 },
+  ]
+};
+
+block_658 = {
+  instrs: [
+    { op:'push', val:$true },
+    { op:'if_true', then:@block_659, else:@block_661 },
+  ]
+};
+
+block_659 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'dup', idx:0 },
+    { op:'push', val:'eof' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_662, num_args:2 },
+  ]
+};
+
+block_662 = {
+  instrs: [
+    { op:'call', ret_to:@block_663, num_args:1 },
+  ]
+};
+
+block_664 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:'end of input in multiline comment' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'parseError' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_665, num_args:2 },
+  ]
+};
+
+block_663 = {
+  instrs: [
+    { op:'if_true', then:@block_664, else:@block_666 },
+  ]
+};
+
+block_665 = {
+  instrs: [
+    { op:'pop' },
+    { op:'jump', to:@block_667 },
+  ]
+};
+
+block_666 = {
+  instrs: [
+    { op:'jump', to:@block_667 },
+  ]
+};
+
+block_667 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'dup', idx:0 },
+    { op:'push', val:'readCh' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_670, num_args:2 },
+  ]
+};
+
+block_670 = {
+  instrs: [
+    { op:'call', ret_to:@block_671, num_args:1 },
+  ]
+};
+
+block_671 = {
+  instrs: [
+    { op:'push', val:'*' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_672, num_args:2 },
+  ]
+};
+
+block_672 = {
+  instrs: [
+    { op:'dup', idx:0 },
+    { op:'if_true', then:@block_668, else:@block_669 },
+  ]
+};
+
+block_668 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:'/' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'match' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_673, num_args:2 },
+  ]
+};
+
+block_673 = {
+  instrs: [
+    { op:'call', ret_to:@block_674, num_args:2 },
+  ]
+};
+
+block_674 = {
+  instrs: [
+    { op:'jump', to:@block_669 },
+  ]
+};
+
+block_675 = {
+  instrs: [
+    { op:'jump', to:@block_661 },
+  ]
+};
+
+block_669 = {
+  instrs: [
+    { op:'if_true', then:@block_675, else:@block_676 },
+  ]
+};
+
+block_676 = {
+  instrs: [
+    { op:'jump', to:@block_677 },
+  ]
+};
+
+block_677 = {
+  instrs: [
+    { op:'jump', to:@block_660 },
+  ]
+};
+
+block_660 = {
+  instrs: [
+    { op:'push', val:$true },
+    { op:'pop' },
+    { op:'jump', to:@block_658 },
+  ]
+};
+
+block_661 = {
+  instrs: [
+    { op:'jump', to:@block_620 },
+  ]
+};
+
+block_656 = {
+  instrs: [
+    { op:'if_true', then:@block_657, else:@block_678 },
+  ]
+};
+
+block_678 = {
+  instrs: [
+    { op:'jump', to:@block_679 },
+  ]
+};
+
+block_679 = {
+  instrs: [
+    { op:'jump', to:@block_621 },
+  ]
+};
+
+block_620 = {
+  instrs: [
+    { op:'push', val:$true },
+    { op:'pop' },
+    { op:'jump', to:@block_618 },
+  ]
+};
+
+block_621 = {
+  instrs: [
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+fun_617 = {
+  entry:@block_616,
+  num_params:1,
+  num_locals:1,
+};
+
+block_680 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'dup', idx:0 },
+    { op:'push', val:'eatWS' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_682, num_args:2 },
+  ]
+};
+
+block_682 = {
+  instrs: [
+    { op:'call', ret_to:@block_683, num_args:1 },
+  ]
+};
+
+block_683 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'dup', idx:1 },
+    { op:'push', val:'next' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_684, num_args:2 },
+  ]
+};
+
+block_684 = {
+  instrs: [
+    { op:'call', ret_to:@block_685, num_args:2 },
+  ]
+};
+
+block_685 = {
+  instrs: [
+    { op:'ret' },
+  ]
+};
+
+fun_681 = {
+  entry:@block_680,
+  num_params:2,
+  num_locals:2,
+};
+
+block_686 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'dup', idx:0 },
+    { op:'push', val:'eatWS' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_688, num_args:2 },
+  ]
+};
+
+block_688 = {
+  instrs: [
+    { op:'call', ret_to:@block_689, num_args:1 },
+  ]
+};
+
+block_689 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'dup', idx:1 },
+    { op:'push', val:'match' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_690, num_args:2 },
+  ]
+};
+
+block_690 = {
+  instrs: [
+    { op:'call', ret_to:@block_691, num_args:2 },
+  ]
+};
+
+block_691 = {
+  instrs: [
+    { op:'ret' },
+  ]
+};
+
+fun_687 = {
+  entry:@block_686,
+  num_params:2,
+  num_locals:2,
+};
+
+block_692 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'dup', idx:0 },
+    { op:'push', val:'eatWS' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_694, num_args:2 },
+  ]
+};
+
+block_694 = {
+  instrs: [
+    { op:'call', ret_to:@block_695, num_args:1 },
+  ]
+};
+
+block_695 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'dup', idx:1 },
+    { op:'push', val:'expect' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_696, num_args:2 },
+  ]
+};
+
+block_696 = {
+  instrs: [
+    { op:'call', ret_to:@block_697, num_args:2 },
+  ]
+};
+
+block_697 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+fun_693 = {
+  entry:@block_692,
+  num_params:2,
+  num_locals:2,
+};
+
+block_698 = {
+  instrs: [
+    { op:'push', val:0 },
+    { op:'set_local', idx:2 },
+    { op:'push', val:$true },
+    { op:'pop' },
+    { op:'jump', to:@block_700 },
+  ]
+};
+
+block_700 = {
+  instrs: [
+    { op:'push', val:$true },
+    { op:'if_true', then:@block_701, else:@block_703 },
+  ]
+};
+
+block_701 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'dup', idx:0 },
+    { op:'push', val:'readCh' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_704, num_args:2 },
+  ]
+};
+
+block_704 = {
+  instrs: [
+    { op:'call', ret_to:@block_705, num_args:1 },
+  ]
+};
+
+block_705 = {
+  instrs: [
+    { op:'set_local', idx:3 },
+    { op:'get_local', idx:3 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'isDigit' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_706, num_args:1 },
+  ]
+};
+
+block_706 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_not' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_707, num_args:1 },
+  ]
+};
+
+block_708 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:'expected digit' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'parseError' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_709, num_args:2 },
+  ]
+};
+
+block_707 = {
+  instrs: [
+    { op:'if_true', then:@block_708, else:@block_710 },
+  ]
+};
+
+block_709 = {
+  instrs: [
+    { op:'pop' },
+    { op:'jump', to:@block_711 },
+  ]
+};
+
+block_710 = {
+  instrs: [
+    { op:'jump', to:@block_711 },
+  ]
+};
+
+block_711 = {
+  instrs: [
+    { op:'push', val:0 },
+    { op:'push', val:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_sub' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_712, num_args:2 },
+  ]
+};
+
+block_712 = {
+  instrs: [
+    { op:'set_local', idx:4 },
+    { op:'push', val:'0123456789' },
+    { op:'set_local', idx:5 },
+    { op:'push', val:0 },
+    { op:'set_local', idx:6 },
+    { op:'jump', to:@block_713 },
+  ]
+};
+
+block_713 = {
+  instrs: [
+    { op:'get_local', idx:6 },
+    { op:'get_local', idx:5 },
+    { op:'push', val:'length' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_717, num_args:2 },
+  ]
+};
+
+block_717 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_lt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_718, num_args:2 },
+  ]
+};
+
+block_718 = {
+  instrs: [
+    { op:'if_true', then:@block_714, else:@block_716 },
+  ]
+};
+
+block_714 = {
+  instrs: [
+    { op:'get_local', idx:3 },
+    { op:'get_local', idx:5 },
+    { op:'get_local', idx:6 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getElem' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_719, num_args:2 },
+  ]
+};
+
+block_719 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_720, num_args:2 },
+  ]
+};
+
+block_721 = {
+  instrs: [
+    { op:'get_local', idx:6 },
+    { op:'dup', idx:0 },
+    { op:'set_local', idx:4 },
+    { op:'pop' },
+    { op:'jump', to:@block_716 },
+  ]
+};
+
+block_720 = {
+  instrs: [
+    { op:'if_true', then:@block_721, else:@block_722 },
+  ]
+};
+
+block_722 = {
+  instrs: [
+    { op:'jump', to:@block_723 },
+  ]
+};
+
+block_723 = {
+  instrs: [
+    { op:'jump', to:@block_715 },
+  ]
+};
+
+block_715 = {
+  instrs: [
+    { op:'get_local', idx:6 },
+    { op:'push', val:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_add' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_724, num_args:2 },
+  ]
+};
+
+block_724 = {
+  instrs: [
+    { op:'dup', idx:0 },
+    { op:'set_local', idx:6 },
+    { op:'pop' },
+    { op:'jump', to:@block_713 },
+  ]
+};
+
+block_716 = {
   instrs: [
     { op:'get_local', idx:4 },
     { op:'push', val:0 },
@@ -4946,53 +6289,61 @@ block_540 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_sub' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_548, num_args:2 },
+    { op:'call', ret_to:@block_725, num_args:2 },
   ]
 };
 
-block_548 = {
+block_725 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_ne' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_549, num_args:2 },
+    { op:'call', ret_to:@block_726, num_args:2 },
   ]
 };
 
-block_549 = {
+block_726 = {
   instrs: [
-    { op:'if_true', then:@block_550, else:@block_551 },
+    { op:'if_true', then:@block_727, else:@block_728 },
   ]
 };
 
-block_550 = {
+block_727 = {
   instrs: [
-    { op:'jump', to:@block_552 },
+    { op:'jump', to:@block_729 },
   ]
 };
 
-block_551 = {
+block_728 = {
   instrs: [
     { op:'push', val:'digit not found' },
     { op:'abort' },
-    { op:'jump', to:@block_552 },
+    { op:'jump', to:@block_729 },
   ]
 };
 
-block_552 = {
+block_729 = {
   instrs: [
     { op:'push', val:10 },
     { op:'get_local', idx:2 },
-    { op:'mul_i32' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_mul' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_730, num_args:2 },
+  ]
+};
+
+block_730 = {
+  instrs: [
     { op:'get_local', idx:4 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_add' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_553, num_args:2 },
+    { op:'call', ret_to:@block_731, num_args:2 },
   ]
 };
 
-block_553 = {
+block_731 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'set_local', idx:2 },
@@ -5003,67 +6354,67 @@ block_553 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_554, num_args:2 },
+    { op:'call', ret_to:@block_732, num_args:2 },
   ]
 };
 
-block_554 = {
+block_732 = {
   instrs: [
-    { op:'call', ret_to:@block_555, num_args:1 },
+    { op:'call', ret_to:@block_733, num_args:1 },
   ]
 };
 
-block_555 = {
+block_733 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'isDigit' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_556, num_args:1 },
+    { op:'call', ret_to:@block_734, num_args:1 },
   ]
 };
 
-block_556 = {
+block_734 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_not' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_557, num_args:1 },
+    { op:'call', ret_to:@block_735, num_args:1 },
   ]
 };
 
-block_558 = {
+block_736 = {
   instrs: [
-    { op:'jump', to:@block_527 },
+    { op:'jump', to:@block_703 },
   ]
 };
 
-block_557 = {
+block_735 = {
   instrs: [
-    { op:'if_true', then:@block_558, else:@block_559 },
+    { op:'if_true', then:@block_736, else:@block_737 },
   ]
 };
 
-block_559 = {
+block_737 = {
   instrs: [
-    { op:'jump', to:@block_560 },
+    { op:'jump', to:@block_738 },
   ]
 };
 
-block_560 = {
+block_738 = {
   instrs: [
-    { op:'jump', to:@block_526 },
+    { op:'jump', to:@block_702 },
   ]
 };
 
-block_526 = {
+block_702 = {
   instrs: [
     { op:'push', val:$true },
     { op:'pop' },
-    { op:'jump', to:@block_524 },
+    { op:'jump', to:@block_700 },
   ]
 };
 
-block_561 = {
+block_739 = {
   instrs: [
     { op:'get_local', idx:2 },
     { op:'push', val:0 },
@@ -5071,34 +6422,42 @@ block_561 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_sub' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_562, num_args:2 },
+    { op:'call', ret_to:@block_740, num_args:2 },
   ]
 };
 
-block_527 = {
+block_740 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_mul' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_741, num_args:2 },
+  ]
+};
+
+block_703 = {
   instrs: [
     { op:'get_local', idx:1 },
-    { op:'if_true', then:@block_561, else:@block_563 },
+    { op:'if_true', then:@block_739, else:@block_742 },
   ]
 };
 
-block_562 = {
+block_741 = {
   instrs: [
-    { op:'mul_i32' },
     { op:'dup', idx:0 },
     { op:'set_local', idx:2 },
     { op:'pop' },
-    { op:'jump', to:@block_564 },
+    { op:'jump', to:@block_743 },
   ]
 };
 
-block_563 = {
+block_742 = {
   instrs: [
-    { op:'jump', to:@block_564 },
+    { op:'jump', to:@block_743 },
   ]
 };
 
-block_564 = {
+block_743 = {
   instrs: [
     { op:'push', val:1 },
     { op:'new_object' },
@@ -5116,13 +6475,13 @@ block_564 = {
   ]
 };
 
-fun_523 = {
-  entry:@block_522,
+fun_699 = {
+  entry:@block_698,
   num_params:2,
   num_locals:7,
 };
 
-block_565 = {
+block_744 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'dup', idx:0 },
@@ -5130,17 +6489,17 @@ block_565 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_567, num_args:2 },
+    { op:'call', ret_to:@block_746, num_args:2 },
   ]
 };
 
-block_567 = {
+block_746 = {
   instrs: [
-    { op:'call', ret_to:@block_568, num_args:1 },
+    { op:'call', ret_to:@block_747, num_args:1 },
   ]
 };
 
-block_568 = {
+block_747 = {
   instrs: [
     { op:'set_local', idx:1 },
     { op:'get_local', idx:1 },
@@ -5148,241 +6507,241 @@ block_568 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_569, num_args:2 },
+    { op:'call', ret_to:@block_748, num_args:2 },
   ]
 };
 
-block_570 = {
+block_749 = {
   instrs: [
     { op:'push', val:'\x0A' },
     { op:'ret' },
   ]
 };
 
-block_569 = {
+block_748 = {
   instrs: [
-    { op:'if_true', then:@block_570, else:@block_571 },
+    { op:'if_true', then:@block_749, else:@block_750 },
   ]
 };
 
-block_571 = {
+block_750 = {
   instrs: [
-    { op:'jump', to:@block_572 },
+    { op:'jump', to:@block_751 },
   ]
 };
 
-block_572 = {
+block_751 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'t' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_573, num_args:2 },
+    { op:'call', ret_to:@block_752, num_args:2 },
   ]
 };
 
-block_574 = {
+block_753 = {
   instrs: [
     { op:'push', val:'\x09' },
     { op:'ret' },
   ]
 };
 
-block_573 = {
+block_752 = {
   instrs: [
-    { op:'if_true', then:@block_574, else:@block_575 },
+    { op:'if_true', then:@block_753, else:@block_754 },
   ]
 };
 
-block_575 = {
+block_754 = {
   instrs: [
-    { op:'jump', to:@block_576 },
+    { op:'jump', to:@block_755 },
   ]
 };
 
-block_576 = {
+block_755 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'0' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_577, num_args:2 },
+    { op:'call', ret_to:@block_756, num_args:2 },
   ]
 };
 
-block_578 = {
+block_757 = {
   instrs: [
     { op:'push', val:'\x00' },
     { op:'ret' },
   ]
 };
 
-block_577 = {
+block_756 = {
   instrs: [
-    { op:'if_true', then:@block_578, else:@block_579 },
+    { op:'if_true', then:@block_757, else:@block_758 },
   ]
 };
 
-block_579 = {
+block_758 = {
   instrs: [
-    { op:'jump', to:@block_580 },
+    { op:'jump', to:@block_759 },
   ]
 };
 
-block_580 = {
+block_759 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'\'' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_581, num_args:2 },
+    { op:'call', ret_to:@block_760, num_args:2 },
   ]
 };
 
-block_582 = {
+block_761 = {
   instrs: [
     { op:'push', val:'\'' },
     { op:'ret' },
   ]
 };
 
-block_581 = {
+block_760 = {
   instrs: [
-    { op:'if_true', then:@block_582, else:@block_583 },
+    { op:'if_true', then:@block_761, else:@block_762 },
   ]
 };
 
-block_583 = {
+block_762 = {
   instrs: [
-    { op:'jump', to:@block_584 },
+    { op:'jump', to:@block_763 },
   ]
 };
 
-block_584 = {
+block_763 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'\"' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_585, num_args:2 },
+    { op:'call', ret_to:@block_764, num_args:2 },
   ]
 };
 
-block_586 = {
+block_765 = {
   instrs: [
     { op:'push', val:'\"' },
     { op:'ret' },
   ]
 };
 
-block_585 = {
+block_764 = {
   instrs: [
-    { op:'if_true', then:@block_586, else:@block_587 },
+    { op:'if_true', then:@block_765, else:@block_766 },
   ]
 };
 
-block_587 = {
+block_766 = {
   instrs: [
-    { op:'jump', to:@block_588 },
+    { op:'jump', to:@block_767 },
   ]
 };
 
-block_588 = {
+block_767 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'\\' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_589, num_args:2 },
+    { op:'call', ret_to:@block_768, num_args:2 },
   ]
 };
 
-block_590 = {
+block_769 = {
   instrs: [
     { op:'push', val:'\\' },
     { op:'ret' },
   ]
 };
 
-block_589 = {
+block_768 = {
   instrs: [
-    { op:'if_true', then:@block_590, else:@block_591 },
+    { op:'if_true', then:@block_769, else:@block_770 },
   ]
 };
 
-block_591 = {
+block_770 = {
   instrs: [
-    { op:'jump', to:@block_592 },
+    { op:'jump', to:@block_771 },
   ]
 };
 
-block_592 = {
+block_771 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'x' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_593, num_args:2 },
+    { op:'call', ret_to:@block_772, num_args:2 },
   ]
 };
 
-block_594 = {
+block_773 = {
   instrs: [
     { op:'push', val:$false },
-    { op:'if_true', then:@block_595, else:@block_596 },
+    { op:'if_true', then:@block_774, else:@block_775 },
   ]
 };
 
-block_595 = {
+block_774 = {
   instrs: [
-    { op:'jump', to:@block_597 },
+    { op:'jump', to:@block_776 },
   ]
 };
 
-block_596 = {
+block_775 = {
   instrs: [
     { op:'push', val:'hexadecimal escape sequence' },
     { op:'abort' },
-    { op:'jump', to:@block_597 },
+    { op:'jump', to:@block_776 },
   ]
 };
 
-block_593 = {
+block_772 = {
   instrs: [
-    { op:'if_true', then:@block_594, else:@block_598 },
+    { op:'if_true', then:@block_773, else:@block_777 },
   ]
 };
 
-block_597 = {
+block_776 = {
   instrs: [
-    { op:'jump', to:@block_599 },
+    { op:'jump', to:@block_778 },
   ]
 };
 
-block_598 = {
+block_777 = {
   instrs: [
-    { op:'jump', to:@block_599 },
+    { op:'jump', to:@block_778 },
   ]
 };
 
-block_599 = {
+block_778 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'invalid character escape sequence' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseError' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_600, num_args:2 },
+    { op:'call', ret_to:@block_779, num_args:2 },
   ]
 };
 
-block_600 = {
+block_779 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -5390,30 +6749,30 @@ block_600 = {
   ]
 };
 
-fun_566 = {
-  entry:@block_565,
+fun_745 = {
+  entry:@block_744,
   num_params:1,
   num_locals:2,
 };
 
-block_601 = {
+block_780 = {
   instrs: [
     { op:'push', val:'' },
     { op:'set_local', idx:2 },
     { op:'push', val:$true },
     { op:'pop' },
-    { op:'jump', to:@block_603 },
+    { op:'jump', to:@block_782 },
   ]
 };
 
-block_603 = {
+block_782 = {
   instrs: [
     { op:'push', val:$true },
-    { op:'if_true', then:@block_604, else:@block_606 },
+    { op:'if_true', then:@block_783, else:@block_785 },
   ]
 };
 
-block_604 = {
+block_783 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'dup', idx:0 },
@@ -5421,47 +6780,47 @@ block_604 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_607, num_args:2 },
+    { op:'call', ret_to:@block_786, num_args:2 },
   ]
 };
 
-block_607 = {
+block_786 = {
   instrs: [
-    { op:'call', ret_to:@block_608, num_args:1 },
+    { op:'call', ret_to:@block_787, num_args:1 },
   ]
 };
 
-block_609 = {
+block_788 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'end of input inside string literal' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseError' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_610, num_args:2 },
+    { op:'call', ret_to:@block_789, num_args:2 },
   ]
 };
 
-block_608 = {
+block_787 = {
   instrs: [
-    { op:'if_true', then:@block_609, else:@block_611 },
+    { op:'if_true', then:@block_788, else:@block_790 },
   ]
 };
 
-block_610 = {
+block_789 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_612 },
+    { op:'jump', to:@block_791 },
   ]
 };
 
-block_611 = {
+block_790 = {
   instrs: [
-    { op:'jump', to:@block_612 },
+    { op:'jump', to:@block_791 },
   ]
 };
 
-block_612 = {
+block_791 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'dup', idx:0 },
@@ -5469,17 +6828,17 @@ block_612 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_613, num_args:2 },
+    { op:'call', ret_to:@block_792, num_args:2 },
   ]
 };
 
-block_613 = {
+block_792 = {
   instrs: [
-    { op:'call', ret_to:@block_614, num_args:1 },
+    { op:'call', ret_to:@block_793, num_args:1 },
   ]
 };
 
-block_614 = {
+block_793 = {
   instrs: [
     { op:'set_local', idx:3 },
     { op:'get_local', idx:3 },
@@ -5487,47 +6846,47 @@ block_614 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_615, num_args:2 },
+    { op:'call', ret_to:@block_794, num_args:2 },
   ]
 };
 
-block_616 = {
+block_795 = {
   instrs: [
-    { op:'jump', to:@block_606 },
+    { op:'jump', to:@block_785 },
   ]
 };
 
-block_615 = {
+block_794 = {
   instrs: [
-    { op:'if_true', then:@block_616, else:@block_617 },
+    { op:'if_true', then:@block_795, else:@block_796 },
   ]
 };
 
-block_617 = {
+block_796 = {
   instrs: [
-    { op:'jump', to:@block_618 },
+    { op:'jump', to:@block_797 },
   ]
 };
 
-block_618 = {
+block_797 = {
   instrs: [
     { op:'get_local', idx:3 },
     { op:'push', val:'\x0D' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_621, num_args:2 },
+    { op:'call', ret_to:@block_800, num_args:2 },
   ]
 };
 
-block_621 = {
+block_800 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_620, else:@block_619 },
+    { op:'if_true', then:@block_799, else:@block_798 },
   ]
 };
 
-block_619 = {
+block_798 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:3 },
@@ -5535,117 +6894,117 @@ block_619 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_622, num_args:2 },
+    { op:'call', ret_to:@block_801, num_args:2 },
   ]
 };
 
-block_622 = {
+block_801 = {
   instrs: [
-    { op:'jump', to:@block_620 },
+    { op:'jump', to:@block_799 },
   ]
 };
 
-block_623 = {
+block_802 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'newline character in string literal' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseError' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_624, num_args:2 },
+    { op:'call', ret_to:@block_803, num_args:2 },
   ]
 };
 
-block_620 = {
+block_799 = {
   instrs: [
-    { op:'if_true', then:@block_623, else:@block_625 },
+    { op:'if_true', then:@block_802, else:@block_804 },
   ]
 };
 
-block_624 = {
+block_803 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_626 },
+    { op:'jump', to:@block_805 },
   ]
 };
 
-block_625 = {
+block_804 = {
   instrs: [
-    { op:'jump', to:@block_626 },
+    { op:'jump', to:@block_805 },
   ]
 };
 
-block_626 = {
+block_805 = {
   instrs: [
     { op:'get_local', idx:3 },
     { op:'push', val:'\\' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_627, num_args:2 },
+    { op:'call', ret_to:@block_806, num_args:2 },
   ]
 };
 
-block_628 = {
+block_807 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseEscSeq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_629, num_args:1 },
+    { op:'call', ret_to:@block_808, num_args:1 },
   ]
 };
 
-block_627 = {
+block_806 = {
   instrs: [
-    { op:'if_true', then:@block_628, else:@block_630 },
+    { op:'if_true', then:@block_807, else:@block_809 },
   ]
 };
 
-block_629 = {
+block_808 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'set_local', idx:3 },
     { op:'pop' },
-    { op:'jump', to:@block_631 },
+    { op:'jump', to:@block_810 },
   ]
 };
 
-block_630 = {
+block_809 = {
   instrs: [
-    { op:'jump', to:@block_631 },
+    { op:'jump', to:@block_810 },
   ]
 };
 
-block_631 = {
+block_810 = {
   instrs: [
     { op:'get_local', idx:2 },
     { op:'get_local', idx:3 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_add' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_632, num_args:2 },
+    { op:'call', ret_to:@block_811, num_args:2 },
   ]
 };
 
-block_632 = {
+block_811 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'set_local', idx:2 },
     { op:'pop' },
-    { op:'jump', to:@block_605 },
+    { op:'jump', to:@block_784 },
   ]
 };
 
-block_605 = {
+block_784 = {
   instrs: [
     { op:'push', val:$true },
     { op:'pop' },
-    { op:'jump', to:@block_603 },
+    { op:'jump', to:@block_782 },
   ]
 };
 
-block_606 = {
+block_785 = {
   instrs: [
     { op:'push', val:1 },
     { op:'new_object' },
@@ -5663,13 +7022,13 @@ block_606 = {
   ]
 };
 
-fun_602 = {
-  entry:@block_601,
+fun_781 = {
+  entry:@block_780,
   num_params:2,
   num_locals:4,
 };
 
-block_633 = {
+block_812 = {
   instrs: [
     { op:'push', val:'' },
     { op:'set_local', idx:1 },
@@ -5679,17 +7038,17 @@ block_633 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_635, num_args:2 },
+    { op:'call', ret_to:@block_814, num_args:2 },
   ]
 };
 
-block_635 = {
+block_814 = {
   instrs: [
-    { op:'call', ret_to:@block_636, num_args:1 },
+    { op:'call', ret_to:@block_815, num_args:1 },
   ]
 };
 
-block_636 = {
+block_815 = {
   instrs: [
     { op:'set_local', idx:2 },
     { op:'get_local', idx:2 },
@@ -5697,89 +7056,89 @@ block_636 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_ne' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_639, num_args:2 },
+    { op:'call', ret_to:@block_818, num_args:2 },
   ]
 };
 
-block_639 = {
+block_818 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_637, else:@block_638 },
+    { op:'if_true', then:@block_816, else:@block_817 },
   ]
 };
 
-block_637 = {
+block_816 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:2 },
     { op:'push', val:@global_obj },
     { op:'push', val:'isAlpha' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_640, num_args:1 },
+    { op:'call', ret_to:@block_819, num_args:1 },
   ]
 };
 
-block_640 = {
+block_819 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_not' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_641, num_args:1 },
+    { op:'call', ret_to:@block_820, num_args:1 },
   ]
 };
 
-block_641 = {
+block_820 = {
   instrs: [
-    { op:'jump', to:@block_638 },
+    { op:'jump', to:@block_817 },
   ]
 };
 
-block_642 = {
+block_821 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'invalid identifier start' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseError' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_643, num_args:2 },
+    { op:'call', ret_to:@block_822, num_args:2 },
   ]
 };
 
-block_638 = {
+block_817 = {
   instrs: [
-    { op:'if_true', then:@block_642, else:@block_644 },
+    { op:'if_true', then:@block_821, else:@block_823 },
   ]
 };
 
-block_643 = {
+block_822 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_645 },
+    { op:'jump', to:@block_824 },
   ]
 };
 
-block_644 = {
+block_823 = {
   instrs: [
-    { op:'jump', to:@block_645 },
+    { op:'jump', to:@block_824 },
   ]
 };
 
-block_645 = {
+block_824 = {
   instrs: [
     { op:'push', val:$true },
     { op:'pop' },
-    { op:'jump', to:@block_646 },
+    { op:'jump', to:@block_825 },
   ]
 };
 
-block_646 = {
+block_825 = {
   instrs: [
     { op:'push', val:$true },
-    { op:'if_true', then:@block_647, else:@block_649 },
+    { op:'if_true', then:@block_826, else:@block_828 },
   ]
 };
 
-block_647 = {
+block_826 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'dup', idx:0 },
@@ -5787,44 +7146,44 @@ block_647 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_650, num_args:2 },
+    { op:'call', ret_to:@block_829, num_args:2 },
   ]
 };
 
-block_650 = {
+block_829 = {
   instrs: [
-    { op:'call', ret_to:@block_651, num_args:1 },
+    { op:'call', ret_to:@block_830, num_args:1 },
   ]
 };
 
-block_651 = {
+block_830 = {
   instrs: [
     { op:'set_local', idx:3 },
     { op:'get_local', idx:3 },
     { op:'push', val:@global_obj },
     { op:'push', val:'isAlnum' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_654, num_args:1 },
+    { op:'call', ret_to:@block_833, num_args:1 },
   ]
 };
 
-block_654 = {
+block_833 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_not' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_655, num_args:1 },
+    { op:'call', ret_to:@block_834, num_args:1 },
   ]
 };
 
-block_655 = {
+block_834 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_652, else:@block_653 },
+    { op:'if_true', then:@block_831, else:@block_832 },
   ]
 };
 
-block_652 = {
+block_831 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:3 },
@@ -5832,35 +7191,35 @@ block_652 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_ne' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_656, num_args:2 },
+    { op:'call', ret_to:@block_835, num_args:2 },
   ]
 };
 
-block_656 = {
+block_835 = {
   instrs: [
-    { op:'jump', to:@block_653 },
+    { op:'jump', to:@block_832 },
   ]
 };
 
-block_657 = {
+block_836 = {
   instrs: [
-    { op:'jump', to:@block_649 },
+    { op:'jump', to:@block_828 },
   ]
 };
 
-block_653 = {
+block_832 = {
   instrs: [
-    { op:'if_true', then:@block_657, else:@block_658 },
+    { op:'if_true', then:@block_836, else:@block_837 },
   ]
 };
 
-block_658 = {
+block_837 = {
   instrs: [
-    { op:'jump', to:@block_659 },
+    { op:'jump', to:@block_838 },
   ]
 };
 
-block_659 = {
+block_838 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'get_local', idx:0 },
@@ -5869,107 +7228,107 @@ block_659 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_660, num_args:2 },
+    { op:'call', ret_to:@block_839, num_args:2 },
   ]
 };
 
-block_660 = {
+block_839 = {
   instrs: [
-    { op:'call', ret_to:@block_661, num_args:1 },
+    { op:'call', ret_to:@block_840, num_args:1 },
   ]
 };
 
-block_661 = {
+block_840 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_add' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_662, num_args:2 },
+    { op:'call', ret_to:@block_841, num_args:2 },
   ]
 };
 
-block_662 = {
+block_841 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'set_local', idx:1 },
     { op:'pop' },
-    { op:'jump', to:@block_648 },
+    { op:'jump', to:@block_827 },
   ]
 };
 
-block_648 = {
+block_827 = {
   instrs: [
     { op:'push', val:$true },
     { op:'pop' },
-    { op:'jump', to:@block_646 },
+    { op:'jump', to:@block_825 },
   ]
 };
 
-block_649 = {
+block_828 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_663, num_args:2 },
+    { op:'call', ret_to:@block_842, num_args:2 },
   ]
 };
 
-block_663 = {
+block_842 = {
   instrs: [
     { op:'push', val:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_664, num_args:2 },
+    { op:'call', ret_to:@block_843, num_args:2 },
   ]
 };
 
-block_665 = {
+block_844 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'invalid identifier' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseError' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_666, num_args:2 },
+    { op:'call', ret_to:@block_845, num_args:2 },
   ]
 };
 
-block_664 = {
+block_843 = {
   instrs: [
-    { op:'if_true', then:@block_665, else:@block_667 },
+    { op:'if_true', then:@block_844, else:@block_846 },
   ]
 };
 
-block_666 = {
+block_845 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_668 },
+    { op:'jump', to:@block_847 },
   ]
 };
 
-block_667 = {
+block_846 = {
   instrs: [
-    { op:'jump', to:@block_668 },
+    { op:'jump', to:@block_847 },
   ]
 };
 
-block_668 = {
+block_847 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'ret' },
   ]
 };
 
-fun_634 = {
-  entry:@block_633,
+fun_813 = {
+  entry:@block_812,
   num_params:1,
   num_locals:4,
 };
 
-block_669 = {
+block_848 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'(' },
@@ -5978,28 +7337,28 @@ block_669 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_671, num_args:2 },
+    { op:'call', ret_to:@block_850, num_args:2 },
   ]
 };
 
-block_671 = {
+block_850 = {
   instrs: [
-    { op:'call', ret_to:@block_672, num_args:2 },
+    { op:'call', ret_to:@block_851, num_args:2 },
   ]
 };
 
-block_672 = {
+block_851 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_673, num_args:1 },
+    { op:'call', ret_to:@block_852, num_args:1 },
   ]
 };
 
-block_673 = {
+block_852 = {
   instrs: [
     { op:'set_local', idx:1 },
     { op:'get_local', idx:0 },
@@ -6009,28 +7368,28 @@ block_673 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_674, num_args:2 },
+    { op:'call', ret_to:@block_853, num_args:2 },
   ]
 };
 
-block_674 = {
+block_853 = {
   instrs: [
-    { op:'call', ret_to:@block_675, num_args:2 },
+    { op:'call', ret_to:@block_854, num_args:2 },
   ]
 };
 
-block_675 = {
+block_854 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseStmt' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_676, num_args:1 },
+    { op:'call', ret_to:@block_855, num_args:1 },
   ]
 };
 
-block_676 = {
+block_855 = {
   instrs: [
     { op:'set_local', idx:2 },
     { op:'get_local', idx:0 },
@@ -6040,40 +7399,40 @@ block_676 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_677, num_args:2 },
+    { op:'call', ret_to:@block_856, num_args:2 },
   ]
 };
 
-block_677 = {
+block_856 = {
   instrs: [
-    { op:'call', ret_to:@block_678, num_args:2 },
+    { op:'call', ret_to:@block_857, num_args:2 },
   ]
 };
 
-block_679 = {
+block_858 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseStmt' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_680, num_args:1 },
+    { op:'call', ret_to:@block_859, num_args:1 },
   ]
 };
 
-block_678 = {
+block_857 = {
   instrs: [
-    { op:'if_true', then:@block_679, else:@block_681 },
+    { op:'if_true', then:@block_858, else:@block_860 },
   ]
 };
 
-block_680 = {
+block_859 = {
   instrs: [
     { op:'set_local', idx:3 },
-    { op:'jump', to:@block_682 },
+    { op:'jump', to:@block_861 },
   ]
 };
 
-block_681 = {
+block_860 = {
   instrs: [
     { op:'push', val:1 },
     { op:'new_object' },
@@ -6089,11 +7448,11 @@ block_681 = {
     { op:'new_array' },
     { op:'set_field' },
     { op:'set_local', idx:3 },
-    { op:'jump', to:@block_682 },
+    { op:'jump', to:@block_861 },
   ]
 };
 
-block_682 = {
+block_861 = {
   instrs: [
     { op:'push', val:3 },
     { op:'new_object' },
@@ -6119,13 +7478,13 @@ block_682 = {
   ]
 };
 
-fun_670 = {
-  entry:@block_669,
+fun_849 = {
+  entry:@block_848,
   num_params:1,
   num_locals:4,
 };
 
-block_683 = {
+block_862 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'(' },
@@ -6134,17 +7493,17 @@ block_683 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_685, num_args:2 },
+    { op:'call', ret_to:@block_864, num_args:2 },
   ]
 };
 
-block_685 = {
+block_864 = {
   instrs: [
-    { op:'call', ret_to:@block_686, num_args:2 },
+    { op:'call', ret_to:@block_865, num_args:2 },
   ]
 };
 
-block_686 = {
+block_865 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$false },
@@ -6156,33 +7515,33 @@ block_686 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_687, num_args:2 },
+    { op:'call', ret_to:@block_866, num_args:2 },
   ]
 };
 
-block_687 = {
+block_866 = {
   instrs: [
-    { op:'call', ret_to:@block_688, num_args:2 },
+    { op:'call', ret_to:@block_867, num_args:2 },
   ]
 };
 
-block_690 = {
+block_869 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseStmt' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_691, num_args:1 },
+    { op:'call', ret_to:@block_870, num_args:1 },
   ]
 };
 
-block_688 = {
+block_867 = {
   instrs: [
-    { op:'if_true', then:@block_689, else:@block_690 },
+    { op:'if_true', then:@block_868, else:@block_869 },
   ]
 };
 
-block_689 = {
+block_868 = {
   instrs: [
     { op:'push', val:1 },
     { op:'new_object' },
@@ -6210,20 +7569,20 @@ block_689 = {
     { op:'dup', idx:0 },
     { op:'set_local', idx:1 },
     { op:'pop' },
-    { op:'jump', to:@block_692 },
+    { op:'jump', to:@block_871 },
   ]
 };
 
-block_691 = {
+block_870 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'set_local', idx:1 },
     { op:'pop' },
-    { op:'jump', to:@block_692 },
+    { op:'jump', to:@block_871 },
   ]
 };
 
-block_692 = {
+block_871 = {
   instrs: [
     { op:'push', val:$false },
     { op:'set_local', idx:2 },
@@ -6234,27 +7593,27 @@ block_692 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_693, num_args:2 },
+    { op:'call', ret_to:@block_872, num_args:2 },
   ]
 };
 
-block_693 = {
+block_872 = {
   instrs: [
-    { op:'call', ret_to:@block_694, num_args:2 },
+    { op:'call', ret_to:@block_873, num_args:2 },
   ]
 };
 
-block_696 = {
+block_875 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_697, num_args:1 },
+    { op:'call', ret_to:@block_876, num_args:1 },
   ]
 };
 
-block_697 = {
+block_876 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'set_local', idx:2 },
@@ -6266,23 +7625,23 @@ block_697 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_698, num_args:2 },
+    { op:'call', ret_to:@block_877, num_args:2 },
   ]
 };
 
-block_698 = {
+block_877 = {
   instrs: [
-    { op:'call', ret_to:@block_699, num_args:2 },
+    { op:'call', ret_to:@block_878, num_args:2 },
   ]
 };
 
-block_694 = {
+block_873 = {
   instrs: [
-    { op:'if_true', then:@block_695, else:@block_696 },
+    { op:'if_true', then:@block_874, else:@block_875 },
   ]
 };
 
-block_695 = {
+block_874 = {
   instrs: [
     { op:'push', val:1 },
     { op:'new_object' },
@@ -6299,18 +7658,18 @@ block_695 = {
     { op:'dup', idx:0 },
     { op:'set_local', idx:2 },
     { op:'pop' },
-    { op:'jump', to:@block_700 },
+    { op:'jump', to:@block_879 },
   ]
 };
 
-block_699 = {
+block_878 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_700 },
+    { op:'jump', to:@block_879 },
   ]
 };
 
-block_700 = {
+block_879 = {
   instrs: [
     { op:'push', val:$false },
     { op:'set_local', idx:3 },
@@ -6321,27 +7680,27 @@ block_700 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_701, num_args:2 },
+    { op:'call', ret_to:@block_880, num_args:2 },
   ]
 };
 
-block_701 = {
+block_880 = {
   instrs: [
-    { op:'call', ret_to:@block_702, num_args:2 },
+    { op:'call', ret_to:@block_881, num_args:2 },
   ]
 };
 
-block_704 = {
+block_883 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_705, num_args:1 },
+    { op:'call', ret_to:@block_884, num_args:1 },
   ]
 };
 
-block_705 = {
+block_884 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'set_local', idx:3 },
@@ -6353,23 +7712,23 @@ block_705 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_706, num_args:2 },
+    { op:'call', ret_to:@block_885, num_args:2 },
   ]
 };
 
-block_706 = {
+block_885 = {
   instrs: [
-    { op:'call', ret_to:@block_707, num_args:2 },
+    { op:'call', ret_to:@block_886, num_args:2 },
   ]
 };
 
-block_702 = {
+block_881 = {
   instrs: [
-    { op:'if_true', then:@block_703, else:@block_704 },
+    { op:'if_true', then:@block_882, else:@block_883 },
   ]
 };
 
-block_703 = {
+block_882 = {
   instrs: [
     { op:'push', val:1 },
     { op:'new_object' },
@@ -6386,28 +7745,28 @@ block_703 = {
     { op:'dup', idx:0 },
     { op:'set_local', idx:3 },
     { op:'pop' },
-    { op:'jump', to:@block_708 },
+    { op:'jump', to:@block_887 },
   ]
 };
 
-block_707 = {
+block_886 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_708 },
+    { op:'jump', to:@block_887 },
   ]
 };
 
-block_708 = {
+block_887 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseStmt' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_709, num_args:1 },
+    { op:'call', ret_to:@block_888, num_args:1 },
   ]
 };
 
-block_709 = {
+block_888 = {
   instrs: [
     { op:'set_local', idx:4 },
     { op:'push', val:4 },
@@ -6438,31 +7797,31 @@ block_709 = {
   ]
 };
 
-fun_684 = {
-  entry:@block_683,
+fun_863 = {
+  entry:@block_862,
   num_params:1,
   num_locals:5,
 };
 
-block_710 = {
+block_889 = {
   instrs: [
     { op:'push', val:0 },
     { op:'new_array' },
     { op:'set_local', idx:2 },
     { op:'push', val:$true },
     { op:'pop' },
-    { op:'jump', to:@block_712 },
+    { op:'jump', to:@block_891 },
   ]
 };
 
-block_712 = {
+block_891 = {
   instrs: [
     { op:'push', val:$true },
-    { op:'if_true', then:@block_713, else:@block_715 },
+    { op:'if_true', then:@block_892, else:@block_894 },
   ]
 };
 
-block_713 = {
+block_892 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
@@ -6471,45 +7830,45 @@ block_713 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_716, num_args:2 },
+    { op:'call', ret_to:@block_895, num_args:2 },
   ]
 };
 
-block_716 = {
+block_895 = {
   instrs: [
-    { op:'call', ret_to:@block_717, num_args:2 },
+    { op:'call', ret_to:@block_896, num_args:2 },
   ]
 };
 
-block_718 = {
+block_897 = {
   instrs: [
-    { op:'jump', to:@block_715 },
+    { op:'jump', to:@block_894 },
   ]
 };
 
-block_717 = {
+block_896 = {
   instrs: [
-    { op:'if_true', then:@block_718, else:@block_719 },
+    { op:'if_true', then:@block_897, else:@block_898 },
   ]
 };
 
-block_719 = {
+block_898 = {
   instrs: [
-    { op:'jump', to:@block_720 },
+    { op:'jump', to:@block_899 },
   ]
 };
 
-block_720 = {
+block_899 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_721, num_args:1 },
+    { op:'call', ret_to:@block_900, num_args:1 },
   ]
 };
 
-block_721 = {
+block_900 = {
   instrs: [
     { op:'set_local', idx:3 },
     { op:'get_local', idx:2 },
@@ -6519,17 +7878,17 @@ block_721 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_722, num_args:2 },
+    { op:'call', ret_to:@block_901, num_args:2 },
   ]
 };
 
-block_722 = {
+block_901 = {
   instrs: [
-    { op:'call', ret_to:@block_723, num_args:2 },
+    { op:'call', ret_to:@block_902, num_args:2 },
   ]
 };
 
-block_723 = {
+block_902 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -6539,35 +7898,35 @@ block_723 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_724, num_args:2 },
+    { op:'call', ret_to:@block_903, num_args:2 },
   ]
 };
 
-block_724 = {
+block_903 = {
   instrs: [
-    { op:'call', ret_to:@block_725, num_args:2 },
+    { op:'call', ret_to:@block_904, num_args:2 },
   ]
 };
 
-block_726 = {
+block_905 = {
   instrs: [
-    { op:'jump', to:@block_715 },
+    { op:'jump', to:@block_894 },
   ]
 };
 
-block_725 = {
+block_904 = {
   instrs: [
-    { op:'if_true', then:@block_726, else:@block_727 },
+    { op:'if_true', then:@block_905, else:@block_906 },
   ]
 };
 
-block_727 = {
+block_906 = {
   instrs: [
-    { op:'jump', to:@block_728 },
+    { op:'jump', to:@block_907 },
   ]
 };
 
-block_728 = {
+block_907 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:',' },
@@ -6576,45 +7935,45 @@ block_728 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_729, num_args:2 },
+    { op:'call', ret_to:@block_908, num_args:2 },
   ]
 };
 
-block_729 = {
+block_908 = {
   instrs: [
-    { op:'call', ret_to:@block_730, num_args:2 },
+    { op:'call', ret_to:@block_909, num_args:2 },
   ]
 };
 
-block_730 = {
+block_909 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_714 },
+    { op:'jump', to:@block_893 },
   ]
 };
 
-block_714 = {
+block_893 = {
   instrs: [
     { op:'push', val:$true },
     { op:'pop' },
-    { op:'jump', to:@block_712 },
+    { op:'jump', to:@block_891 },
   ]
 };
 
-block_715 = {
+block_894 = {
   instrs: [
     { op:'get_local', idx:2 },
     { op:'ret' },
   ]
 };
 
-fun_711 = {
-  entry:@block_710,
+fun_890 = {
+  entry:@block_889,
   num_params:2,
   num_locals:4,
 };
 
-block_731 = {
+block_910 = {
   instrs: [
     { op:'push', val:0 },
     { op:'new_array' },
@@ -6624,18 +7983,18 @@ block_731 = {
     { op:'set_local', idx:2 },
     { op:'push', val:$true },
     { op:'pop' },
-    { op:'jump', to:@block_733 },
+    { op:'jump', to:@block_912 },
   ]
 };
 
-block_733 = {
+block_912 = {
   instrs: [
     { op:'push', val:$true },
-    { op:'if_true', then:@block_734, else:@block_736 },
+    { op:'if_true', then:@block_913, else:@block_915 },
   ]
 };
 
-block_734 = {
+block_913 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'}' },
@@ -6644,45 +8003,45 @@ block_734 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_737, num_args:2 },
+    { op:'call', ret_to:@block_916, num_args:2 },
   ]
 };
 
-block_737 = {
+block_916 = {
   instrs: [
-    { op:'call', ret_to:@block_738, num_args:2 },
+    { op:'call', ret_to:@block_917, num_args:2 },
   ]
 };
 
-block_739 = {
+block_918 = {
   instrs: [
-    { op:'jump', to:@block_736 },
+    { op:'jump', to:@block_915 },
   ]
 };
 
-block_738 = {
+block_917 = {
   instrs: [
-    { op:'if_true', then:@block_739, else:@block_740 },
+    { op:'if_true', then:@block_918, else:@block_919 },
   ]
 };
 
-block_740 = {
+block_919 = {
   instrs: [
-    { op:'jump', to:@block_741 },
+    { op:'jump', to:@block_920 },
   ]
 };
 
-block_741 = {
+block_920 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseIdentStr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_742, num_args:1 },
+    { op:'call', ret_to:@block_921, num_args:1 },
   ]
 };
 
-block_742 = {
+block_921 = {
   instrs: [
     { op:'set_local', idx:3 },
     { op:'get_local', idx:0 },
@@ -6692,28 +8051,28 @@ block_742 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_743, num_args:2 },
+    { op:'call', ret_to:@block_922, num_args:2 },
   ]
 };
 
-block_743 = {
+block_922 = {
   instrs: [
-    { op:'call', ret_to:@block_744, num_args:2 },
+    { op:'call', ret_to:@block_923, num_args:2 },
   ]
 };
 
-block_744 = {
+block_923 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_745, num_args:1 },
+    { op:'call', ret_to:@block_924, num_args:1 },
   ]
 };
 
-block_745 = {
+block_924 = {
   instrs: [
     { op:'set_local', idx:4 },
     { op:'get_local', idx:1 },
@@ -6723,17 +8082,17 @@ block_745 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_746, num_args:2 },
+    { op:'call', ret_to:@block_925, num_args:2 },
   ]
 };
 
-block_746 = {
+block_925 = {
   instrs: [
-    { op:'call', ret_to:@block_747, num_args:2 },
+    { op:'call', ret_to:@block_926, num_args:2 },
   ]
 };
 
-block_747 = {
+block_926 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:2 },
@@ -6743,17 +8102,17 @@ block_747 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_748, num_args:2 },
+    { op:'call', ret_to:@block_927, num_args:2 },
   ]
 };
 
-block_748 = {
+block_927 = {
   instrs: [
-    { op:'call', ret_to:@block_749, num_args:2 },
+    { op:'call', ret_to:@block_928, num_args:2 },
   ]
 };
 
-block_749 = {
+block_928 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -6763,35 +8122,35 @@ block_749 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_750, num_args:2 },
+    { op:'call', ret_to:@block_929, num_args:2 },
   ]
 };
 
-block_750 = {
+block_929 = {
   instrs: [
-    { op:'call', ret_to:@block_751, num_args:2 },
+    { op:'call', ret_to:@block_930, num_args:2 },
   ]
 };
 
-block_752 = {
+block_931 = {
   instrs: [
-    { op:'jump', to:@block_736 },
+    { op:'jump', to:@block_915 },
   ]
 };
 
-block_751 = {
+block_930 = {
   instrs: [
-    { op:'if_true', then:@block_752, else:@block_753 },
+    { op:'if_true', then:@block_931, else:@block_932 },
   ]
 };
 
-block_753 = {
+block_932 = {
   instrs: [
-    { op:'jump', to:@block_754 },
+    { op:'jump', to:@block_933 },
   ]
 };
 
-block_754 = {
+block_933 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:',' },
@@ -6800,32 +8159,32 @@ block_754 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_755, num_args:2 },
+    { op:'call', ret_to:@block_934, num_args:2 },
   ]
 };
 
-block_755 = {
+block_934 = {
   instrs: [
-    { op:'call', ret_to:@block_756, num_args:2 },
+    { op:'call', ret_to:@block_935, num_args:2 },
   ]
 };
 
-block_756 = {
+block_935 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_735 },
+    { op:'jump', to:@block_914 },
   ]
 };
 
-block_735 = {
+block_914 = {
   instrs: [
     { op:'push', val:$true },
     { op:'pop' },
-    { op:'jump', to:@block_733 },
+    { op:'jump', to:@block_912 },
   ]
 };
 
-block_736 = {
+block_915 = {
   instrs: [
     { op:'push', val:2 },
     { op:'new_object' },
@@ -6847,13 +8206,13 @@ block_736 = {
   ]
 };
 
-fun_732 = {
-  entry:@block_731,
+fun_911 = {
+  entry:@block_910,
   num_params:1,
   num_locals:5,
 };
 
-block_757 = {
+block_936 = {
   instrs: [
     { op:'push', val:'' },
     { op:'set_local', idx:1 },
@@ -6864,57 +8223,57 @@ block_757 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_759, num_args:2 },
+    { op:'call', ret_to:@block_938, num_args:2 },
   ]
 };
 
-block_759 = {
+block_938 = {
   instrs: [
-    { op:'call', ret_to:@block_760, num_args:2 },
+    { op:'call', ret_to:@block_939, num_args:2 },
   ]
 };
 
-block_760 = {
+block_939 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_not' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_761, num_args:1 },
+    { op:'call', ret_to:@block_940, num_args:1 },
   ]
 };
 
-block_762 = {
+block_941 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseIdentStr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_763, num_args:1 },
+    { op:'call', ret_to:@block_942, num_args:1 },
   ]
 };
 
-block_761 = {
+block_940 = {
   instrs: [
-    { op:'if_true', then:@block_762, else:@block_764 },
+    { op:'if_true', then:@block_941, else:@block_943 },
   ]
 };
 
-block_763 = {
+block_942 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'set_local', idx:1 },
     { op:'pop' },
-    { op:'jump', to:@block_765 },
+    { op:'jump', to:@block_944 },
   ]
 };
 
-block_764 = {
+block_943 = {
   instrs: [
-    { op:'jump', to:@block_765 },
+    { op:'jump', to:@block_944 },
   ]
 };
 
-block_765 = {
+block_944 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'(' },
@@ -6923,17 +8282,17 @@ block_765 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_766, num_args:2 },
+    { op:'call', ret_to:@block_945, num_args:2 },
   ]
 };
 
-block_766 = {
+block_945 = {
   instrs: [
-    { op:'call', ret_to:@block_767, num_args:2 },
+    { op:'call', ret_to:@block_946, num_args:2 },
   ]
 };
 
-block_767 = {
+block_946 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:0 },
@@ -6941,18 +8300,18 @@ block_767 = {
     { op:'set_local', idx:2 },
     { op:'push', val:$true },
     { op:'pop' },
-    { op:'jump', to:@block_768 },
+    { op:'jump', to:@block_947 },
   ]
 };
 
-block_768 = {
+block_947 = {
   instrs: [
     { op:'push', val:$true },
-    { op:'if_true', then:@block_769, else:@block_771 },
+    { op:'if_true', then:@block_948, else:@block_950 },
   ]
 };
 
-block_769 = {
+block_948 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:')' },
@@ -6961,45 +8320,45 @@ block_769 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_772, num_args:2 },
+    { op:'call', ret_to:@block_951, num_args:2 },
   ]
 };
 
-block_772 = {
+block_951 = {
   instrs: [
-    { op:'call', ret_to:@block_773, num_args:2 },
+    { op:'call', ret_to:@block_952, num_args:2 },
   ]
 };
 
-block_774 = {
+block_953 = {
   instrs: [
-    { op:'jump', to:@block_771 },
+    { op:'jump', to:@block_950 },
   ]
 };
 
-block_773 = {
+block_952 = {
   instrs: [
-    { op:'if_true', then:@block_774, else:@block_775 },
+    { op:'if_true', then:@block_953, else:@block_954 },
   ]
 };
 
-block_775 = {
+block_954 = {
   instrs: [
-    { op:'jump', to:@block_776 },
+    { op:'jump', to:@block_955 },
   ]
 };
 
-block_776 = {
+block_955 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseIdentStr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_777, num_args:1 },
+    { op:'call', ret_to:@block_956, num_args:1 },
   ]
 };
 
-block_777 = {
+block_956 = {
   instrs: [
     { op:'set_local', idx:3 },
     { op:'get_local', idx:2 },
@@ -7009,17 +8368,17 @@ block_777 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_778, num_args:2 },
+    { op:'call', ret_to:@block_957, num_args:2 },
   ]
 };
 
-block_778 = {
+block_957 = {
   instrs: [
-    { op:'call', ret_to:@block_779, num_args:2 },
+    { op:'call', ret_to:@block_958, num_args:2 },
   ]
 };
 
-block_779 = {
+block_958 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -7029,35 +8388,35 @@ block_779 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_780, num_args:2 },
+    { op:'call', ret_to:@block_959, num_args:2 },
   ]
 };
 
-block_780 = {
+block_959 = {
   instrs: [
-    { op:'call', ret_to:@block_781, num_args:2 },
+    { op:'call', ret_to:@block_960, num_args:2 },
   ]
 };
 
-block_782 = {
+block_961 = {
   instrs: [
-    { op:'jump', to:@block_771 },
+    { op:'jump', to:@block_950 },
   ]
 };
 
-block_781 = {
+block_960 = {
   instrs: [
-    { op:'if_true', then:@block_782, else:@block_783 },
+    { op:'if_true', then:@block_961, else:@block_962 },
   ]
 };
 
-block_783 = {
+block_962 = {
   instrs: [
-    { op:'jump', to:@block_784 },
+    { op:'jump', to:@block_963 },
   ]
 };
 
-block_784 = {
+block_963 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:',' },
@@ -7066,32 +8425,32 @@ block_784 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_785, num_args:2 },
+    { op:'call', ret_to:@block_964, num_args:2 },
   ]
 };
 
-block_785 = {
+block_964 = {
   instrs: [
-    { op:'call', ret_to:@block_786, num_args:2 },
+    { op:'call', ret_to:@block_965, num_args:2 },
   ]
 };
 
-block_786 = {
+block_965 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_770 },
+    { op:'jump', to:@block_949 },
   ]
 };
 
-block_770 = {
+block_949 = {
   instrs: [
     { op:'push', val:$true },
     { op:'pop' },
-    { op:'jump', to:@block_768 },
+    { op:'jump', to:@block_947 },
   ]
 };
 
-block_771 = {
+block_950 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'{' },
@@ -7100,17 +8459,17 @@ block_771 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_787, num_args:2 },
+    { op:'call', ret_to:@block_966, num_args:2 },
   ]
 };
 
-block_787 = {
+block_966 = {
   instrs: [
-    { op:'call', ret_to:@block_788, num_args:2 },
+    { op:'call', ret_to:@block_967, num_args:2 },
   ]
 };
 
-block_788 = {
+block_967 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -7118,11 +8477,11 @@ block_788 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'parseBlockStmt' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_789, num_args:2 },
+    { op:'call', ret_to:@block_968, num_args:2 },
   ]
 };
 
-block_789 = {
+block_968 = {
   instrs: [
     { op:'set_local', idx:4 },
     { op:'push', val:3 },
@@ -7149,13 +8508,13 @@ block_789 = {
   ]
 };
 
-fun_758 = {
-  entry:@block_757,
+fun_937 = {
+  entry:@block_936,
   num_params:1,
   num_locals:5,
 };
 
-block_790 = {
+block_969 = {
   instrs: [
     { op:'push', val:$false },
     { op:'set_local', idx:3 },
@@ -7163,11 +8522,11 @@ block_790 = {
     { op:'set_local', idx:4 },
     { op:'push', val:0 },
     { op:'set_local', idx:5 },
-    { op:'jump', to:@block_792 },
+    { op:'jump', to:@block_971 },
   ]
 };
 
-block_792 = {
+block_971 = {
   instrs: [
     { op:'get_local', idx:5 },
     { op:'push', val:@global_obj },
@@ -7177,18 +8536,26 @@ block_792 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_796, num_args:2 },
+    { op:'call', ret_to:@block_975, num_args:2 },
   ]
 };
 
-block_796 = {
+block_975 = {
   instrs: [
-    { op:'lt_i32' },
-    { op:'if_true', then:@block_793, else:@block_795 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_lt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_976, num_args:2 },
   ]
 };
 
-block_793 = {
+block_976 = {
+  instrs: [
+    { op:'if_true', then:@block_972, else:@block_974 },
+  ]
+};
+
+block_972 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'opList' },
@@ -7197,11 +8564,11 @@ block_793 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getElem' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_797, num_args:2 },
+    { op:'call', ret_to:@block_977, num_args:2 },
   ]
 };
 
-block_797 = {
+block_977 = {
   instrs: [
     { op:'set_local', idx:6 },
     { op:'get_local', idx:0 },
@@ -7210,84 +8577,92 @@ block_797 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_798, num_args:2 },
+    { op:'call', ret_to:@block_978, num_args:2 },
   ]
 };
 
-block_798 = {
+block_978 = {
   instrs: [
     { op:'dup', idx:1 },
     { op:'push', val:'next' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_799, num_args:2 },
+    { op:'call', ret_to:@block_979, num_args:2 },
   ]
 };
 
-block_799 = {
+block_979 = {
   instrs: [
-    { op:'call', ret_to:@block_800, num_args:2 },
+    { op:'call', ret_to:@block_980, num_args:2 },
   ]
 };
 
-block_800 = {
+block_980 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_not' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_801, num_args:1 },
+    { op:'call', ret_to:@block_981, num_args:1 },
   ]
 };
 
-block_802 = {
+block_982 = {
   instrs: [
-    { op:'jump', to:@block_794 },
+    { op:'jump', to:@block_973 },
   ]
 };
 
-block_801 = {
+block_981 = {
   instrs: [
-    { op:'if_true', then:@block_802, else:@block_803 },
+    { op:'if_true', then:@block_982, else:@block_983 },
   ]
 };
 
-block_803 = {
+block_983 = {
   instrs: [
-    { op:'jump', to:@block_804 },
+    { op:'jump', to:@block_984 },
   ]
 };
 
-block_804 = {
+block_984 = {
   instrs: [
     { op:'get_local', idx:6 },
     { op:'push', val:'prec' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_811, num_args:2 },
+    { op:'call', ret_to:@block_991, num_args:2 },
   ]
 };
 
-block_811 = {
+block_991 = {
   instrs: [
     { op:'get_local', idx:1 },
-    { op:'lt_i32' },
-    { op:'dup', idx:0 },
-    { op:'if_true', then:@block_810, else:@block_809 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_lt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_992, num_args:2 },
   ]
 };
 
-block_809 = {
+block_992 = {
+  instrs: [
+    { op:'dup', idx:0 },
+    { op:'if_true', then:@block_990, else:@block_989 },
+  ]
+};
+
+block_989 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:2 },
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_812, else:@block_813 },
+    { op:'if_true', then:@block_993, else:@block_994 },
   ]
 };
 
-block_812 = {
+block_993 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:6 },
@@ -7295,58 +8670,58 @@ block_812 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_814, num_args:2 },
+    { op:'call', ret_to:@block_995, num_args:2 },
   ]
 };
 
-block_814 = {
+block_995 = {
   instrs: [
     { op:'push', val:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_ne' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_815, num_args:2 },
+    { op:'call', ret_to:@block_996, num_args:2 },
   ]
 };
 
-block_815 = {
+block_996 = {
   instrs: [
-    { op:'jump', to:@block_813 },
+    { op:'jump', to:@block_994 },
   ]
 };
 
-block_813 = {
+block_994 = {
   instrs: [
-    { op:'jump', to:@block_810 },
+    { op:'jump', to:@block_990 },
   ]
 };
 
-block_810 = {
+block_990 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_808, else:@block_807 },
+    { op:'if_true', then:@block_988, else:@block_987 },
   ]
 };
 
-block_807 = {
+block_987 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:2 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_not' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_818, num_args:1 },
+    { op:'call', ret_to:@block_999, num_args:1 },
   ]
 };
 
-block_818 = {
+block_999 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_816, else:@block_817 },
+    { op:'if_true', then:@block_997, else:@block_998 },
   ]
 };
 
-block_816 = {
+block_997 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:6 },
@@ -7354,49 +8729,49 @@ block_816 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_819, num_args:2 },
+    { op:'call', ret_to:@block_1000, num_args:2 },
   ]
 };
 
-block_819 = {
+block_1000 = {
   instrs: [
     { op:'push', val:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_820, num_args:2 },
+    { op:'call', ret_to:@block_1001, num_args:2 },
   ]
 };
 
-block_820 = {
+block_1001 = {
   instrs: [
-    { op:'jump', to:@block_817 },
+    { op:'jump', to:@block_998 },
   ]
 };
 
-block_817 = {
+block_998 = {
   instrs: [
-    { op:'jump', to:@block_808 },
+    { op:'jump', to:@block_988 },
   ]
 };
 
-block_808 = {
+block_988 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_806, else:@block_805 },
+    { op:'if_true', then:@block_986, else:@block_985 },
   ]
 };
 
-block_805 = {
+block_985 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:2 },
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_821, else:@block_822 },
+    { op:'if_true', then:@block_1002, else:@block_1003 },
   ]
 };
 
-block_821 = {
+block_1002 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:6 },
@@ -7404,82 +8779,90 @@ block_821 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_823, num_args:2 },
+    { op:'call', ret_to:@block_1004, num_args:2 },
   ]
 };
 
-block_823 = {
+block_1004 = {
   instrs: [
     { op:'push', val:'r' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_ne' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_824, num_args:2 },
+    { op:'call', ret_to:@block_1005, num_args:2 },
   ]
 };
 
-block_824 = {
+block_1005 = {
   instrs: [
-    { op:'jump', to:@block_822 },
+    { op:'jump', to:@block_1003 },
   ]
 };
 
-block_822 = {
+block_1003 = {
   instrs: [
-    { op:'jump', to:@block_806 },
+    { op:'jump', to:@block_986 },
   ]
 };
 
-block_825 = {
+block_1006 = {
   instrs: [
-    { op:'jump', to:@block_794 },
+    { op:'jump', to:@block_973 },
   ]
 };
 
-block_806 = {
+block_986 = {
   instrs: [
-    { op:'if_true', then:@block_825, else:@block_826 },
+    { op:'if_true', then:@block_1006, else:@block_1007 },
   ]
 };
 
-block_826 = {
+block_1007 = {
   instrs: [
-    { op:'jump', to:@block_827 },
+    { op:'jump', to:@block_1008 },
   ]
 };
 
-block_827 = {
+block_1008 = {
   instrs: [
     { op:'get_local', idx:6 },
     { op:'push', val:'str' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_828, num_args:2 },
+    { op:'call', ret_to:@block_1009, num_args:2 },
   ]
 };
 
-block_828 = {
+block_1009 = {
   instrs: [
     { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_829, num_args:2 },
+    { op:'call', ret_to:@block_1010, num_args:2 },
   ]
 };
 
-block_829 = {
+block_1010 = {
   instrs: [
     { op:'set_local', idx:7 },
     { op:'get_local', idx:7 },
     { op:'get_local', idx:4 },
-    { op:'gt_i32' },
-    { op:'if_true', then:@block_830, else:@block_831 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_gt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1011, num_args:2 },
   ]
 };
 
-block_830 = {
+block_1011 = {
+  instrs: [
+    { op:'if_true', then:@block_1012, else:@block_1013 },
+  ]
+};
+
+block_1012 = {
   instrs: [
     { op:'get_local', idx:6 },
     { op:'dup', idx:0 },
@@ -7489,73 +8872,73 @@ block_830 = {
     { op:'dup', idx:0 },
     { op:'set_local', idx:4 },
     { op:'pop' },
-    { op:'jump', to:@block_832 },
+    { op:'jump', to:@block_1014 },
   ]
 };
 
-block_831 = {
+block_1013 = {
   instrs: [
-    { op:'jump', to:@block_832 },
+    { op:'jump', to:@block_1014 },
   ]
 };
 
-block_832 = {
+block_1014 = {
   instrs: [
-    { op:'jump', to:@block_794 },
+    { op:'jump', to:@block_973 },
   ]
 };
 
-block_794 = {
+block_973 = {
   instrs: [
     { op:'get_local', idx:5 },
     { op:'push', val:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_add' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_833, num_args:2 },
+    { op:'call', ret_to:@block_1015, num_args:2 },
   ]
 };
 
-block_833 = {
+block_1015 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'set_local', idx:5 },
     { op:'pop' },
-    { op:'jump', to:@block_792 },
+    { op:'jump', to:@block_971 },
   ]
 };
 
-block_795 = {
+block_974 = {
   instrs: [
     { op:'get_local', idx:3 },
     { op:'push', val:$false },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_834, num_args:2 },
+    { op:'call', ret_to:@block_1016, num_args:2 },
   ]
 };
 
-block_835 = {
+block_1017 = {
   instrs: [
     { op:'push', val:$false },
     { op:'ret' },
   ]
 };
 
-block_834 = {
+block_1016 = {
   instrs: [
-    { op:'if_true', then:@block_835, else:@block_836 },
+    { op:'if_true', then:@block_1017, else:@block_1018 },
   ]
 };
 
-block_836 = {
+block_1018 = {
   instrs: [
-    { op:'jump', to:@block_837 },
+    { op:'jump', to:@block_1019 },
   ]
 };
 
-block_837 = {
+block_1019 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:3 },
@@ -7563,28 +8946,28 @@ block_837 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_838, num_args:2 },
+    { op:'call', ret_to:@block_1020, num_args:2 },
   ]
 };
 
-block_838 = {
+block_1020 = {
   instrs: [
     { op:'dup', idx:1 },
     { op:'push', val:'expect' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_839, num_args:2 },
+    { op:'call', ret_to:@block_1021, num_args:2 },
   ]
 };
 
-block_839 = {
+block_1021 = {
   instrs: [
-    { op:'call', ret_to:@block_840, num_args:2 },
+    { op:'call', ret_to:@block_1022, num_args:2 },
   ]
 };
 
-block_840 = {
+block_1022 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:3 },
@@ -7592,13 +8975,13 @@ block_840 = {
   ]
 };
 
-fun_791 = {
-  entry:@block_790,
+fun_970 = {
+  entry:@block_969,
   num_params:3,
   num_locals:8,
 };
 
-block_841 = {
+block_1023 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'dup', idx:0 },
@@ -7606,17 +8989,17 @@ block_841 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_843, num_args:2 },
+    { op:'call', ret_to:@block_1025, num_args:2 },
   ]
 };
 
-block_843 = {
+block_1025 = {
   instrs: [
-    { op:'call', ret_to:@block_844, num_args:1 },
+    { op:'call', ret_to:@block_1026, num_args:1 },
   ]
 };
 
-block_844 = {
+block_1026 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -7625,55 +9008,55 @@ block_844 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_845, num_args:2 },
+    { op:'call', ret_to:@block_1027, num_args:2 },
   ]
 };
 
-block_845 = {
+block_1027 = {
   instrs: [
-    { op:'call', ret_to:@block_846, num_args:1 },
+    { op:'call', ret_to:@block_1028, num_args:1 },
   ]
 };
 
-block_846 = {
+block_1028 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'isDigit' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_847, num_args:1 },
+    { op:'call', ret_to:@block_1029, num_args:1 },
   ]
 };
 
-block_848 = {
+block_1030 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:$false },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseInt' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_849, num_args:2 },
+    { op:'call', ret_to:@block_1031, num_args:2 },
   ]
 };
 
-block_849 = {
+block_1031 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-block_847 = {
+block_1029 = {
   instrs: [
-    { op:'if_true', then:@block_848, else:@block_850 },
+    { op:'if_true', then:@block_1030, else:@block_1032 },
   ]
 };
 
-block_850 = {
+block_1032 = {
   instrs: [
-    { op:'jump', to:@block_851 },
+    { op:'jump', to:@block_1033 },
   ]
 };
 
-block_851 = {
+block_1033 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'\'' },
@@ -7682,46 +9065,46 @@ block_851 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_852, num_args:2 },
+    { op:'call', ret_to:@block_1034, num_args:2 },
   ]
 };
 
-block_852 = {
+block_1034 = {
   instrs: [
-    { op:'call', ret_to:@block_853, num_args:2 },
+    { op:'call', ret_to:@block_1035, num_args:2 },
   ]
 };
 
-block_854 = {
+block_1036 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'\'' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseStringLit' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_855, num_args:2 },
+    { op:'call', ret_to:@block_1037, num_args:2 },
   ]
 };
 
-block_855 = {
+block_1037 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-block_853 = {
+block_1035 = {
   instrs: [
-    { op:'if_true', then:@block_854, else:@block_856 },
+    { op:'if_true', then:@block_1036, else:@block_1038 },
   ]
 };
 
-block_856 = {
+block_1038 = {
   instrs: [
-    { op:'jump', to:@block_857 },
+    { op:'jump', to:@block_1039 },
   ]
 };
 
-block_857 = {
+block_1039 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'\"' },
@@ -7730,46 +9113,46 @@ block_857 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_858, num_args:2 },
+    { op:'call', ret_to:@block_1040, num_args:2 },
   ]
 };
 
-block_858 = {
+block_1040 = {
   instrs: [
-    { op:'call', ret_to:@block_859, num_args:2 },
+    { op:'call', ret_to:@block_1041, num_args:2 },
   ]
 };
 
-block_860 = {
+block_1042 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'\"' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseStringLit' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_861, num_args:2 },
+    { op:'call', ret_to:@block_1043, num_args:2 },
   ]
 };
 
-block_861 = {
+block_1043 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-block_859 = {
+block_1041 = {
   instrs: [
-    { op:'if_true', then:@block_860, else:@block_862 },
+    { op:'if_true', then:@block_1042, else:@block_1044 },
   ]
 };
 
-block_862 = {
+block_1044 = {
   instrs: [
-    { op:'jump', to:@block_863 },
+    { op:'jump', to:@block_1045 },
   ]
 };
 
-block_863 = {
+block_1045 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'[' },
@@ -7778,17 +9161,17 @@ block_863 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_864, num_args:2 },
+    { op:'call', ret_to:@block_1046, num_args:2 },
   ]
 };
 
-block_864 = {
+block_1046 = {
   instrs: [
-    { op:'call', ret_to:@block_865, num_args:2 },
+    { op:'call', ret_to:@block_1047, num_args:2 },
   ]
 };
 
-block_866 = {
+block_1048 = {
   instrs: [
     { op:'push', val:1 },
     { op:'new_object' },
@@ -7805,30 +9188,30 @@ block_866 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExprList' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_867, num_args:2 },
+    { op:'call', ret_to:@block_1049, num_args:2 },
   ]
 };
 
-block_867 = {
+block_1049 = {
   instrs: [
     { op:'set_field' },
     { op:'ret' },
   ]
 };
 
-block_865 = {
+block_1047 = {
   instrs: [
-    { op:'if_true', then:@block_866, else:@block_868 },
+    { op:'if_true', then:@block_1048, else:@block_1050 },
   ]
 };
 
-block_868 = {
+block_1050 = {
   instrs: [
-    { op:'jump', to:@block_869 },
+    { op:'jump', to:@block_1051 },
   ]
 };
 
-block_869 = {
+block_1051 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'{' },
@@ -7837,45 +9220,45 @@ block_869 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_870, num_args:2 },
+    { op:'call', ret_to:@block_1052, num_args:2 },
   ]
 };
 
-block_870 = {
+block_1052 = {
   instrs: [
-    { op:'call', ret_to:@block_871, num_args:2 },
+    { op:'call', ret_to:@block_1053, num_args:2 },
   ]
 };
 
-block_872 = {
+block_1054 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseObjExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_873, num_args:1 },
+    { op:'call', ret_to:@block_1055, num_args:1 },
   ]
 };
 
-block_873 = {
+block_1055 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-block_871 = {
+block_1053 = {
   instrs: [
-    { op:'if_true', then:@block_872, else:@block_874 },
+    { op:'if_true', then:@block_1054, else:@block_1056 },
   ]
 };
 
-block_874 = {
+block_1056 = {
   instrs: [
-    { op:'jump', to:@block_875 },
+    { op:'jump', to:@block_1057 },
   ]
 };
 
-block_875 = {
+block_1057 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'(' },
@@ -7884,27 +9267,27 @@ block_875 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_876, num_args:2 },
+    { op:'call', ret_to:@block_1058, num_args:2 },
   ]
 };
 
-block_876 = {
+block_1058 = {
   instrs: [
-    { op:'call', ret_to:@block_877, num_args:2 },
+    { op:'call', ret_to:@block_1059, num_args:2 },
   ]
 };
 
-block_878 = {
+block_1060 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_879, num_args:1 },
+    { op:'call', ret_to:@block_1061, num_args:1 },
   ]
 };
 
-block_879 = {
+block_1061 = {
   instrs: [
     { op:'set_local', idx:1 },
     { op:'get_local', idx:0 },
@@ -7914,17 +9297,17 @@ block_879 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_880, num_args:2 },
+    { op:'call', ret_to:@block_1062, num_args:2 },
   ]
 };
 
-block_880 = {
+block_1062 = {
   instrs: [
-    { op:'call', ret_to:@block_881, num_args:2 },
+    { op:'call', ret_to:@block_1063, num_args:2 },
   ]
 };
 
-block_881 = {
+block_1063 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:1 },
@@ -7932,19 +9315,19 @@ block_881 = {
   ]
 };
 
-block_877 = {
+block_1059 = {
   instrs: [
-    { op:'if_true', then:@block_878, else:@block_882 },
+    { op:'if_true', then:@block_1060, else:@block_1064 },
   ]
 };
 
-block_882 = {
+block_1064 = {
   instrs: [
-    { op:'jump', to:@block_883 },
+    { op:'jump', to:@block_1065 },
   ]
 };
 
-block_883 = {
+block_1065 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:0 },
@@ -7952,11 +9335,11 @@ block_883 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'matchOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_884, num_args:3 },
+    { op:'call', ret_to:@block_1066, num_args:3 },
   ]
 };
 
-block_884 = {
+block_1066 = {
   instrs: [
     { op:'set_local', idx:2 },
     { op:'get_local', idx:2 },
@@ -7964,11 +9347,11 @@ block_884 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_ne' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_885, num_args:2 },
+    { op:'call', ret_to:@block_1067, num_args:2 },
   ]
 };
 
-block_886 = {
+block_1068 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:2 },
@@ -7976,20 +9359,20 @@ block_886 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_887, num_args:2 },
+    { op:'call', ret_to:@block_1069, num_args:2 },
   ]
 };
 
-block_887 = {
+block_1069 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExprPrec' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_888, num_args:2 },
+    { op:'call', ret_to:@block_1070, num_args:2 },
   ]
 };
 
-block_888 = {
+block_1070 = {
   instrs: [
     { op:'set_local', idx:1 },
     { op:'push', val:2 },
@@ -8012,19 +9395,19 @@ block_888 = {
   ]
 };
 
-block_885 = {
+block_1067 = {
   instrs: [
-    { op:'if_true', then:@block_886, else:@block_889 },
+    { op:'if_true', then:@block_1068, else:@block_1071 },
   ]
 };
 
-block_889 = {
+block_1071 = {
   instrs: [
-    { op:'jump', to:@block_890 },
+    { op:'jump', to:@block_1072 },
   ]
 };
 
-block_890 = {
+block_1072 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'dup', idx:0 },
@@ -8032,26 +9415,26 @@ block_890 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_891, num_args:2 },
+    { op:'call', ret_to:@block_1073, num_args:2 },
   ]
 };
 
-block_891 = {
+block_1073 = {
   instrs: [
-    { op:'call', ret_to:@block_892, num_args:1 },
+    { op:'call', ret_to:@block_1074, num_args:1 },
   ]
 };
 
-block_892 = {
+block_1074 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'isAlnum' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_893, num_args:1 },
+    { op:'call', ret_to:@block_1075, num_args:1 },
   ]
 };
 
-block_894 = {
+block_1076 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'function' },
@@ -8060,45 +9443,45 @@ block_894 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_895, num_args:2 },
+    { op:'call', ret_to:@block_1077, num_args:2 },
   ]
 };
 
-block_895 = {
+block_1077 = {
   instrs: [
-    { op:'call', ret_to:@block_896, num_args:2 },
+    { op:'call', ret_to:@block_1078, num_args:2 },
   ]
 };
 
-block_897 = {
+block_1079 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseFunExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_898, num_args:1 },
+    { op:'call', ret_to:@block_1080, num_args:1 },
   ]
 };
 
-block_898 = {
+block_1080 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-block_896 = {
+block_1078 = {
   instrs: [
-    { op:'if_true', then:@block_897, else:@block_899 },
+    { op:'if_true', then:@block_1079, else:@block_1081 },
   ]
 };
 
-block_899 = {
+block_1081 = {
   instrs: [
-    { op:'jump', to:@block_900 },
+    { op:'jump', to:@block_1082 },
   ]
 };
 
-block_900 = {
+block_1082 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'import' },
@@ -8107,27 +9490,27 @@ block_900 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_901, num_args:2 },
+    { op:'call', ret_to:@block_1083, num_args:2 },
   ]
 };
 
-block_901 = {
+block_1083 = {
   instrs: [
-    { op:'call', ret_to:@block_902, num_args:2 },
+    { op:'call', ret_to:@block_1084, num_args:2 },
   ]
 };
 
-block_903 = {
+block_1085 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseAtom' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_904, num_args:1 },
+    { op:'call', ret_to:@block_1086, num_args:1 },
   ]
 };
 
-block_904 = {
+block_1086 = {
   instrs: [
     { op:'set_local', idx:3 },
     { op:'push', val:'val' },
@@ -8135,50 +9518,50 @@ block_904 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_in' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_905, num_args:2 },
+    { op:'call', ret_to:@block_1087, num_args:2 },
   ]
 };
 
-block_905 = {
+block_1087 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_not' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_906, num_args:1 },
+    { op:'call', ret_to:@block_1088, num_args:1 },
   ]
 };
 
-block_907 = {
+block_1089 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'invalid package name expression' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseError' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_908, num_args:2 },
+    { op:'call', ret_to:@block_1090, num_args:2 },
   ]
 };
 
-block_906 = {
+block_1088 = {
   instrs: [
-    { op:'if_true', then:@block_907, else:@block_909 },
+    { op:'if_true', then:@block_1089, else:@block_1091 },
   ]
 };
 
-block_908 = {
+block_1090 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_910 },
+    { op:'jump', to:@block_1092 },
   ]
 };
 
-block_909 = {
+block_1091 = {
   instrs: [
-    { op:'jump', to:@block_910 },
+    { op:'jump', to:@block_1092 },
   ]
 };
 
-block_910 = {
+block_1092 = {
   instrs: [
     { op:'push', val:1 },
     { op:'new_object' },
@@ -8195,30 +9578,30 @@ block_910 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_911, num_args:2 },
+    { op:'call', ret_to:@block_1093, num_args:2 },
   ]
 };
 
-block_911 = {
+block_1093 = {
   instrs: [
     { op:'set_field' },
     { op:'ret' },
   ]
 };
 
-block_902 = {
+block_1084 = {
   instrs: [
-    { op:'if_true', then:@block_903, else:@block_912 },
+    { op:'if_true', then:@block_1085, else:@block_1094 },
   ]
 };
 
-block_912 = {
+block_1094 = {
   instrs: [
-    { op:'jump', to:@block_913 },
+    { op:'jump', to:@block_1095 },
   ]
 };
 
-block_913 = {
+block_1095 = {
   instrs: [
     { op:'push', val:1 },
     { op:'new_object' },
@@ -8234,30 +9617,30 @@ block_913 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'parseIdentStr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_914, num_args:1 },
+    { op:'call', ret_to:@block_1096, num_args:1 },
   ]
 };
 
-block_914 = {
+block_1096 = {
   instrs: [
     { op:'set_field' },
     { op:'ret' },
   ]
 };
 
-block_893 = {
+block_1075 = {
   instrs: [
-    { op:'if_true', then:@block_894, else:@block_915 },
+    { op:'if_true', then:@block_1076, else:@block_1097 },
   ]
 };
 
-block_915 = {
+block_1097 = {
   instrs: [
-    { op:'jump', to:@block_916 },
+    { op:'jump', to:@block_1098 },
   ]
 };
 
-block_916 = {
+block_1098 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'$' },
@@ -8266,27 +9649,27 @@ block_916 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_917, num_args:2 },
+    { op:'call', ret_to:@block_1099, num_args:2 },
   ]
 };
 
-block_917 = {
+block_1099 = {
   instrs: [
-    { op:'call', ret_to:@block_918, num_args:2 },
+    { op:'call', ret_to:@block_1100, num_args:2 },
   ]
 };
 
-block_919 = {
+block_1101 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseIdentStr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_920, num_args:1 },
+    { op:'call', ret_to:@block_1102, num_args:1 },
   ]
 };
 
-block_920 = {
+block_1102 = {
   instrs: [
     { op:'set_local', idx:4 },
     { op:'get_local', idx:0 },
@@ -8296,17 +9679,17 @@ block_920 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_921, num_args:2 },
+    { op:'call', ret_to:@block_1103, num_args:2 },
   ]
 };
 
-block_921 = {
+block_1103 = {
   instrs: [
-    { op:'call', ret_to:@block_922, num_args:2 },
+    { op:'call', ret_to:@block_1104, num_args:2 },
   ]
 };
 
-block_922 = {
+block_1104 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -8314,11 +9697,11 @@ block_922 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExprList' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_923, num_args:2 },
+    { op:'call', ret_to:@block_1105, num_args:2 },
   ]
 };
 
-block_923 = {
+block_1105 = {
   instrs: [
     { op:'set_local', idx:5 },
     { op:'push', val:2 },
@@ -8341,30 +9724,30 @@ block_923 = {
   ]
 };
 
-block_918 = {
+block_1100 = {
   instrs: [
-    { op:'if_true', then:@block_919, else:@block_924 },
+    { op:'if_true', then:@block_1101, else:@block_1106 },
   ]
 };
 
-block_924 = {
+block_1106 = {
   instrs: [
-    { op:'jump', to:@block_925 },
+    { op:'jump', to:@block_1107 },
   ]
 };
 
-block_925 = {
+block_1107 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'expected atomic expression' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseError' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_926, num_args:2 },
+    { op:'call', ret_to:@block_1108, num_args:2 },
   ]
 };
 
-block_926 = {
+block_1108 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -8372,39 +9755,39 @@ block_926 = {
   ]
 };
 
-fun_842 = {
-  entry:@block_841,
+fun_1024 = {
+  entry:@block_1023,
   num_params:1,
   num_locals:6,
 };
 
-block_927 = {
+block_1109 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseAtom' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_929, num_args:1 },
+    { op:'call', ret_to:@block_1111, num_args:1 },
   ]
 };
 
-block_929 = {
+block_1111 = {
   instrs: [
     { op:'set_local', idx:2 },
     { op:'push', val:$true },
     { op:'pop' },
-    { op:'jump', to:@block_930 },
+    { op:'jump', to:@block_1112 },
   ]
 };
 
-block_930 = {
+block_1112 = {
   instrs: [
     { op:'push', val:$true },
-    { op:'if_true', then:@block_931, else:@block_933 },
+    { op:'if_true', then:@block_1113, else:@block_1115 },
   ]
 };
 
-block_931 = {
+block_1113 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'dup', idx:0 },
@@ -8412,17 +9795,17 @@ block_931 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_934, num_args:2 },
+    { op:'call', ret_to:@block_1116, num_args:2 },
   ]
 };
 
-block_934 = {
+block_1116 = {
   instrs: [
-    { op:'call', ret_to:@block_935, num_args:1 },
+    { op:'call', ret_to:@block_1117, num_args:1 },
   ]
 };
 
-block_935 = {
+block_1117 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -8431,17 +9814,17 @@ block_935 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_936, num_args:2 },
+    { op:'call', ret_to:@block_1118, num_args:2 },
   ]
 };
 
-block_936 = {
+block_1118 = {
   instrs: [
-    { op:'call', ret_to:@block_937, num_args:1 },
+    { op:'call', ret_to:@block_1119, num_args:1 },
   ]
 };
 
-block_937 = {
+block_1119 = {
   instrs: [
     { op:'set_local', idx:3 },
     { op:'get_local', idx:0 },
@@ -8450,11 +9833,11 @@ block_937 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'matchOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_938, num_args:3 },
+    { op:'call', ret_to:@block_1120, num_args:3 },
   ]
 };
 
-block_938 = {
+block_1120 = {
   instrs: [
     { op:'set_local', idx:4 },
     { op:'get_local', idx:4 },
@@ -8462,40 +9845,40 @@ block_938 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_939, num_args:2 },
+    { op:'call', ret_to:@block_1121, num_args:2 },
   ]
 };
 
-block_940 = {
+block_1122 = {
   instrs: [
-    { op:'jump', to:@block_933 },
+    { op:'jump', to:@block_1115 },
   ]
 };
 
-block_939 = {
+block_1121 = {
   instrs: [
-    { op:'if_true', then:@block_940, else:@block_941 },
+    { op:'if_true', then:@block_1122, else:@block_1123 },
   ]
 };
 
-block_941 = {
+block_1123 = {
   instrs: [
-    { op:'jump', to:@block_942 },
+    { op:'jump', to:@block_1124 },
   ]
 };
 
-block_942 = {
+block_1124 = {
   instrs: [
     { op:'get_local', idx:4 },
     { op:'push', val:'prec' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_943, num_args:2 },
+    { op:'call', ret_to:@block_1125, num_args:2 },
   ]
 };
 
-block_943 = {
+block_1125 = {
   instrs: [
     { op:'set_local', idx:5 },
     { op:'get_local', idx:4 },
@@ -8503,108 +9886,116 @@ block_943 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_944, num_args:2 },
+    { op:'call', ret_to:@block_1126, num_args:2 },
   ]
 };
 
-block_944 = {
+block_1126 = {
   instrs: [
     { op:'push', val:'l' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_945, num_args:2 },
+    { op:'call', ret_to:@block_1127, num_args:2 },
   ]
 };
 
-block_946 = {
+block_1128 = {
   instrs: [
     { op:'get_local', idx:4 },
     { op:'push', val:'closeStr' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_947, num_args:2 },
+    { op:'call', ret_to:@block_1129, num_args:2 },
   ]
 };
 
-block_947 = {
+block_1129 = {
   instrs: [
     { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_948, num_args:2 },
+    { op:'call', ret_to:@block_1130, num_args:2 },
   ]
 };
 
-block_950 = {
+block_1130 = {
+  instrs: [
+    { op:'push', val:0 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_gt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1131, num_args:2 },
+  ]
+};
+
+block_1133 = {
   instrs: [
     { op:'get_local', idx:4 },
     { op:'push', val:'prec' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_951, num_args:2 },
+    { op:'call', ret_to:@block_1134, num_args:2 },
   ]
 };
 
-block_951 = {
+block_1134 = {
   instrs: [
     { op:'push', val:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_add' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_952, num_args:2 },
+    { op:'call', ret_to:@block_1135, num_args:2 },
   ]
 };
 
-block_948 = {
+block_1131 = {
   instrs: [
-    { op:'push', val:0 },
-    { op:'gt_i32' },
-    { op:'if_true', then:@block_949, else:@block_950 },
+    { op:'if_true', then:@block_1132, else:@block_1133 },
   ]
 };
 
-block_949 = {
+block_1132 = {
   instrs: [
     { op:'push', val:0 },
     { op:'dup', idx:0 },
     { op:'set_local', idx:5 },
     { op:'pop' },
-    { op:'jump', to:@block_953 },
+    { op:'jump', to:@block_1136 },
   ]
 };
 
-block_952 = {
+block_1135 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'set_local', idx:5 },
     { op:'pop' },
-    { op:'jump', to:@block_953 },
+    { op:'jump', to:@block_1136 },
   ]
 };
 
-block_945 = {
+block_1127 = {
   instrs: [
-    { op:'if_true', then:@block_946, else:@block_954 },
+    { op:'if_true', then:@block_1128, else:@block_1137 },
   ]
 };
 
-block_953 = {
+block_1136 = {
   instrs: [
-    { op:'jump', to:@block_955 },
+    { op:'jump', to:@block_1138 },
   ]
 };
 
-block_954 = {
+block_1137 = {
   instrs: [
-    { op:'jump', to:@block_955 },
+    { op:'jump', to:@block_1138 },
   ]
 };
 
-block_955 = {
+block_1138 = {
   instrs: [
     { op:'get_local', idx:4 },
     { op:'push', val:@global_obj },
@@ -8613,22 +10004,22 @@ block_955 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_956, num_args:2 },
+    { op:'call', ret_to:@block_1139, num_args:2 },
   ]
 };
 
-block_957 = {
+block_1140 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:')' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExprList' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_958, num_args:2 },
+    { op:'call', ret_to:@block_1141, num_args:2 },
   ]
 };
 
-block_959 = {
+block_1142 = {
   instrs: [
     { op:'get_local', idx:4 },
     { op:'push', val:@global_obj },
@@ -8637,21 +10028,21 @@ block_959 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_960, num_args:2 },
+    { op:'call', ret_to:@block_1143, num_args:2 },
   ]
 };
 
-block_961 = {
+block_1144 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseIdentStr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_962, num_args:1 },
+    { op:'call', ret_to:@block_1145, num_args:1 },
   ]
 };
 
-block_962 = {
+block_1145 = {
   instrs: [
     { op:'set_local', idx:7 },
     { op:'get_local', idx:0 },
@@ -8661,17 +10052,17 @@ block_962 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_963, num_args:2 },
+    { op:'call', ret_to:@block_1146, num_args:2 },
   ]
 };
 
-block_963 = {
+block_1146 = {
   instrs: [
-    { op:'call', ret_to:@block_964, num_args:2 },
+    { op:'call', ret_to:@block_1147, num_args:2 },
   ]
 };
 
-block_964 = {
+block_1147 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -8679,11 +10070,11 @@ block_964 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExprList' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_965, num_args:2 },
+    { op:'call', ret_to:@block_1148, num_args:2 },
   ]
 };
 
-block_966 = {
+block_1149 = {
   instrs: [
     { op:'get_local', idx:4 },
     { op:'push', val:@global_obj },
@@ -8692,60 +10083,60 @@ block_966 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_967, num_args:2 },
+    { op:'call', ret_to:@block_1150, num_args:2 },
   ]
 };
 
-block_968 = {
+block_1151 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseIdentStr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_969, num_args:1 },
+    { op:'call', ret_to:@block_1152, num_args:1 },
   ]
 };
 
-block_970 = {
+block_1153 = {
   instrs: [
     { op:'get_local', idx:4 },
     { op:'push', val:'arity' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_971, num_args:2 },
+    { op:'call', ret_to:@block_1154, num_args:2 },
   ]
 };
 
-block_971 = {
+block_1154 = {
   instrs: [
     { op:'push', val:2 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_972, num_args:2 },
+    { op:'call', ret_to:@block_1155, num_args:2 },
   ]
 };
 
-block_973 = {
+block_1156 = {
   instrs: [
     { op:'get_local', idx:4 },
     { op:'push', val:'foldAssign' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_976, num_args:2 },
+    { op:'call', ret_to:@block_1159, num_args:2 },
   ]
 };
 
-block_976 = {
+block_1159 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_974, else:@block_975 },
+    { op:'if_true', then:@block_1157, else:@block_1158 },
   ]
 };
 
-block_974 = {
+block_1157 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -8755,23 +10146,23 @@ block_974 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_977, num_args:2 },
+    { op:'call', ret_to:@block_1160, num_args:2 },
   ]
 };
 
-block_977 = {
+block_1160 = {
   instrs: [
-    { op:'call', ret_to:@block_978, num_args:2 },
+    { op:'call', ret_to:@block_1161, num_args:2 },
   ]
 };
 
-block_978 = {
+block_1161 = {
   instrs: [
-    { op:'jump', to:@block_975 },
+    { op:'jump', to:@block_1158 },
   ]
 };
 
-block_979 = {
+block_1162 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
@@ -8781,41 +10172,41 @@ block_979 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_980, num_args:2 },
+    { op:'call', ret_to:@block_1163, num_args:2 },
   ]
 };
 
-block_980 = {
+block_1163 = {
   instrs: [
     { op:'push', val:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_add' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_981, num_args:2 },
+    { op:'call', ret_to:@block_1164, num_args:2 },
   ]
 };
 
-block_981 = {
+block_1164 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExprPrec' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_982, num_args:2 },
+    { op:'call', ret_to:@block_1165, num_args:2 },
   ]
 };
 
-block_983 = {
+block_1166 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:5 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExprPrec' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_984, num_args:2 },
+    { op:'call', ret_to:@block_1167, num_args:2 },
   ]
 };
 
-block_984 = {
+block_1167 = {
   instrs: [
     { op:'set_local', idx:8 },
     { op:'push', val:3 },
@@ -8846,30 +10237,38 @@ block_984 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_987, num_args:2 },
+    { op:'call', ret_to:@block_1170, num_args:2 },
   ]
 };
 
-block_987 = {
+block_1170 = {
   instrs: [
     { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_988, num_args:2 },
+    { op:'call', ret_to:@block_1171, num_args:2 },
   ]
 };
 
-block_988 = {
+block_1171 = {
   instrs: [
     { op:'push', val:0 },
-    { op:'gt_i32' },
-    { op:'dup', idx:0 },
-    { op:'if_true', then:@block_985, else:@block_986 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_gt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1172, num_args:2 },
   ]
 };
 
-block_985 = {
+block_1172 = {
+  instrs: [
+    { op:'dup', idx:0 },
+    { op:'if_true', then:@block_1168, else:@block_1169 },
+  ]
+};
+
+block_1168 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -8878,79 +10277,79 @@ block_985 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_989, num_args:2 },
+    { op:'call', ret_to:@block_1173, num_args:2 },
   ]
 };
 
-block_989 = {
+block_1173 = {
   instrs: [
     { op:'dup', idx:1 },
     { op:'push', val:'matchWS' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_990, num_args:2 },
+    { op:'call', ret_to:@block_1174, num_args:2 },
   ]
 };
 
-block_990 = {
+block_1174 = {
   instrs: [
-    { op:'call', ret_to:@block_991, num_args:2 },
+    { op:'call', ret_to:@block_1175, num_args:2 },
   ]
 };
 
-block_991 = {
+block_1175 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_not' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_992, num_args:1 },
+    { op:'call', ret_to:@block_1176, num_args:1 },
   ]
 };
 
-block_992 = {
+block_1176 = {
   instrs: [
-    { op:'jump', to:@block_986 },
+    { op:'jump', to:@block_1169 },
   ]
 };
 
-block_993 = {
+block_1177 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'expected operator closing' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseError' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_994, num_args:2 },
+    { op:'call', ret_to:@block_1178, num_args:2 },
   ]
 };
 
-block_986 = {
+block_1169 = {
   instrs: [
-    { op:'if_true', then:@block_993, else:@block_995 },
+    { op:'if_true', then:@block_1177, else:@block_1179 },
   ]
 };
 
-block_994 = {
+block_1178 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_996 },
+    { op:'jump', to:@block_1180 },
   ]
 };
 
-block_995 = {
+block_1179 = {
   instrs: [
-    { op:'jump', to:@block_996 },
+    { op:'jump', to:@block_1180 },
   ]
 };
 
-block_975 = {
+block_1158 = {
   instrs: [
-    { op:'if_true', then:@block_979, else:@block_983 },
+    { op:'if_true', then:@block_1162, else:@block_1166 },
   ]
 };
 
-block_982 = {
+block_1165 = {
   instrs: [
     { op:'set_local', idx:8 },
     { op:'push', val:3 },
@@ -9001,62 +10400,62 @@ block_982 = {
     { op:'dup', idx:0 },
     { op:'set_local', idx:2 },
     { op:'pop' },
-    { op:'jump', to:@block_997 },
+    { op:'jump', to:@block_1181 },
   ]
 };
 
-block_996 = {
+block_1180 = {
   instrs: [
-    { op:'jump', to:@block_997 },
+    { op:'jump', to:@block_1181 },
   ]
 };
 
-block_998 = {
+block_1182 = {
   instrs: [
     { op:'push', val:$false },
-    { op:'if_true', then:@block_999, else:@block_1000 },
+    { op:'if_true', then:@block_1183, else:@block_1184 },
   ]
 };
 
-block_999 = {
+block_1183 = {
   instrs: [
-    { op:'jump', to:@block_1001 },
+    { op:'jump', to:@block_1185 },
   ]
 };
 
-block_1000 = {
+block_1184 = {
   instrs: [
     { op:'push', val:'operator not handled correctly' },
     { op:'abort' },
-    { op:'jump', to:@block_1001 },
+    { op:'jump', to:@block_1185 },
   ]
 };
 
-block_972 = {
+block_1155 = {
   instrs: [
-    { op:'if_true', then:@block_973, else:@block_998 },
+    { op:'if_true', then:@block_1156, else:@block_1182 },
   ]
 };
 
-block_997 = {
+block_1181 = {
   instrs: [
-    { op:'jump', to:@block_1002 },
+    { op:'jump', to:@block_1186 },
   ]
 };
 
-block_1001 = {
+block_1185 = {
   instrs: [
-    { op:'jump', to:@block_1002 },
+    { op:'jump', to:@block_1186 },
   ]
 };
 
-block_967 = {
+block_1150 = {
   instrs: [
-    { op:'if_true', then:@block_968, else:@block_970 },
+    { op:'if_true', then:@block_1151, else:@block_1153 },
   ]
 };
 
-block_969 = {
+block_1152 = {
   instrs: [
     { op:'set_local', idx:7 },
     { op:'push', val:3 },
@@ -9093,23 +10492,23 @@ block_969 = {
     { op:'dup', idx:0 },
     { op:'set_local', idx:2 },
     { op:'pop' },
-    { op:'jump', to:@block_1003 },
+    { op:'jump', to:@block_1187 },
   ]
 };
 
-block_1002 = {
+block_1186 = {
   instrs: [
-    { op:'jump', to:@block_1003 },
+    { op:'jump', to:@block_1187 },
   ]
 };
 
-block_960 = {
+block_1143 = {
   instrs: [
-    { op:'if_true', then:@block_961, else:@block_966 },
+    { op:'if_true', then:@block_1144, else:@block_1149 },
   ]
 };
 
-block_965 = {
+block_1148 = {
   instrs: [
     { op:'set_local', idx:6 },
     { op:'push', val:4 },
@@ -9139,23 +10538,23 @@ block_965 = {
     { op:'dup', idx:0 },
     { op:'set_local', idx:2 },
     { op:'pop' },
-    { op:'jump', to:@block_1004 },
+    { op:'jump', to:@block_1188 },
   ]
 };
 
-block_1003 = {
+block_1187 = {
   instrs: [
-    { op:'jump', to:@block_1004 },
+    { op:'jump', to:@block_1188 },
   ]
 };
 
-block_956 = {
+block_1139 = {
   instrs: [
-    { op:'if_true', then:@block_957, else:@block_959 },
+    { op:'if_true', then:@block_1140, else:@block_1142 },
   ]
 };
 
-block_958 = {
+block_1141 = {
   instrs: [
     { op:'set_local', idx:6 },
     { op:'push', val:3 },
@@ -9181,85 +10580,85 @@ block_958 = {
     { op:'dup', idx:0 },
     { op:'set_local', idx:2 },
     { op:'pop' },
-    { op:'jump', to:@block_1005 },
+    { op:'jump', to:@block_1189 },
   ]
 };
 
-block_1004 = {
+block_1188 = {
   instrs: [
-    { op:'jump', to:@block_1005 },
+    { op:'jump', to:@block_1189 },
   ]
 };
 
-block_1005 = {
+block_1189 = {
   instrs: [
-    { op:'jump', to:@block_932 },
+    { op:'jump', to:@block_1114 },
   ]
 };
 
-block_932 = {
+block_1114 = {
   instrs: [
     { op:'push', val:$true },
     { op:'pop' },
-    { op:'jump', to:@block_930 },
+    { op:'jump', to:@block_1112 },
   ]
 };
 
-block_933 = {
+block_1115 = {
   instrs: [
     { op:'get_local', idx:2 },
     { op:'ret' },
   ]
 };
 
-fun_928 = {
-  entry:@block_927,
+fun_1110 = {
+  entry:@block_1109,
   num_params:2,
   num_locals:11,
 };
 
-block_1006 = {
+block_1190 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExprPrec' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1008, num_args:2 },
+    { op:'call', ret_to:@block_1192, num_args:2 },
   ]
 };
 
-block_1008 = {
+block_1192 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-fun_1007 = {
-  entry:@block_1006,
+fun_1191 = {
+  entry:@block_1190,
   num_params:1,
   num_locals:1,
 };
 
-block_1009 = {
+block_1193 = {
   instrs: [
     { op:'push', val:0 },
     { op:'new_array' },
     { op:'set_local', idx:2 },
     { op:'push', val:$true },
     { op:'pop' },
-    { op:'jump', to:@block_1011 },
+    { op:'jump', to:@block_1195 },
   ]
 };
 
-block_1011 = {
+block_1195 = {
   instrs: [
     { op:'push', val:$true },
-    { op:'if_true', then:@block_1012, else:@block_1014 },
+    { op:'if_true', then:@block_1196, else:@block_1198 },
   ]
 };
 
-block_1012 = {
+block_1196 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'dup', idx:0 },
@@ -9267,17 +10666,17 @@ block_1012 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1015, num_args:2 },
+    { op:'call', ret_to:@block_1199, num_args:2 },
   ]
 };
 
-block_1015 = {
+block_1199 = {
   instrs: [
-    { op:'call', ret_to:@block_1016, num_args:1 },
+    { op:'call', ret_to:@block_1200, num_args:1 },
   ]
 };
 
-block_1016 = {
+block_1200 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:1 },
@@ -9285,18 +10684,18 @@ block_1016 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1021, num_args:2 },
+    { op:'call', ret_to:@block_1205, num_args:2 },
   ]
 };
 
-block_1021 = {
+block_1205 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_1019, else:@block_1020 },
+    { op:'if_true', then:@block_1203, else:@block_1204 },
   ]
 };
 
-block_1019 = {
+block_1203 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -9305,30 +10704,30 @@ block_1019 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1022, num_args:2 },
+    { op:'call', ret_to:@block_1206, num_args:2 },
   ]
 };
 
-block_1022 = {
+block_1206 = {
   instrs: [
-    { op:'call', ret_to:@block_1023, num_args:1 },
+    { op:'call', ret_to:@block_1207, num_args:1 },
   ]
 };
 
-block_1023 = {
+block_1207 = {
   instrs: [
-    { op:'jump', to:@block_1020 },
+    { op:'jump', to:@block_1204 },
   ]
 };
 
-block_1020 = {
+block_1204 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_1018, else:@block_1017 },
+    { op:'if_true', then:@block_1202, else:@block_1201 },
   ]
 };
 
-block_1017 = {
+block_1201 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:1 },
@@ -9336,18 +10735,18 @@ block_1017 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_ne' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1026, num_args:2 },
+    { op:'call', ret_to:@block_1210, num_args:2 },
   ]
 };
 
-block_1026 = {
+block_1210 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_1024, else:@block_1025 },
+    { op:'if_true', then:@block_1208, else:@block_1209 },
   ]
 };
 
-block_1024 = {
+block_1208 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -9357,57 +10756,57 @@ block_1024 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1027, num_args:2 },
+    { op:'call', ret_to:@block_1211, num_args:2 },
   ]
 };
 
-block_1027 = {
+block_1211 = {
   instrs: [
-    { op:'call', ret_to:@block_1028, num_args:2 },
+    { op:'call', ret_to:@block_1212, num_args:2 },
   ]
 };
 
-block_1028 = {
+block_1212 = {
   instrs: [
-    { op:'jump', to:@block_1025 },
+    { op:'jump', to:@block_1209 },
   ]
 };
 
-block_1025 = {
+block_1209 = {
   instrs: [
-    { op:'jump', to:@block_1018 },
+    { op:'jump', to:@block_1202 },
   ]
 };
 
-block_1029 = {
+block_1213 = {
   instrs: [
-    { op:'jump', to:@block_1014 },
+    { op:'jump', to:@block_1198 },
   ]
 };
 
-block_1018 = {
+block_1202 = {
   instrs: [
-    { op:'if_true', then:@block_1029, else:@block_1030 },
+    { op:'if_true', then:@block_1213, else:@block_1214 },
   ]
 };
 
-block_1030 = {
+block_1214 = {
   instrs: [
-    { op:'jump', to:@block_1031 },
+    { op:'jump', to:@block_1215 },
   ]
 };
 
-block_1031 = {
+block_1215 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseStmt' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1032, num_args:1 },
+    { op:'call', ret_to:@block_1216, num_args:1 },
   ]
 };
 
-block_1032 = {
+block_1216 = {
   instrs: [
     { op:'set_local', idx:3 },
     { op:'get_local', idx:2 },
@@ -9417,32 +10816,32 @@ block_1032 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1033, num_args:2 },
+    { op:'call', ret_to:@block_1217, num_args:2 },
   ]
 };
 
-block_1033 = {
+block_1217 = {
   instrs: [
-    { op:'call', ret_to:@block_1034, num_args:2 },
+    { op:'call', ret_to:@block_1218, num_args:2 },
   ]
 };
 
-block_1034 = {
+block_1218 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_1013 },
+    { op:'jump', to:@block_1197 },
   ]
 };
 
-block_1013 = {
+block_1197 = {
   instrs: [
     { op:'push', val:$true },
     { op:'pop' },
-    { op:'jump', to:@block_1011 },
+    { op:'jump', to:@block_1195 },
   ]
 };
 
-block_1014 = {
+block_1198 = {
   instrs: [
     { op:'push', val:1 },
     { op:'new_object' },
@@ -9460,13 +10859,13 @@ block_1014 = {
   ]
 };
 
-fun_1010 = {
-  entry:@block_1009,
+fun_1194 = {
+  entry:@block_1193,
   num_params:2,
   num_locals:4,
 };
 
-block_1035 = {
+block_1219 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'{' },
@@ -9475,46 +10874,46 @@ block_1035 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1037, num_args:2 },
+    { op:'call', ret_to:@block_1221, num_args:2 },
   ]
 };
 
-block_1037 = {
+block_1221 = {
   instrs: [
-    { op:'call', ret_to:@block_1038, num_args:2 },
+    { op:'call', ret_to:@block_1222, num_args:2 },
   ]
 };
 
-block_1039 = {
+block_1223 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'}' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseBlockStmt' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1040, num_args:2 },
+    { op:'call', ret_to:@block_1224, num_args:2 },
   ]
 };
 
-block_1040 = {
+block_1224 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-block_1038 = {
+block_1222 = {
   instrs: [
-    { op:'if_true', then:@block_1039, else:@block_1041 },
+    { op:'if_true', then:@block_1223, else:@block_1225 },
   ]
 };
 
-block_1041 = {
+block_1225 = {
   instrs: [
-    { op:'jump', to:@block_1042 },
+    { op:'jump', to:@block_1226 },
   ]
 };
 
-block_1042 = {
+block_1226 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'var' },
@@ -9523,17 +10922,17 @@ block_1042 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1043, num_args:2 },
+    { op:'call', ret_to:@block_1227, num_args:2 },
   ]
 };
 
-block_1043 = {
+block_1227 = {
   instrs: [
-    { op:'call', ret_to:@block_1044, num_args:2 },
+    { op:'call', ret_to:@block_1228, num_args:2 },
   ]
 };
 
-block_1045 = {
+block_1229 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'dup', idx:0 },
@@ -9541,28 +10940,28 @@ block_1045 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1046, num_args:2 },
+    { op:'call', ret_to:@block_1230, num_args:2 },
   ]
 };
 
-block_1046 = {
+block_1230 = {
   instrs: [
-    { op:'call', ret_to:@block_1047, num_args:1 },
+    { op:'call', ret_to:@block_1231, num_args:1 },
   ]
 };
 
-block_1047 = {
+block_1231 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseIdentStr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1048, num_args:1 },
+    { op:'call', ret_to:@block_1232, num_args:1 },
   ]
 };
 
-block_1048 = {
+block_1232 = {
   instrs: [
     { op:'set_local', idx:1 },
     { op:'get_local', idx:0 },
@@ -9572,28 +10971,28 @@ block_1048 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1049, num_args:2 },
+    { op:'call', ret_to:@block_1233, num_args:2 },
   ]
 };
 
-block_1049 = {
+block_1233 = {
   instrs: [
-    { op:'call', ret_to:@block_1050, num_args:2 },
+    { op:'call', ret_to:@block_1234, num_args:2 },
   ]
 };
 
-block_1050 = {
+block_1234 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1051, num_args:1 },
+    { op:'call', ret_to:@block_1235, num_args:1 },
   ]
 };
 
-block_1051 = {
+block_1235 = {
   instrs: [
     { op:'set_local', idx:2 },
     { op:'get_local', idx:0 },
@@ -9603,17 +11002,17 @@ block_1051 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1052, num_args:2 },
+    { op:'call', ret_to:@block_1236, num_args:2 },
   ]
 };
 
-block_1052 = {
+block_1236 = {
   instrs: [
-    { op:'call', ret_to:@block_1053, num_args:2 },
+    { op:'call', ret_to:@block_1237, num_args:2 },
   ]
 };
 
-block_1053 = {
+block_1237 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:2 },
@@ -9636,19 +11035,19 @@ block_1053 = {
   ]
 };
 
-block_1044 = {
+block_1228 = {
   instrs: [
-    { op:'if_true', then:@block_1045, else:@block_1054 },
+    { op:'if_true', then:@block_1229, else:@block_1238 },
   ]
 };
 
-block_1054 = {
+block_1238 = {
   instrs: [
-    { op:'jump', to:@block_1055 },
+    { op:'jump', to:@block_1239 },
   ]
 };
 
-block_1055 = {
+block_1239 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'if' },
@@ -9657,45 +11056,45 @@ block_1055 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1056, num_args:2 },
+    { op:'call', ret_to:@block_1240, num_args:2 },
   ]
 };
 
-block_1056 = {
+block_1240 = {
   instrs: [
-    { op:'call', ret_to:@block_1057, num_args:2 },
+    { op:'call', ret_to:@block_1241, num_args:2 },
   ]
 };
 
-block_1058 = {
+block_1242 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseIfStmt' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1059, num_args:1 },
+    { op:'call', ret_to:@block_1243, num_args:1 },
   ]
 };
 
-block_1059 = {
+block_1243 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-block_1057 = {
+block_1241 = {
   instrs: [
-    { op:'if_true', then:@block_1058, else:@block_1060 },
+    { op:'if_true', then:@block_1242, else:@block_1244 },
   ]
 };
 
-block_1060 = {
+block_1244 = {
   instrs: [
-    { op:'jump', to:@block_1061 },
+    { op:'jump', to:@block_1245 },
   ]
 };
 
-block_1061 = {
+block_1245 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'for' },
@@ -9704,45 +11103,45 @@ block_1061 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1062, num_args:2 },
+    { op:'call', ret_to:@block_1246, num_args:2 },
   ]
 };
 
-block_1062 = {
+block_1246 = {
   instrs: [
-    { op:'call', ret_to:@block_1063, num_args:2 },
+    { op:'call', ret_to:@block_1247, num_args:2 },
   ]
 };
 
-block_1064 = {
+block_1248 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseForStmt' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1065, num_args:1 },
+    { op:'call', ret_to:@block_1249, num_args:1 },
   ]
 };
 
-block_1065 = {
+block_1249 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-block_1063 = {
+block_1247 = {
   instrs: [
-    { op:'if_true', then:@block_1064, else:@block_1066 },
+    { op:'if_true', then:@block_1248, else:@block_1250 },
   ]
 };
 
-block_1066 = {
+block_1250 = {
   instrs: [
-    { op:'jump', to:@block_1067 },
+    { op:'jump', to:@block_1251 },
   ]
 };
 
-block_1067 = {
+block_1251 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'break' },
@@ -9751,17 +11150,17 @@ block_1067 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1068, num_args:2 },
+    { op:'call', ret_to:@block_1252, num_args:2 },
   ]
 };
 
-block_1068 = {
+block_1252 = {
   instrs: [
-    { op:'call', ret_to:@block_1069, num_args:2 },
+    { op:'call', ret_to:@block_1253, num_args:2 },
   ]
 };
 
-block_1070 = {
+block_1254 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:';' },
@@ -9770,17 +11169,17 @@ block_1070 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1071, num_args:2 },
+    { op:'call', ret_to:@block_1255, num_args:2 },
   ]
 };
 
-block_1071 = {
+block_1255 = {
   instrs: [
-    { op:'call', ret_to:@block_1072, num_args:2 },
+    { op:'call', ret_to:@block_1256, num_args:2 },
   ]
 };
 
-block_1072 = {
+block_1256 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:0 },
@@ -9795,19 +11194,19 @@ block_1072 = {
   ]
 };
 
-block_1069 = {
+block_1253 = {
   instrs: [
-    { op:'if_true', then:@block_1070, else:@block_1073 },
+    { op:'if_true', then:@block_1254, else:@block_1257 },
   ]
 };
 
-block_1073 = {
+block_1257 = {
   instrs: [
-    { op:'jump', to:@block_1074 },
+    { op:'jump', to:@block_1258 },
   ]
 };
 
-block_1074 = {
+block_1258 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'continue' },
@@ -9816,17 +11215,17 @@ block_1074 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1075, num_args:2 },
+    { op:'call', ret_to:@block_1259, num_args:2 },
   ]
 };
 
-block_1075 = {
+block_1259 = {
   instrs: [
-    { op:'call', ret_to:@block_1076, num_args:2 },
+    { op:'call', ret_to:@block_1260, num_args:2 },
   ]
 };
 
-block_1077 = {
+block_1261 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:';' },
@@ -9835,17 +11234,17 @@ block_1077 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1078, num_args:2 },
+    { op:'call', ret_to:@block_1262, num_args:2 },
   ]
 };
 
-block_1078 = {
+block_1262 = {
   instrs: [
-    { op:'call', ret_to:@block_1079, num_args:2 },
+    { op:'call', ret_to:@block_1263, num_args:2 },
   ]
 };
 
-block_1079 = {
+block_1263 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:0 },
@@ -9860,19 +11259,19 @@ block_1079 = {
   ]
 };
 
-block_1076 = {
+block_1260 = {
   instrs: [
-    { op:'if_true', then:@block_1077, else:@block_1080 },
+    { op:'if_true', then:@block_1261, else:@block_1264 },
   ]
 };
 
-block_1080 = {
+block_1264 = {
   instrs: [
-    { op:'jump', to:@block_1081 },
+    { op:'jump', to:@block_1265 },
   ]
 };
 
-block_1081 = {
+block_1265 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'return' },
@@ -9881,17 +11280,17 @@ block_1081 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1082, num_args:2 },
+    { op:'call', ret_to:@block_1266, num_args:2 },
   ]
 };
 
-block_1082 = {
+block_1266 = {
   instrs: [
-    { op:'call', ret_to:@block_1083, num_args:2 },
+    { op:'call', ret_to:@block_1267, num_args:2 },
   ]
 };
 
-block_1084 = {
+block_1268 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:';' },
@@ -9900,17 +11299,17 @@ block_1084 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1085, num_args:2 },
+    { op:'call', ret_to:@block_1269, num_args:2 },
   ]
 };
 
-block_1085 = {
+block_1269 = {
   instrs: [
-    { op:'call', ret_to:@block_1086, num_args:2 },
+    { op:'call', ret_to:@block_1270, num_args:2 },
   ]
 };
 
-block_1087 = {
+block_1271 = {
   instrs: [
     { op:'push', val:1 },
     { op:'new_object' },
@@ -9939,29 +11338,29 @@ block_1087 = {
   ]
 };
 
-block_1086 = {
+block_1270 = {
   instrs: [
-    { op:'if_true', then:@block_1087, else:@block_1088 },
+    { op:'if_true', then:@block_1271, else:@block_1272 },
   ]
 };
 
-block_1088 = {
+block_1272 = {
   instrs: [
-    { op:'jump', to:@block_1089 },
+    { op:'jump', to:@block_1273 },
   ]
 };
 
-block_1089 = {
+block_1273 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1090, num_args:1 },
+    { op:'call', ret_to:@block_1274, num_args:1 },
   ]
 };
 
-block_1090 = {
+block_1274 = {
   instrs: [
     { op:'set_local', idx:3 },
     { op:'get_local', idx:0 },
@@ -9971,17 +11370,17 @@ block_1090 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1091, num_args:2 },
+    { op:'call', ret_to:@block_1275, num_args:2 },
   ]
 };
 
-block_1091 = {
+block_1275 = {
   instrs: [
-    { op:'call', ret_to:@block_1092, num_args:2 },
+    { op:'call', ret_to:@block_1276, num_args:2 },
   ]
 };
 
-block_1092 = {
+block_1276 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:1 },
@@ -10000,19 +11399,19 @@ block_1092 = {
   ]
 };
 
-block_1083 = {
+block_1267 = {
   instrs: [
-    { op:'if_true', then:@block_1084, else:@block_1093 },
+    { op:'if_true', then:@block_1268, else:@block_1277 },
   ]
 };
 
-block_1093 = {
+block_1277 = {
   instrs: [
-    { op:'jump', to:@block_1094 },
+    { op:'jump', to:@block_1278 },
   ]
 };
 
-block_1094 = {
+block_1278 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'assert' },
@@ -10021,17 +11420,17 @@ block_1094 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1095, num_args:2 },
+    { op:'call', ret_to:@block_1279, num_args:2 },
   ]
 };
 
-block_1095 = {
+block_1279 = {
   instrs: [
-    { op:'call', ret_to:@block_1096, num_args:2 },
+    { op:'call', ret_to:@block_1280, num_args:2 },
   ]
 };
 
-block_1097 = {
+block_1281 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'dup', idx:0 },
@@ -10039,17 +11438,17 @@ block_1097 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1098, num_args:2 },
+    { op:'call', ret_to:@block_1282, num_args:2 },
   ]
 };
 
-block_1098 = {
+block_1282 = {
   instrs: [
-    { op:'call', ret_to:@block_1099, num_args:1 },
+    { op:'call', ret_to:@block_1283, num_args:1 },
   ]
 };
 
-block_1099 = {
+block_1283 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -10058,17 +11457,17 @@ block_1099 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1100, num_args:2 },
+    { op:'call', ret_to:@block_1284, num_args:2 },
   ]
 };
 
-block_1100 = {
+block_1284 = {
   instrs: [
-    { op:'call', ret_to:@block_1101, num_args:1 },
+    { op:'call', ret_to:@block_1285, num_args:1 },
   ]
 };
 
-block_1101 = {
+block_1285 = {
   instrs: [
     { op:'set_local', idx:4 },
     { op:'get_local', idx:0 },
@@ -10078,17 +11477,17 @@ block_1101 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1102, num_args:2 },
+    { op:'call', ret_to:@block_1286, num_args:2 },
   ]
 };
 
-block_1102 = {
+block_1286 = {
   instrs: [
-    { op:'call', ret_to:@block_1103, num_args:2 },
+    { op:'call', ret_to:@block_1287, num_args:2 },
   ]
 };
 
-block_1103 = {
+block_1287 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -10098,28 +11497,28 @@ block_1103 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1104, num_args:2 },
+    { op:'call', ret_to:@block_1288, num_args:2 },
   ]
 };
 
-block_1104 = {
+block_1288 = {
   instrs: [
-    { op:'call', ret_to:@block_1105, num_args:2 },
+    { op:'call', ret_to:@block_1289, num_args:2 },
   ]
 };
 
-block_1105 = {
+block_1289 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1106, num_args:1 },
+    { op:'call', ret_to:@block_1290, num_args:1 },
   ]
 };
 
-block_1106 = {
+block_1290 = {
   instrs: [
     { op:'set_local', idx:5 },
     { op:'push', val:$false },
@@ -10131,42 +11530,42 @@ block_1106 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1107, num_args:2 },
+    { op:'call', ret_to:@block_1291, num_args:2 },
   ]
 };
 
-block_1107 = {
+block_1291 = {
   instrs: [
-    { op:'call', ret_to:@block_1108, num_args:2 },
+    { op:'call', ret_to:@block_1292, num_args:2 },
   ]
 };
 
-block_1109 = {
+block_1293 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1110, num_args:1 },
+    { op:'call', ret_to:@block_1294, num_args:1 },
   ]
 };
 
-block_1108 = {
+block_1292 = {
   instrs: [
-    { op:'if_true', then:@block_1109, else:@block_1111 },
+    { op:'if_true', then:@block_1293, else:@block_1295 },
   ]
 };
 
-block_1110 = {
+block_1294 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'set_local', idx:6 },
     { op:'pop' },
-    { op:'jump', to:@block_1112 },
+    { op:'jump', to:@block_1296 },
   ]
 };
 
-block_1111 = {
+block_1295 = {
   instrs: [
     { op:'push', val:1 },
     { op:'new_object' },
@@ -10183,11 +11582,11 @@ block_1111 = {
     { op:'dup', idx:0 },
     { op:'set_local', idx:6 },
     { op:'pop' },
-    { op:'jump', to:@block_1112 },
+    { op:'jump', to:@block_1296 },
   ]
 };
 
-block_1112 = {
+block_1296 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:')' },
@@ -10196,17 +11595,17 @@ block_1112 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1113, num_args:2 },
+    { op:'call', ret_to:@block_1297, num_args:2 },
   ]
 };
 
-block_1113 = {
+block_1297 = {
   instrs: [
-    { op:'call', ret_to:@block_1114, num_args:2 },
+    { op:'call', ret_to:@block_1298, num_args:2 },
   ]
 };
 
-block_1114 = {
+block_1298 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -10216,17 +11615,17 @@ block_1114 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1115, num_args:2 },
+    { op:'call', ret_to:@block_1299, num_args:2 },
   ]
 };
 
-block_1115 = {
+block_1299 = {
   instrs: [
-    { op:'call', ret_to:@block_1116, num_args:2 },
+    { op:'call', ret_to:@block_1300, num_args:2 },
   ]
 };
 
-block_1116 = {
+block_1300 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:3 },
@@ -10293,29 +11692,29 @@ block_1116 = {
   ]
 };
 
-block_1096 = {
+block_1280 = {
   instrs: [
-    { op:'if_true', then:@block_1097, else:@block_1117 },
+    { op:'if_true', then:@block_1281, else:@block_1301 },
   ]
 };
 
-block_1117 = {
+block_1301 = {
   instrs: [
-    { op:'jump', to:@block_1118 },
+    { op:'jump', to:@block_1302 },
   ]
 };
 
-block_1118 = {
+block_1302 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1119, num_args:1 },
+    { op:'call', ret_to:@block_1303, num_args:1 },
   ]
 };
 
-block_1119 = {
+block_1303 = {
   instrs: [
     { op:'set_local', idx:3 },
     { op:'get_local', idx:0 },
@@ -10325,17 +11724,17 @@ block_1119 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1120, num_args:2 },
+    { op:'call', ret_to:@block_1304, num_args:2 },
   ]
 };
 
-block_1120 = {
+block_1304 = {
   instrs: [
-    { op:'call', ret_to:@block_1121, num_args:2 },
+    { op:'call', ret_to:@block_1305, num_args:2 },
   ]
 };
 
-block_1121 = {
+block_1305 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:1 },
@@ -10354,24 +11753,24 @@ block_1121 = {
   ]
 };
 
-fun_1036 = {
-  entry:@block_1035,
+fun_1220 = {
+  entry:@block_1219,
   num_params:1,
   num_locals:7,
 };
 
-block_1122 = {
+block_1306 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseBlockStmt' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1124, num_args:2 },
+    { op:'call', ret_to:@block_1308, num_args:2 },
   ]
 };
 
-block_1124 = {
+block_1308 = {
   instrs: [
     { op:'set_local', idx:1 },
     { op:'push', val:3 },
@@ -10399,13 +11798,13 @@ block_1124 = {
   ]
 };
 
-fun_1123 = {
-  entry:@block_1122,
+fun_1307 = {
+  entry:@block_1306,
   num_params:1,
   num_locals:2,
 };
 
-block_1125 = {
+block_1309 = {
   instrs: [
     { op:'push', val:2 },
     { op:'new_object' },
@@ -10428,33 +11827,33 @@ block_1125 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'parseUnit' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1127, num_args:1 },
+    { op:'call', ret_to:@block_1311, num_args:1 },
   ]
 };
 
-block_1127 = {
+block_1311 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-fun_1126 = {
-  entry:@block_1125,
+fun_1310 = {
+  entry:@block_1309,
   num_params:2,
   num_locals:3,
 };
 
-block_1128 = {
+block_1312 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'readFile' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1130, num_args:1 },
+    { op:'call', ret_to:@block_1314, num_args:1 },
   ]
 };
 
-block_1130 = {
+block_1314 = {
   instrs: [
     { op:'set_local', idx:1 },
     { op:'push', val:2 },
@@ -10478,23 +11877,23 @@ block_1130 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'parseUnit' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1131, num_args:1 },
+    { op:'call', ret_to:@block_1315, num_args:1 },
   ]
 };
 
-block_1131 = {
+block_1315 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-fun_1129 = {
-  entry:@block_1128,
+fun_1313 = {
+  entry:@block_1312,
   num_params:1,
   num_locals:3,
 };
 
-block_1132 = {
+block_1316 = {
   instrs: [
     { op:'push', val:1 },
     { op:'new_object' },
@@ -10513,114 +11912,114 @@ block_1132 = {
   ]
 };
 
-fun_1133 = {
-  entry:@block_1132,
+fun_1317 = {
+  entry:@block_1316,
   num_params:0,
   num_locals:0,
 };
 
-block_1134 = {
+block_1318 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'instrs' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1136, num_args:2 },
+    { op:'call', ret_to:@block_1320, num_args:2 },
   ]
 };
 
-block_1136 = {
+block_1320 = {
   instrs: [
     { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1137, num_args:2 },
+    { op:'call', ret_to:@block_1321, num_args:2 },
   ]
 };
 
-block_1137 = {
+block_1321 = {
   instrs: [
     { op:'push', val:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1138, num_args:2 },
+    { op:'call', ret_to:@block_1322, num_args:2 },
   ]
 };
 
-block_1139 = {
+block_1323 = {
   instrs: [
     { op:'push', val:$false },
     { op:'ret' },
   ]
 };
 
-block_1138 = {
+block_1322 = {
   instrs: [
-    { op:'if_true', then:@block_1139, else:@block_1140 },
+    { op:'if_true', then:@block_1323, else:@block_1324 },
   ]
 };
 
-block_1140 = {
+block_1324 = {
   instrs: [
-    { op:'jump', to:@block_1141 },
+    { op:'jump', to:@block_1325 },
   ]
 };
 
-block_1141 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'instrs' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1142, num_args:2 },
-  ]
-};
-
-block_1142 = {
+block_1325 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'instrs' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1143, num_args:2 },
+    { op:'call', ret_to:@block_1326, num_args:2 },
   ]
 };
 
-block_1143 = {
+block_1326 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:'instrs' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1327, num_args:2 },
+  ]
+};
+
+block_1327 = {
   instrs: [
     { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1144, num_args:2 },
+    { op:'call', ret_to:@block_1328, num_args:2 },
   ]
 };
 
-block_1144 = {
+block_1328 = {
   instrs: [
     { op:'push', val:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_sub' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1145, num_args:2 },
+    { op:'call', ret_to:@block_1329, num_args:2 },
   ]
 };
 
-block_1145 = {
+block_1329 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getElem' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1146, num_args:2 },
+    { op:'call', ret_to:@block_1330, num_args:2 },
   ]
 };
 
-block_1146 = {
+block_1330 = {
   instrs: [
     { op:'set_local', idx:1 },
     { op:'get_local', idx:1 },
@@ -10628,11 +12027,11 @@ block_1146 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1147, num_args:2 },
+    { op:'call', ret_to:@block_1331, num_args:2 },
   ]
 };
 
-block_1147 = {
+block_1331 = {
   instrs: [
     { op:'set_local', idx:2 },
     { op:'get_local', idx:2 },
@@ -10640,18 +12039,18 @@ block_1147 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1152, num_args:2 },
+    { op:'call', ret_to:@block_1336, num_args:2 },
   ]
 };
 
-block_1152 = {
+block_1336 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_1151, else:@block_1150 },
+    { op:'if_true', then:@block_1335, else:@block_1334 },
   ]
 };
 
-block_1150 = {
+block_1334 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:2 },
@@ -10659,24 +12058,24 @@ block_1150 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1153, num_args:2 },
+    { op:'call', ret_to:@block_1337, num_args:2 },
   ]
 };
 
-block_1153 = {
+block_1337 = {
   instrs: [
-    { op:'jump', to:@block_1151 },
+    { op:'jump', to:@block_1335 },
   ]
 };
 
-block_1151 = {
+block_1335 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_1149, else:@block_1148 },
+    { op:'if_true', then:@block_1333, else:@block_1332 },
   ]
 };
 
-block_1148 = {
+block_1332 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:2 },
@@ -10684,40 +12083,40 @@ block_1148 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1154, num_args:2 },
+    { op:'call', ret_to:@block_1338, num_args:2 },
   ]
 };
 
-block_1154 = {
+block_1338 = {
   instrs: [
-    { op:'jump', to:@block_1149 },
+    { op:'jump', to:@block_1333 },
   ]
 };
 
-block_1149 = {
+block_1333 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-fun_1135 = {
-  entry:@block_1134,
+fun_1319 = {
+  entry:@block_1318,
   num_params:1,
   num_locals:3,
 };
 
-block_1155 = {
+block_1339 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'instrs' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1157, num_args:2 },
+    { op:'call', ret_to:@block_1341, num_args:2 },
   ]
 };
 
-block_1157 = {
+block_1341 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'dup', idx:1 },
@@ -10725,17 +12124,17 @@ block_1157 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1158, num_args:2 },
+    { op:'call', ret_to:@block_1342, num_args:2 },
   ]
 };
 
-block_1158 = {
+block_1342 = {
   instrs: [
-    { op:'call', ret_to:@block_1159, num_args:2 },
+    { op:'call', ret_to:@block_1343, num_args:2 },
   ]
 };
 
-block_1159 = {
+block_1343 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -10743,13 +12142,13 @@ block_1159 = {
   ]
 };
 
-fun_1156 = {
-  entry:@block_1155,
+fun_1340 = {
+  entry:@block_1339,
   num_params:2,
   num_locals:2,
 };
 
-block_1160 = {
+block_1344 = {
   instrs: [
     { op:'push', val:4 },
     { op:'new_object' },
@@ -10780,13 +12179,13 @@ block_1160 = {
   ]
 };
 
-fun_1161 = {
-  entry:@block_1160,
+fun_1345 = {
+  entry:@block_1344,
   num_params:2,
   num_locals:2,
 };
 
-block_1162 = {
+block_1346 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
@@ -10795,47 +12194,47 @@ block_1162 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1164, num_args:2 },
+    { op:'call', ret_to:@block_1348, num_args:2 },
   ]
 };
 
-block_1164 = {
+block_1348 = {
   instrs: [
-    { op:'call', ret_to:@block_1165, num_args:2 },
+    { op:'call', ret_to:@block_1349, num_args:2 },
   ]
 };
 
-block_1166 = {
+block_1350 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-block_1165 = {
+block_1349 = {
   instrs: [
-    { op:'if_true', then:@block_1166, else:@block_1167 },
+    { op:'if_true', then:@block_1350, else:@block_1351 },
   ]
 };
 
-block_1167 = {
+block_1351 = {
   instrs: [
-    { op:'jump', to:@block_1168 },
+    { op:'jump', to:@block_1352 },
   ]
 };
 
-block_1168 = {
+block_1352 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'num_locals' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1169, num_args:2 },
+    { op:'call', ret_to:@block_1353, num_args:2 },
   ]
 };
 
-block_1169 = {
+block_1353 = {
   instrs: [
     { op:'set_local', idx:2 },
     { op:'get_local', idx:0 },
@@ -10843,11 +12242,11 @@ block_1169 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1170, num_args:2 },
+    { op:'call', ret_to:@block_1354, num_args:2 },
   ]
 };
 
-block_1170 = {
+block_1354 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'dup', idx:1 },
@@ -10855,17 +12254,17 @@ block_1170 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1171, num_args:2 },
+    { op:'call', ret_to:@block_1355, num_args:2 },
   ]
 };
 
-block_1171 = {
+block_1355 = {
   instrs: [
-    { op:'call', ret_to:@block_1172, num_args:2 },
+    { op:'call', ret_to:@block_1356, num_args:2 },
   ]
 };
 
-block_1172 = {
+block_1356 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -10873,21 +12272,21 @@ block_1172 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1173, num_args:2 },
+    { op:'call', ret_to:@block_1357, num_args:2 },
   ]
 };
 
-block_1173 = {
+block_1357 = {
   instrs: [
     { op:'push', val:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_add' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1174, num_args:2 },
+    { op:'call', ret_to:@block_1358, num_args:2 },
   ]
 };
 
-block_1174 = {
+block_1358 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'num_locals' },
@@ -10899,13 +12298,13 @@ block_1174 = {
   ]
 };
 
-fun_1163 = {
-  entry:@block_1162,
+fun_1347 = {
+  entry:@block_1346,
   num_params:2,
   num_locals:3,
 };
 
-block_1175 = {
+block_1359 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
@@ -10914,57 +12313,57 @@ block_1175 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1177, num_args:2 },
+    { op:'call', ret_to:@block_1361, num_args:2 },
   ]
 };
 
-block_1177 = {
+block_1361 = {
   instrs: [
-    { op:'call', ret_to:@block_1178, num_args:2 },
+    { op:'call', ret_to:@block_1362, num_args:2 },
   ]
 };
 
-block_1178 = {
+block_1362 = {
   instrs: [
     { op:'push', val:0 },
     { op:'push', val:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_sub' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1179, num_args:2 },
+    { op:'call', ret_to:@block_1363, num_args:2 },
   ]
 };
 
-block_1179 = {
+block_1363 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_ne' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1180, num_args:2 },
+    { op:'call', ret_to:@block_1364, num_args:2 },
   ]
 };
 
-block_1180 = {
+block_1364 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-fun_1176 = {
-  entry:@block_1175,
+fun_1360 = {
+  entry:@block_1359,
   num_params:2,
   num_locals:2,
 };
 
-block_1181 = {
+block_1365 = {
   instrs: [
     { op:'push', val:0 },
     { op:'set_local', idx:2 },
-    { op:'jump', to:@block_1183 },
+    { op:'jump', to:@block_1367 },
   ]
 };
 
-block_1183 = {
+block_1367 = {
   instrs: [
     { op:'get_local', idx:2 },
     { op:'get_local', idx:0 },
@@ -10972,127 +12371,135 @@ block_1183 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1187, num_args:2 },
+    { op:'call', ret_to:@block_1371, num_args:2 },
   ]
 };
 
-block_1187 = {
+block_1371 = {
   instrs: [
     { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1188, num_args:2 },
+    { op:'call', ret_to:@block_1372, num_args:2 },
   ]
 };
 
-block_1188 = {
+block_1372 = {
   instrs: [
-    { op:'lt_i32' },
-    { op:'if_true', then:@block_1184, else:@block_1186 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_lt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1373, num_args:2 },
   ]
 };
 
-block_1184 = {
+block_1373 = {
+  instrs: [
+    { op:'if_true', then:@block_1368, else:@block_1370 },
+  ]
+};
+
+block_1368 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'localNames' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1189, num_args:2 },
+    { op:'call', ret_to:@block_1374, num_args:2 },
   ]
 };
 
-block_1189 = {
+block_1374 = {
   instrs: [
     { op:'get_local', idx:2 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getElem' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1190, num_args:2 },
+    { op:'call', ret_to:@block_1375, num_args:2 },
   ]
 };
 
-block_1190 = {
+block_1375 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1191, num_args:2 },
+    { op:'call', ret_to:@block_1376, num_args:2 },
   ]
 };
 
-block_1192 = {
+block_1377 = {
   instrs: [
     { op:'get_local', idx:2 },
     { op:'ret' },
   ]
 };
 
-block_1191 = {
+block_1376 = {
   instrs: [
-    { op:'if_true', then:@block_1192, else:@block_1193 },
+    { op:'if_true', then:@block_1377, else:@block_1378 },
   ]
 };
 
-block_1193 = {
+block_1378 = {
   instrs: [
-    { op:'jump', to:@block_1194 },
+    { op:'jump', to:@block_1379 },
   ]
 };
 
-block_1194 = {
+block_1379 = {
   instrs: [
-    { op:'jump', to:@block_1185 },
+    { op:'jump', to:@block_1369 },
   ]
 };
 
-block_1185 = {
+block_1369 = {
   instrs: [
     { op:'get_local', idx:2 },
     { op:'push', val:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_add' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1195, num_args:2 },
+    { op:'call', ret_to:@block_1380, num_args:2 },
   ]
 };
 
-block_1195 = {
+block_1380 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'set_local', idx:2 },
     { op:'pop' },
-    { op:'jump', to:@block_1183 },
+    { op:'jump', to:@block_1367 },
   ]
 };
 
-block_1186 = {
+block_1370 = {
   instrs: [
     { op:'push', val:0 },
     { op:'push', val:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_sub' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1196, num_args:2 },
+    { op:'call', ret_to:@block_1381, num_args:2 },
   ]
 };
 
-block_1196 = {
+block_1381 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-fun_1182 = {
-  entry:@block_1181,
+fun_1366 = {
+  entry:@block_1365,
   num_params:2,
   num_locals:3,
 };
 
-block_1197 = {
+block_1382 = {
   instrs: [
     { op:'push', val:7 },
     { op:'new_object' },
@@ -11134,13 +12541,13 @@ block_1197 = {
   ]
 };
 
-fun_1198 = {
-  entry:@block_1197,
+fun_1383 = {
+  entry:@block_1382,
   num_params:5,
   num_locals:5,
 };
 
-block_1199 = {
+block_1384 = {
   instrs: [
     { op:'push', val:7 },
     { op:'new_object' },
@@ -11157,11 +12564,11 @@ block_1199 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1201, num_args:2 },
+    { op:'call', ret_to:@block_1386, num_args:2 },
   ]
 };
 
-block_1201 = {
+block_1386 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:0 },
@@ -11171,11 +12578,11 @@ block_1201 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1202, num_args:2 },
+    { op:'call', ret_to:@block_1387, num_args:2 },
   ]
 };
 
-block_1202 = {
+block_1387 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:0 },
@@ -11185,11 +12592,11 @@ block_1202 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1203, num_args:2 },
+    { op:'call', ret_to:@block_1388, num_args:2 },
   ]
 };
 
-block_1203 = {
+block_1388 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:0 },
@@ -11199,11 +12606,11 @@ block_1203 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1204, num_args:2 },
+    { op:'call', ret_to:@block_1389, num_args:2 },
   ]
 };
 
-block_1204 = {
+block_1389 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:0 },
@@ -11217,11 +12624,11 @@ block_1204 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1205, num_args:2 },
+    { op:'call', ret_to:@block_1390, num_args:2 },
   ]
 };
 
-block_1205 = {
+block_1390 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:0 },
@@ -11231,24 +12638,24 @@ block_1205 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1206, num_args:2 },
+    { op:'call', ret_to:@block_1391, num_args:2 },
   ]
 };
 
-block_1206 = {
+block_1391 = {
   instrs: [
     { op:'set_field' },
     { op:'ret' },
   ]
 };
 
-fun_1200 = {
-  entry:@block_1199,
+fun_1385 = {
+  entry:@block_1384,
   num_params:2,
   num_locals:2,
 };
 
-block_1207 = {
+block_1392 = {
   instrs: [
     { op:'push', val:7 },
     { op:'new_object' },
@@ -11265,11 +12672,11 @@ block_1207 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1209, num_args:2 },
+    { op:'call', ret_to:@block_1394, num_args:2 },
   ]
 };
 
-block_1209 = {
+block_1394 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:0 },
@@ -11279,11 +12686,11 @@ block_1209 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1210, num_args:2 },
+    { op:'call', ret_to:@block_1395, num_args:2 },
   ]
 };
 
-block_1210 = {
+block_1395 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:0 },
@@ -11293,11 +12700,11 @@ block_1210 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1211, num_args:2 },
+    { op:'call', ret_to:@block_1396, num_args:2 },
   ]
 };
 
-block_1211 = {
+block_1396 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:0 },
@@ -11307,11 +12714,11 @@ block_1211 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1212, num_args:2 },
+    { op:'call', ret_to:@block_1397, num_args:2 },
   ]
 };
 
-block_1212 = {
+block_1397 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:0 },
@@ -11330,13 +12737,13 @@ block_1212 = {
   ]
 };
 
-fun_1208 = {
-  entry:@block_1207,
+fun_1393 = {
+  entry:@block_1392,
   num_params:4,
   num_locals:4,
 };
 
-block_1213 = {
+block_1398 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'get_local', idx:0 },
@@ -11349,65 +12756,65 @@ block_1213 = {
   ]
 };
 
-fun_1214 = {
-  entry:@block_1213,
+fun_1399 = {
+  entry:@block_1398,
   num_params:2,
   num_locals:2,
 };
 
-block_1215 = {
+block_1400 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'curBlock' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1217, num_args:2 },
+    { op:'call', ret_to:@block_1402, num_args:2 },
   ]
 };
 
-block_1217 = {
+block_1402 = {
   instrs: [
     { op:'push', val:$false },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_ne' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1218, num_args:2 },
+    { op:'call', ret_to:@block_1403, num_args:2 },
   ]
 };
 
-block_1218 = {
+block_1403 = {
   instrs: [
-    { op:'if_true', then:@block_1219, else:@block_1220 },
+    { op:'if_true', then:@block_1404, else:@block_1405 },
   ]
 };
 
-block_1219 = {
+block_1404 = {
   instrs: [
-    { op:'jump', to:@block_1221 },
+    { op:'jump', to:@block_1406 },
   ]
 };
 
-block_1220 = {
+block_1405 = {
   instrs: [
     { op:'push', val:'assertion failed' },
     { op:'abort' },
-    { op:'jump', to:@block_1221 },
+    { op:'jump', to:@block_1406 },
   ]
 };
 
-block_1221 = {
+block_1406 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'curBlock' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1222, num_args:2 },
+    { op:'call', ret_to:@block_1407, num_args:2 },
   ]
 };
 
-block_1222 = {
+block_1407 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'dup', idx:1 },
@@ -11415,17 +12822,17 @@ block_1222 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1223, num_args:2 },
+    { op:'call', ret_to:@block_1408, num_args:2 },
   ]
 };
 
-block_1223 = {
+block_1408 = {
   instrs: [
-    { op:'call', ret_to:@block_1224, num_args:2 },
+    { op:'call', ret_to:@block_1409, num_args:2 },
   ]
 };
 
-block_1224 = {
+block_1409 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -11433,24 +12840,24 @@ block_1224 = {
   ]
 };
 
-fun_1216 = {
-  entry:@block_1215,
+fun_1401 = {
+  entry:@block_1400,
   num_params:2,
   num_locals:2,
 };
 
-block_1225 = {
+block_1410 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'curBlock' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1227, num_args:2 },
+    { op:'call', ret_to:@block_1412, num_args:2 },
   ]
 };
 
-block_1227 = {
+block_1412 = {
   instrs: [
     { op:'push', val:1 },
     { op:'new_object' },
@@ -11463,17 +12870,17 @@ block_1227 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1228, num_args:2 },
+    { op:'call', ret_to:@block_1413, num_args:2 },
   ]
 };
 
-block_1228 = {
+block_1413 = {
   instrs: [
-    { op:'call', ret_to:@block_1229, num_args:2 },
+    { op:'call', ret_to:@block_1414, num_args:2 },
   ]
 };
 
-block_1229 = {
+block_1414 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -11481,24 +12888,24 @@ block_1229 = {
   ]
 };
 
-fun_1226 = {
-  entry:@block_1225,
+fun_1411 = {
+  entry:@block_1410,
   num_params:2,
   num_locals:2,
 };
 
-block_1230 = {
+block_1415 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'curBlock' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1232, num_args:2 },
+    { op:'call', ret_to:@block_1417, num_args:2 },
   ]
 };
 
-block_1232 = {
+block_1417 = {
   instrs: [
     { op:'push', val:2 },
     { op:'new_object' },
@@ -11515,17 +12922,17 @@ block_1232 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1233, num_args:2 },
+    { op:'call', ret_to:@block_1418, num_args:2 },
   ]
 };
 
-block_1233 = {
+block_1418 = {
   instrs: [
-    { op:'call', ret_to:@block_1234, num_args:2 },
+    { op:'call', ret_to:@block_1419, num_args:2 },
   ]
 };
 
-block_1234 = {
+block_1419 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -11533,13 +12940,13 @@ block_1234 = {
   ]
 };
 
-fun_1231 = {
-  entry:@block_1230,
+fun_1416 = {
+  entry:@block_1415,
   num_params:2,
   num_locals:2,
 };
 
-block_1235 = {
+block_1420 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -11548,19 +12955,19 @@ block_1235 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1237, num_args:2 },
+    { op:'call', ret_to:@block_1422, num_args:2 },
   ]
 };
 
-block_1238 = {
+block_1423 = {
   instrs: [
     { op:'push', val:0 },
     { op:'set_local', idx:3 },
-    { op:'jump', to:@block_1239 },
+    { op:'jump', to:@block_1424 },
   ]
 };
 
-block_1239 = {
+block_1424 = {
   instrs: [
     { op:'get_local', idx:3 },
     { op:'get_local', idx:1 },
@@ -11568,28 +12975,36 @@ block_1239 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1243, num_args:2 },
+    { op:'call', ret_to:@block_1428, num_args:2 },
   ]
 };
 
-block_1243 = {
+block_1428 = {
   instrs: [
     { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1244, num_args:2 },
+    { op:'call', ret_to:@block_1429, num_args:2 },
   ]
 };
 
-block_1244 = {
+block_1429 = {
   instrs: [
-    { op:'lt_i32' },
-    { op:'if_true', then:@block_1240, else:@block_1242 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_lt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1430, num_args:2 },
   ]
 };
 
-block_1240 = {
+block_1430 = {
+  instrs: [
+    { op:'if_true', then:@block_1425, else:@block_1427 },
+  ]
+};
+
+block_1425 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
@@ -11597,77 +13012,77 @@ block_1240 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1245, num_args:2 },
+    { op:'call', ret_to:@block_1431, num_args:2 },
   ]
 };
 
-block_1245 = {
+block_1431 = {
   instrs: [
     { op:'get_local', idx:3 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getElem' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1246, num_args:2 },
+    { op:'call', ret_to:@block_1432, num_args:2 },
   ]
 };
 
-block_1246 = {
+block_1432 = {
   instrs: [
     { op:'get_local', idx:2 },
     { op:'push', val:@global_obj },
     { op:'push', val:'registerDecls' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1247, num_args:3 },
+    { op:'call', ret_to:@block_1433, num_args:3 },
   ]
 };
 
-block_1247 = {
+block_1433 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_1241 },
+    { op:'jump', to:@block_1426 },
   ]
 };
 
-block_1241 = {
+block_1426 = {
   instrs: [
     { op:'get_local', idx:3 },
     { op:'push', val:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_add' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1248, num_args:2 },
+    { op:'call', ret_to:@block_1434, num_args:2 },
   ]
 };
 
-block_1248 = {
+block_1434 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'set_local', idx:3 },
     { op:'pop' },
-    { op:'jump', to:@block_1239 },
+    { op:'jump', to:@block_1424 },
   ]
 };
 
-block_1242 = {
+block_1427 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-block_1237 = {
+block_1422 = {
   instrs: [
-    { op:'if_true', then:@block_1238, else:@block_1249 },
+    { op:'if_true', then:@block_1423, else:@block_1435 },
   ]
 };
 
-block_1249 = {
+block_1435 = {
   instrs: [
-    { op:'jump', to:@block_1250 },
+    { op:'jump', to:@block_1436 },
   ]
 };
 
-block_1250 = {
+block_1436 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -11676,21 +13091,21 @@ block_1250 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1251, num_args:2 },
+    { op:'call', ret_to:@block_1437, num_args:2 },
   ]
 };
 
-block_1252 = {
+block_1438 = {
   instrs: [
     { op:'get_local', idx:2 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_not' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1253, num_args:1 },
+    { op:'call', ret_to:@block_1439, num_args:1 },
   ]
 };
 
-block_1254 = {
+block_1440 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
@@ -11698,66 +13113,66 @@ block_1254 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1255, num_args:2 },
+    { op:'call', ret_to:@block_1441, num_args:2 },
   ]
 };
 
-block_1255 = {
+block_1441 = {
   instrs: [
     { op:'dup', idx:1 },
     { op:'push', val:'registerDecl' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1256, num_args:2 },
+    { op:'call', ret_to:@block_1442, num_args:2 },
   ]
 };
 
-block_1256 = {
+block_1442 = {
   instrs: [
-    { op:'call', ret_to:@block_1257, num_args:2 },
+    { op:'call', ret_to:@block_1443, num_args:2 },
   ]
 };
 
-block_1253 = {
+block_1439 = {
   instrs: [
-    { op:'if_true', then:@block_1254, else:@block_1258 },
+    { op:'if_true', then:@block_1440, else:@block_1444 },
   ]
 };
 
-block_1257 = {
+block_1443 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_1259 },
+    { op:'jump', to:@block_1445 },
   ]
 };
 
-block_1258 = {
+block_1444 = {
   instrs: [
-    { op:'jump', to:@block_1259 },
+    { op:'jump', to:@block_1445 },
   ]
 };
 
-block_1259 = {
+block_1445 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-block_1251 = {
+block_1437 = {
   instrs: [
-    { op:'if_true', then:@block_1252, else:@block_1260 },
+    { op:'if_true', then:@block_1438, else:@block_1446 },
   ]
 };
 
-block_1260 = {
+block_1446 = {
   instrs: [
-    { op:'jump', to:@block_1261 },
+    { op:'jump', to:@block_1447 },
   ]
 };
 
-block_1261 = {
+block_1447 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -11766,30 +13181,30 @@ block_1261 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1262, num_args:2 },
+    { op:'call', ret_to:@block_1448, num_args:2 },
   ]
 };
 
-block_1263 = {
+block_1449 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-block_1262 = {
+block_1448 = {
   instrs: [
-    { op:'if_true', then:@block_1263, else:@block_1264 },
+    { op:'if_true', then:@block_1449, else:@block_1450 },
   ]
 };
 
-block_1264 = {
+block_1450 = {
   instrs: [
-    { op:'jump', to:@block_1265 },
+    { op:'jump', to:@block_1451 },
   ]
 };
 
-block_1265 = {
+block_1451 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -11798,11 +13213,11 @@ block_1265 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1266, num_args:2 },
+    { op:'call', ret_to:@block_1452, num_args:2 },
   ]
 };
 
-block_1267 = {
+block_1453 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
@@ -11810,21 +13225,21 @@ block_1267 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1268, num_args:2 },
+    { op:'call', ret_to:@block_1454, num_args:2 },
   ]
 };
 
-block_1268 = {
+block_1454 = {
   instrs: [
     { op:'get_local', idx:2 },
     { op:'push', val:@global_obj },
     { op:'push', val:'registerDecls' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1269, num_args:3 },
+    { op:'call', ret_to:@block_1455, num_args:3 },
   ]
 };
 
-block_1269 = {
+block_1455 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -11833,21 +13248,21 @@ block_1269 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1270, num_args:2 },
+    { op:'call', ret_to:@block_1456, num_args:2 },
   ]
 };
 
-block_1270 = {
+block_1456 = {
   instrs: [
     { op:'get_local', idx:2 },
     { op:'push', val:@global_obj },
     { op:'push', val:'registerDecls' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1271, num_args:3 },
+    { op:'call', ret_to:@block_1457, num_args:3 },
   ]
 };
 
-block_1271 = {
+block_1457 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -11855,19 +13270,19 @@ block_1271 = {
   ]
 };
 
-block_1266 = {
+block_1452 = {
   instrs: [
-    { op:'if_true', then:@block_1267, else:@block_1272 },
+    { op:'if_true', then:@block_1453, else:@block_1458 },
   ]
 };
 
-block_1272 = {
+block_1458 = {
   instrs: [
-    { op:'jump', to:@block_1273 },
+    { op:'jump', to:@block_1459 },
   ]
 };
 
-block_1273 = {
+block_1459 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -11876,11 +13291,11 @@ block_1273 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1274, num_args:2 },
+    { op:'call', ret_to:@block_1460, num_args:2 },
   ]
 };
 
-block_1275 = {
+block_1461 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
@@ -11888,21 +13303,21 @@ block_1275 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1276, num_args:2 },
+    { op:'call', ret_to:@block_1462, num_args:2 },
   ]
 };
 
-block_1276 = {
+block_1462 = {
   instrs: [
     { op:'get_local', idx:2 },
     { op:'push', val:@global_obj },
     { op:'push', val:'registerDecls' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1277, num_args:3 },
+    { op:'call', ret_to:@block_1463, num_args:3 },
   ]
 };
 
-block_1277 = {
+block_1463 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -11911,21 +13326,21 @@ block_1277 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1278, num_args:2 },
+    { op:'call', ret_to:@block_1464, num_args:2 },
   ]
 };
 
-block_1278 = {
+block_1464 = {
   instrs: [
     { op:'get_local', idx:2 },
     { op:'push', val:@global_obj },
     { op:'push', val:'registerDecls' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1279, num_args:3 },
+    { op:'call', ret_to:@block_1465, num_args:3 },
   ]
 };
 
-block_1279 = {
+block_1465 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -11933,19 +13348,19 @@ block_1279 = {
   ]
 };
 
-block_1274 = {
+block_1460 = {
   instrs: [
-    { op:'if_true', then:@block_1275, else:@block_1280 },
+    { op:'if_true', then:@block_1461, else:@block_1466 },
   ]
 };
 
-block_1280 = {
+block_1466 = {
   instrs: [
-    { op:'jump', to:@block_1281 },
+    { op:'jump', to:@block_1467 },
   ]
 };
 
-block_1281 = {
+block_1467 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -11954,30 +13369,30 @@ block_1281 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1282, num_args:2 },
+    { op:'call', ret_to:@block_1468, num_args:2 },
   ]
 };
 
-block_1283 = {
+block_1469 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-block_1282 = {
+block_1468 = {
   instrs: [
-    { op:'if_true', then:@block_1283, else:@block_1284 },
+    { op:'if_true', then:@block_1469, else:@block_1470 },
   ]
 };
 
-block_1284 = {
+block_1470 = {
   instrs: [
-    { op:'jump', to:@block_1285 },
+    { op:'jump', to:@block_1471 },
   ]
 };
 
-block_1285 = {
+block_1471 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -11986,30 +13401,30 @@ block_1285 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1286, num_args:2 },
+    { op:'call', ret_to:@block_1472, num_args:2 },
   ]
 };
 
-block_1287 = {
+block_1473 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-block_1286 = {
+block_1472 = {
   instrs: [
-    { op:'if_true', then:@block_1287, else:@block_1288 },
+    { op:'if_true', then:@block_1473, else:@block_1474 },
   ]
 };
 
-block_1288 = {
+block_1474 = {
   instrs: [
-    { op:'jump', to:@block_1289 },
+    { op:'jump', to:@block_1475 },
   ]
 };
 
-block_1289 = {
+block_1475 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -12018,30 +13433,30 @@ block_1289 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1290, num_args:2 },
+    { op:'call', ret_to:@block_1476, num_args:2 },
   ]
 };
 
-block_1291 = {
+block_1477 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-block_1290 = {
+block_1476 = {
   instrs: [
-    { op:'if_true', then:@block_1291, else:@block_1292 },
+    { op:'if_true', then:@block_1477, else:@block_1478 },
   ]
 };
 
-block_1292 = {
+block_1478 = {
   instrs: [
-    { op:'jump', to:@block_1293 },
+    { op:'jump', to:@block_1479 },
   ]
 };
 
-block_1293 = {
+block_1479 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -12050,64 +13465,64 @@ block_1293 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1294, num_args:2 },
+    { op:'call', ret_to:@block_1480, num_args:2 },
   ]
 };
 
-block_1295 = {
+block_1481 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-block_1294 = {
+block_1480 = {
   instrs: [
-    { op:'if_true', then:@block_1295, else:@block_1296 },
+    { op:'if_true', then:@block_1481, else:@block_1482 },
   ]
 };
 
-block_1296 = {
+block_1482 = {
   instrs: [
-    { op:'jump', to:@block_1297 },
+    { op:'jump', to:@block_1483 },
   ]
 };
 
-block_1297 = {
+block_1483 = {
   instrs: [
     { op:'push', val:$false },
-    { op:'if_true', then:@block_1298, else:@block_1299 },
+    { op:'if_true', then:@block_1484, else:@block_1485 },
   ]
 };
 
-block_1298 = {
+block_1484 = {
   instrs: [
-    { op:'jump', to:@block_1300 },
+    { op:'jump', to:@block_1486 },
   ]
 };
 
-block_1299 = {
+block_1485 = {
   instrs: [
     { op:'push', val:'unknown statement type in registerDecls' },
     { op:'abort' },
-    { op:'jump', to:@block_1300 },
+    { op:'jump', to:@block_1486 },
   ]
 };
 
-block_1300 = {
+block_1486 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-fun_1236 = {
-  entry:@block_1235,
+fun_1421 = {
+  entry:@block_1420,
   num_params:3,
   num_locals:4,
 };
 
-block_1301 = {
+block_1487 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'Block' },
@@ -12116,17 +13531,17 @@ block_1301 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1303, num_args:2 },
+    { op:'call', ret_to:@block_1489, num_args:2 },
   ]
 };
 
-block_1303 = {
+block_1489 = {
   instrs: [
-    { op:'call', ret_to:@block_1304, num_args:0 },
+    { op:'call', ret_to:@block_1490, num_args:0 },
   ]
 };
 
-block_1304 = {
+block_1490 = {
   instrs: [
     { op:'set_local', idx:1 },
     { op:'push', val:0 },
@@ -12138,17 +13553,17 @@ block_1304 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1305, num_args:2 },
+    { op:'call', ret_to:@block_1491, num_args:2 },
   ]
 };
 
-block_1305 = {
+block_1491 = {
   instrs: [
-    { op:'call', ret_to:@block_1306, num_args:2 },
+    { op:'call', ret_to:@block_1492, num_args:2 },
   ]
 };
 
-block_1306 = {
+block_1492 = {
   instrs: [
     { op:'set_local', idx:2 },
     { op:'get_local', idx:2 },
@@ -12157,21 +13572,21 @@ block_1306 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1307, num_args:2 },
+    { op:'call', ret_to:@block_1493, num_args:2 },
   ]
 };
 
-block_1307 = {
+block_1493 = {
   instrs: [
     { op:'push', val:$true },
     { op:'push', val:@global_obj },
     { op:'push', val:'registerDecls' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1308, num_args:3 },
+    { op:'call', ret_to:@block_1494, num_args:3 },
   ]
 };
 
-block_1308 = {
+block_1494 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:1 },
@@ -12206,17 +13621,17 @@ block_1308 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1309, num_args:2 },
+    { op:'call', ret_to:@block_1495, num_args:2 },
   ]
 };
 
-block_1309 = {
+block_1495 = {
   instrs: [
-    { op:'call', ret_to:@block_1310, num_args:5 },
+    { op:'call', ret_to:@block_1496, num_args:5 },
   ]
 };
 
-block_1310 = {
+block_1496 = {
   instrs: [
     { op:'set_local', idx:5 },
     { op:'get_local', idx:5 },
@@ -12225,20 +13640,20 @@ block_1310 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1311, num_args:2 },
+    { op:'call', ret_to:@block_1497, num_args:2 },
   ]
 };
 
-block_1311 = {
+block_1497 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'genStmt' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1312, num_args:2 },
+    { op:'call', ret_to:@block_1498, num_args:2 },
   ]
 };
 
-block_1312 = {
+block_1498 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:5 },
@@ -12246,37 +13661,37 @@ block_1312 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1313, num_args:2 },
+    { op:'call', ret_to:@block_1499, num_args:2 },
   ]
 };
 
-block_1313 = {
+block_1499 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'push', val:'hasBranch' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1314, num_args:2 },
+    { op:'call', ret_to:@block_1500, num_args:2 },
   ]
 };
 
-block_1314 = {
+block_1500 = {
   instrs: [
-    { op:'call', ret_to:@block_1315, num_args:1 },
+    { op:'call', ret_to:@block_1501, num_args:1 },
   ]
 };
 
-block_1315 = {
+block_1501 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_not' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1316, num_args:1 },
+    { op:'call', ret_to:@block_1502, num_args:1 },
   ]
 };
 
-block_1317 = {
+block_1503 = {
   instrs: [
     { op:'get_local', idx:5 },
     { op:'push', val:2 },
@@ -12294,17 +13709,17 @@ block_1317 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1318, num_args:2 },
+    { op:'call', ret_to:@block_1504, num_args:2 },
   ]
 };
 
-block_1318 = {
+block_1504 = {
   instrs: [
-    { op:'call', ret_to:@block_1319, num_args:2 },
+    { op:'call', ret_to:@block_1505, num_args:2 },
   ]
 };
 
-block_1319 = {
+block_1505 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:5 },
@@ -12319,49 +13734,49 @@ block_1319 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1320, num_args:2 },
+    { op:'call', ret_to:@block_1506, num_args:2 },
   ]
 };
 
-block_1320 = {
+block_1506 = {
   instrs: [
-    { op:'call', ret_to:@block_1321, num_args:2 },
+    { op:'call', ret_to:@block_1507, num_args:2 },
   ]
 };
 
-block_1316 = {
+block_1502 = {
   instrs: [
-    { op:'if_true', then:@block_1317, else:@block_1322 },
+    { op:'if_true', then:@block_1503, else:@block_1508 },
   ]
 };
 
-block_1321 = {
+block_1507 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_1323 },
+    { op:'jump', to:@block_1509 },
   ]
 };
 
-block_1322 = {
+block_1508 = {
   instrs: [
-    { op:'jump', to:@block_1323 },
+    { op:'jump', to:@block_1509 },
   ]
 };
 
-block_1323 = {
+block_1509 = {
   instrs: [
     { op:'get_local', idx:3 },
     { op:'ret' },
   ]
 };
 
-fun_1302 = {
-  entry:@block_1301,
+fun_1488 = {
+  entry:@block_1487,
   num_params:1,
   num_locals:6,
 };
 
-block_1324 = {
+block_1510 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'Block' },
@@ -12370,17 +13785,17 @@ block_1324 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1326, num_args:2 },
+    { op:'call', ret_to:@block_1512, num_args:2 },
   ]
 };
 
-block_1326 = {
+block_1512 = {
   instrs: [
-    { op:'call', ret_to:@block_1327, num_args:0 },
+    { op:'call', ret_to:@block_1513, num_args:0 },
   ]
 };
 
-block_1327 = {
+block_1513 = {
   instrs: [
     { op:'set_local', idx:2 },
     { op:'get_local', idx:0 },
@@ -12390,17 +13805,17 @@ block_1327 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1328, num_args:2 },
+    { op:'call', ret_to:@block_1514, num_args:2 },
   ]
 };
 
-block_1328 = {
+block_1514 = {
   instrs: [
-    { op:'call', ret_to:@block_1329, num_args:2 },
+    { op:'call', ret_to:@block_1515, num_args:2 },
   ]
 };
 
-block_1329 = {
+block_1515 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -12421,11 +13836,11 @@ block_1329 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1330, num_args:2 },
+    { op:'call', ret_to:@block_1516, num_args:2 },
   ]
 };
 
-block_1330 = {
+block_1516 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:1 },
@@ -12433,17 +13848,17 @@ block_1330 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1331, num_args:2 },
+    { op:'call', ret_to:@block_1517, num_args:2 },
   ]
 };
 
-block_1331 = {
+block_1517 = {
   instrs: [
-    { op:'call', ret_to:@block_1332, num_args:2 },
+    { op:'call', ret_to:@block_1518, num_args:2 },
   ]
 };
 
-block_1332 = {
+block_1518 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -12453,17 +13868,17 @@ block_1332 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1333, num_args:2 },
+    { op:'call', ret_to:@block_1519, num_args:2 },
   ]
 };
 
-block_1333 = {
+block_1519 = {
   instrs: [
-    { op:'call', ret_to:@block_1334, num_args:2 },
+    { op:'call', ret_to:@block_1520, num_args:2 },
   ]
 };
 
-block_1334 = {
+block_1520 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -12471,13 +13886,13 @@ block_1334 = {
   ]
 };
 
-fun_1325 = {
-  entry:@block_1324,
+fun_1511 = {
+  entry:@block_1510,
   num_params:2,
   num_locals:3,
 };
 
-block_1335 = {
+block_1521 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -12486,11 +13901,11 @@ block_1335 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1337, num_args:2 },
+    { op:'call', ret_to:@block_1523, num_args:2 },
   ]
 };
 
-block_1338 = {
+block_1524 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
@@ -12498,28 +13913,28 @@ block_1338 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1339, num_args:2 },
+    { op:'call', ret_to:@block_1525, num_args:2 },
   ]
 };
 
-block_1339 = {
+block_1525 = {
   instrs: [
     { op:'dup', idx:1 },
     { op:'push', val:'addPush' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1340, num_args:2 },
+    { op:'call', ret_to:@block_1526, num_args:2 },
   ]
 };
 
-block_1340 = {
+block_1526 = {
   instrs: [
-    { op:'call', ret_to:@block_1341, num_args:2 },
+    { op:'call', ret_to:@block_1527, num_args:2 },
   ]
 };
 
-block_1341 = {
+block_1527 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -12527,19 +13942,19 @@ block_1341 = {
   ]
 };
 
-block_1337 = {
+block_1523 = {
   instrs: [
-    { op:'if_true', then:@block_1338, else:@block_1342 },
+    { op:'if_true', then:@block_1524, else:@block_1528 },
   ]
 };
 
-block_1342 = {
+block_1528 = {
   instrs: [
-    { op:'jump', to:@block_1343 },
+    { op:'jump', to:@block_1529 },
   ]
 };
 
-block_1343 = {
+block_1529 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -12548,11 +13963,11 @@ block_1343 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1344, num_args:2 },
+    { op:'call', ret_to:@block_1530, num_args:2 },
   ]
 };
 
-block_1345 = {
+block_1531 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
@@ -12560,28 +13975,28 @@ block_1345 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1346, num_args:2 },
+    { op:'call', ret_to:@block_1532, num_args:2 },
   ]
 };
 
-block_1346 = {
+block_1532 = {
   instrs: [
     { op:'dup', idx:1 },
     { op:'push', val:'addPush' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1347, num_args:2 },
+    { op:'call', ret_to:@block_1533, num_args:2 },
   ]
 };
 
-block_1347 = {
+block_1533 = {
   instrs: [
-    { op:'call', ret_to:@block_1348, num_args:2 },
+    { op:'call', ret_to:@block_1534, num_args:2 },
   ]
 };
 
-block_1348 = {
+block_1534 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -12589,19 +14004,19 @@ block_1348 = {
   ]
 };
 
-block_1344 = {
+block_1530 = {
   instrs: [
-    { op:'if_true', then:@block_1345, else:@block_1349 },
+    { op:'if_true', then:@block_1531, else:@block_1535 },
   ]
 };
 
-block_1349 = {
+block_1535 = {
   instrs: [
-    { op:'jump', to:@block_1350 },
+    { op:'jump', to:@block_1536 },
   ]
 };
 
-block_1350 = {
+block_1536 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -12610,32 +14025,32 @@ block_1350 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1351, num_args:2 },
+    { op:'call', ret_to:@block_1537, num_args:2 },
   ]
 };
 
-block_1352 = {
+block_1538 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'name' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1353, num_args:2 },
+    { op:'call', ret_to:@block_1539, num_args:2 },
   ]
 };
 
-block_1353 = {
+block_1539 = {
   instrs: [
     { op:'push', val:'exports' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1354, num_args:2 },
+    { op:'call', ret_to:@block_1540, num_args:2 },
   ]
 };
 
-block_1355 = {
+block_1541 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:0 },
@@ -12643,28 +14058,28 @@ block_1355 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1356, num_args:2 },
+    { op:'call', ret_to:@block_1542, num_args:2 },
   ]
 };
 
-block_1356 = {
+block_1542 = {
   instrs: [
     { op:'dup', idx:1 },
     { op:'push', val:'addPush' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1357, num_args:2 },
+    { op:'call', ret_to:@block_1543, num_args:2 },
   ]
 };
 
-block_1357 = {
+block_1543 = {
   instrs: [
-    { op:'call', ret_to:@block_1358, num_args:2 },
+    { op:'call', ret_to:@block_1544, num_args:2 },
   ]
 };
 
-block_1358 = {
+block_1544 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -12672,40 +14087,40 @@ block_1358 = {
   ]
 };
 
-block_1354 = {
+block_1540 = {
   instrs: [
-    { op:'if_true', then:@block_1355, else:@block_1359 },
+    { op:'if_true', then:@block_1541, else:@block_1545 },
   ]
 };
 
-block_1359 = {
+block_1545 = {
   instrs: [
-    { op:'jump', to:@block_1360 },
+    { op:'jump', to:@block_1546 },
   ]
 };
 
-block_1360 = {
+block_1546 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'name' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1361, num_args:2 },
+    { op:'call', ret_to:@block_1547, num_args:2 },
   ]
 };
 
-block_1361 = {
+block_1547 = {
   instrs: [
     { op:'push', val:'true' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1362, num_args:2 },
+    { op:'call', ret_to:@block_1548, num_args:2 },
   ]
 };
 
-block_1363 = {
+block_1549 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:$true },
@@ -12714,17 +14129,17 @@ block_1363 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1364, num_args:2 },
+    { op:'call', ret_to:@block_1550, num_args:2 },
   ]
 };
 
-block_1364 = {
+block_1550 = {
   instrs: [
-    { op:'call', ret_to:@block_1365, num_args:2 },
+    { op:'call', ret_to:@block_1551, num_args:2 },
   ]
 };
 
-block_1365 = {
+block_1551 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -12732,40 +14147,40 @@ block_1365 = {
   ]
 };
 
-block_1362 = {
+block_1548 = {
   instrs: [
-    { op:'if_true', then:@block_1363, else:@block_1366 },
+    { op:'if_true', then:@block_1549, else:@block_1552 },
   ]
 };
 
-block_1366 = {
+block_1552 = {
   instrs: [
-    { op:'jump', to:@block_1367 },
+    { op:'jump', to:@block_1553 },
   ]
 };
 
-block_1367 = {
+block_1553 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'name' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1368, num_args:2 },
+    { op:'call', ret_to:@block_1554, num_args:2 },
   ]
 };
 
-block_1368 = {
+block_1554 = {
   instrs: [
     { op:'push', val:'false' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1369, num_args:2 },
+    { op:'call', ret_to:@block_1555, num_args:2 },
   ]
 };
 
-block_1370 = {
+block_1556 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:$false },
@@ -12774,17 +14189,17 @@ block_1370 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1371, num_args:2 },
+    { op:'call', ret_to:@block_1557, num_args:2 },
   ]
 };
 
-block_1371 = {
+block_1557 = {
   instrs: [
-    { op:'call', ret_to:@block_1372, num_args:2 },
+    { op:'call', ret_to:@block_1558, num_args:2 },
   ]
 };
 
-block_1372 = {
+block_1558 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -12792,40 +14207,40 @@ block_1372 = {
   ]
 };
 
-block_1369 = {
+block_1555 = {
   instrs: [
-    { op:'if_true', then:@block_1370, else:@block_1373 },
+    { op:'if_true', then:@block_1556, else:@block_1559 },
   ]
 };
 
-block_1373 = {
+block_1559 = {
   instrs: [
-    { op:'jump', to:@block_1374 },
+    { op:'jump', to:@block_1560 },
   ]
 };
 
-block_1374 = {
+block_1560 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'name' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1375, num_args:2 },
+    { op:'call', ret_to:@block_1561, num_args:2 },
   ]
 };
 
-block_1375 = {
+block_1561 = {
   instrs: [
     { op:'push', val:'undef' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1376, num_args:2 },
+    { op:'call', ret_to:@block_1562, num_args:2 },
   ]
 };
 
-block_1377 = {
+block_1563 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:$undef },
@@ -12834,17 +14249,17 @@ block_1377 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1378, num_args:2 },
+    { op:'call', ret_to:@block_1564, num_args:2 },
   ]
 };
 
-block_1378 = {
+block_1564 = {
   instrs: [
-    { op:'call', ret_to:@block_1379, num_args:2 },
+    { op:'call', ret_to:@block_1565, num_args:2 },
   ]
 };
 
-block_1379 = {
+block_1565 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -12852,97 +14267,97 @@ block_1379 = {
   ]
 };
 
-block_1376 = {
+block_1562 = {
   instrs: [
-    { op:'if_true', then:@block_1377, else:@block_1380 },
+    { op:'if_true', then:@block_1563, else:@block_1566 },
   ]
 };
 
-block_1380 = {
+block_1566 = {
   instrs: [
-    { op:'jump', to:@block_1381 },
+    { op:'jump', to:@block_1567 },
   ]
 };
 
-block_1381 = {
+block_1567 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'fun' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1382, num_args:2 },
+    { op:'call', ret_to:@block_1568, num_args:2 },
   ]
 };
 
-block_1382 = {
+block_1568 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'name' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1383, num_args:2 },
+    { op:'call', ret_to:@block_1569, num_args:2 },
   ]
 };
 
-block_1383 = {
+block_1569 = {
   instrs: [
     { op:'dup', idx:1 },
     { op:'push', val:'hasLocal' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1384, num_args:2 },
+    { op:'call', ret_to:@block_1570, num_args:2 },
   ]
 };
 
-block_1384 = {
+block_1570 = {
   instrs: [
-    { op:'call', ret_to:@block_1385, num_args:2 },
+    { op:'call', ret_to:@block_1571, num_args:2 },
   ]
 };
 
-block_1386 = {
+block_1572 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'fun' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1387, num_args:2 },
+    { op:'call', ret_to:@block_1573, num_args:2 },
   ]
 };
 
-block_1387 = {
+block_1573 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'name' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1388, num_args:2 },
+    { op:'call', ret_to:@block_1574, num_args:2 },
   ]
 };
 
-block_1388 = {
+block_1574 = {
   instrs: [
     { op:'dup', idx:1 },
     { op:'push', val:'getLocalIdx' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1389, num_args:2 },
+    { op:'call', ret_to:@block_1575, num_args:2 },
   ]
 };
 
-block_1389 = {
+block_1575 = {
   instrs: [
-    { op:'call', ret_to:@block_1390, num_args:2 },
+    { op:'call', ret_to:@block_1576, num_args:2 },
   ]
 };
 
-block_1390 = {
+block_1576 = {
   instrs: [
     { op:'set_local', idx:2 },
     { op:'get_local', idx:0 },
@@ -12961,17 +14376,17 @@ block_1390 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1391, num_args:2 },
+    { op:'call', ret_to:@block_1577, num_args:2 },
   ]
 };
 
-block_1391 = {
+block_1577 = {
   instrs: [
-    { op:'call', ret_to:@block_1392, num_args:2 },
+    { op:'call', ret_to:@block_1578, num_args:2 },
   ]
 };
 
-block_1392 = {
+block_1578 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -12979,19 +14394,19 @@ block_1392 = {
   ]
 };
 
-block_1385 = {
+block_1571 = {
   instrs: [
-    { op:'if_true', then:@block_1386, else:@block_1393 },
+    { op:'if_true', then:@block_1572, else:@block_1579 },
   ]
 };
 
-block_1393 = {
+block_1579 = {
   instrs: [
-    { op:'jump', to:@block_1394 },
+    { op:'jump', to:@block_1580 },
   ]
 };
 
-block_1394 = {
+block_1580 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:0 },
@@ -12999,1802 +14414,14 @@ block_1394 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1395, num_args:2 },
-  ]
-};
-
-block_1395 = {
-  instrs: [
-    { op:'dup', idx:1 },
-    { op:'push', val:'addPush' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1396, num_args:2 },
-  ]
-};
-
-block_1396 = {
-  instrs: [
-    { op:'call', ret_to:@block_1397, num_args:2 },
-  ]
-};
-
-block_1397 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'name' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1398, num_args:2 },
-  ]
-};
-
-block_1398 = {
-  instrs: [
-    { op:'dup', idx:1 },
-    { op:'push', val:'addPush' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1399, num_args:2 },
-  ]
-};
-
-block_1399 = {
-  instrs: [
-    { op:'call', ret_to:@block_1400, num_args:2 },
-  ]
-};
-
-block_1400 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:'get_field' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addOp' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1401, num_args:2 },
-  ]
-};
-
-block_1401 = {
-  instrs: [
-    { op:'call', ret_to:@block_1402, num_args:2 },
-  ]
-};
-
-block_1402 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1351 = {
-  instrs: [
-    { op:'if_true', then:@block_1352, else:@block_1403 },
-  ]
-};
-
-block_1403 = {
-  instrs: [
-    { op:'jump', to:@block_1404 },
-  ]
-};
-
-block_1404 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'UnOpExpr' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_instOf' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1405, num_args:2 },
-  ]
-};
-
-block_1406 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'op' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1407, num_args:2 },
-  ]
-};
-
-block_1407 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'OP_NOT' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1408, num_args:2 },
-  ]
-};
-
-block_1409 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'expr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1410, num_args:2 },
-  ]
-};
-
-block_1410 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1411, num_args:2 },
-  ]
-};
-
-block_1411 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_not' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'runtimeCall' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1412, num_args:2 },
-  ]
-};
-
-block_1412 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1408 = {
-  instrs: [
-    { op:'if_true', then:@block_1409, else:@block_1413 },
-  ]
-};
-
-block_1413 = {
-  instrs: [
-    { op:'jump', to:@block_1414 },
-  ]
-};
-
-block_1414 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'op' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1415, num_args:2 },
-  ]
-};
-
-block_1415 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'OP_NEG' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1416, num_args:2 },
-  ]
-};
-
-block_1417 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:0 },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addPush' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1418, num_args:2 },
-  ]
-};
-
-block_1418 = {
-  instrs: [
-    { op:'call', ret_to:@block_1419, num_args:2 },
-  ]
-};
-
-block_1419 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'expr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1420, num_args:2 },
-  ]
-};
-
-block_1420 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1421, num_args:2 },
-  ]
-};
-
-block_1421 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_sub' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'runtimeCall' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1422, num_args:2 },
-  ]
-};
-
-block_1422 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1416 = {
-  instrs: [
-    { op:'if_true', then:@block_1417, else:@block_1423 },
-  ]
-};
-
-block_1423 = {
-  instrs: [
-    { op:'jump', to:@block_1424 },
-  ]
-};
-
-block_1424 = {
-  instrs: [
-    { op:'push', val:$false },
-    { op:'if_true', then:@block_1425, else:@block_1426 },
-  ]
-};
-
-block_1425 = {
-  instrs: [
-    { op:'jump', to:@block_1427 },
-  ]
-};
-
-block_1426 = {
-  instrs: [
-    { op:'push', val:'unhandled unary op' },
-    { op:'abort' },
-    { op:'jump', to:@block_1427 },
-  ]
-};
-
-block_1405 = {
-  instrs: [
-    { op:'if_true', then:@block_1406, else:@block_1428 },
-  ]
-};
-
-block_1427 = {
-  instrs: [
-    { op:'jump', to:@block_1429 },
-  ]
-};
-
-block_1428 = {
-  instrs: [
-    { op:'jump', to:@block_1429 },
-  ]
-};
-
-block_1429 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'BinOpExpr' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_instOf' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1430, num_args:2 },
-  ]
-};
-
-block_1431 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'op' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1432, num_args:2 },
-  ]
-};
-
-block_1432 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'OP_ASSIGN' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1433, num_args:2 },
-  ]
-};
-
-block_1434 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'lhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1435, num_args:2 },
-  ]
-};
-
-block_1435 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1436, num_args:2 },
-  ]
-};
-
-block_1436 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genAssign' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1437, num_args:3 },
-  ]
-};
-
-block_1437 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1433 = {
-  instrs: [
-    { op:'if_true', then:@block_1434, else:@block_1438 },
-  ]
-};
-
-block_1438 = {
-  instrs: [
-    { op:'jump', to:@block_1439 },
-  ]
-};
-
-block_1439 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'op' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1440, num_args:2 },
-  ]
-};
-
-block_1440 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'OP_AND' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1441, num_args:2 },
-  ]
-};
-
-block_1442 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'lhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1443, num_args:2 },
-  ]
-};
-
-block_1443 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1444, num_args:2 },
-  ]
-};
-
-block_1444 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genLogicalAnd' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1445, num_args:3 },
-  ]
-};
-
-block_1445 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1441 = {
-  instrs: [
-    { op:'if_true', then:@block_1442, else:@block_1446 },
-  ]
-};
-
-block_1446 = {
-  instrs: [
-    { op:'jump', to:@block_1447 },
-  ]
-};
-
-block_1447 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'op' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1448, num_args:2 },
-  ]
-};
-
-block_1448 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'OP_OR' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1449, num_args:2 },
-  ]
-};
-
-block_1450 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'lhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1451, num_args:2 },
-  ]
-};
-
-block_1451 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1452, num_args:2 },
-  ]
-};
-
-block_1452 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genLogicalOr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1453, num_args:3 },
-  ]
-};
-
-block_1453 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1449 = {
-  instrs: [
-    { op:'if_true', then:@block_1450, else:@block_1454 },
-  ]
-};
-
-block_1454 = {
-  instrs: [
-    { op:'jump', to:@block_1455 },
-  ]
-};
-
-block_1455 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'op' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1456, num_args:2 },
-  ]
-};
-
-block_1456 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'OP_EQ' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1457, num_args:2 },
-  ]
-};
-
-block_1458 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'lhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1459, num_args:2 },
-  ]
-};
-
-block_1459 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'UnOpExpr' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_instOf' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1460, num_args:2 },
-  ]
-};
-
-block_1461 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'lhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1462, num_args:2 },
-  ]
-};
-
-block_1462 = {
-  instrs: [
-    { op:'push', val:'op' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1463, num_args:2 },
-  ]
-};
-
-block_1463 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'OP_TYPEOF' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1464, num_args:2 },
-  ]
-};
-
-block_1465 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1466, num_args:2 },
-  ]
-};
-
-block_1466 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'StringExpr' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_instOf' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1467, num_args:2 },
-  ]
-};
-
-block_1468 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1469, num_args:2 },
-  ]
-};
-
-block_1469 = {
-  instrs: [
-    { op:'push', val:'val' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1470, num_args:2 },
-  ]
-};
-
-block_1470 = {
-  instrs: [
-    { op:'set_local', idx:3 },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'lhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1471, num_args:2 },
-  ]
-};
-
-block_1471 = {
-  instrs: [
-    { op:'push', val:'expr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1472, num_args:2 },
-  ]
-};
-
-block_1472 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1473, num_args:2 },
-  ]
-};
-
-block_1473 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:2 },
-    { op:'new_object' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'op' },
-    { op:'push', val:'has_tag' },
-    { op:'set_field' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'tag' },
-    { op:'get_local', idx:3 },
-    { op:'set_field' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addInstr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1474, num_args:2 },
-  ]
-};
-
-block_1474 = {
-  instrs: [
-    { op:'call', ret_to:@block_1475, num_args:2 },
-  ]
-};
-
-block_1475 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1467 = {
-  instrs: [
-    { op:'if_true', then:@block_1468, else:@block_1476 },
-  ]
-};
-
-block_1476 = {
-  instrs: [
-    { op:'jump', to:@block_1477 },
-  ]
-};
-
-block_1464 = {
-  instrs: [
-    { op:'if_true', then:@block_1465, else:@block_1478 },
-  ]
-};
-
-block_1477 = {
-  instrs: [
-    { op:'jump', to:@block_1479 },
-  ]
-};
-
-block_1478 = {
-  instrs: [
-    { op:'jump', to:@block_1479 },
-  ]
-};
-
-block_1460 = {
-  instrs: [
-    { op:'if_true', then:@block_1461, else:@block_1480 },
-  ]
-};
-
-block_1479 = {
-  instrs: [
-    { op:'jump', to:@block_1481 },
-  ]
-};
-
-block_1480 = {
-  instrs: [
-    { op:'jump', to:@block_1481 },
-  ]
-};
-
-block_1481 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'lhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1482, num_args:2 },
-  ]
-};
-
-block_1482 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1483, num_args:2 },
-  ]
-};
-
-block_1483 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1484, num_args:2 },
-  ]
-};
-
-block_1484 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1485, num_args:2 },
-  ]
-};
-
-block_1485 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'runtimeCall' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1486, num_args:2 },
-  ]
-};
-
-block_1486 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1457 = {
-  instrs: [
-    { op:'if_true', then:@block_1458, else:@block_1487 },
-  ]
-};
-
-block_1487 = {
-  instrs: [
-    { op:'jump', to:@block_1488 },
-  ]
-};
-
-block_1488 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'op' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1489, num_args:2 },
-  ]
-};
-
-block_1489 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'OP_NE' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1490, num_args:2 },
-  ]
-};
-
-block_1491 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'lhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1492, num_args:2 },
-  ]
-};
-
-block_1492 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1493, num_args:2 },
-  ]
-};
-
-block_1493 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1494, num_args:2 },
-  ]
-};
-
-block_1494 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1495, num_args:2 },
-  ]
-};
-
-block_1495 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_ne' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'runtimeCall' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1496, num_args:2 },
-  ]
-};
-
-block_1496 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1490 = {
-  instrs: [
-    { op:'if_true', then:@block_1491, else:@block_1497 },
-  ]
-};
-
-block_1497 = {
-  instrs: [
-    { op:'jump', to:@block_1498 },
-  ]
-};
-
-block_1498 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'op' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1499, num_args:2 },
-  ]
-};
-
-block_1499 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'OP_LT' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1500, num_args:2 },
-  ]
-};
-
-block_1501 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'lhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1502, num_args:2 },
-  ]
-};
-
-block_1502 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1503, num_args:2 },
-  ]
-};
-
-block_1503 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1504, num_args:2 },
-  ]
-};
-
-block_1504 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1505, num_args:2 },
-  ]
-};
-
-block_1505 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:'lt_i32' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addOp' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1506, num_args:2 },
-  ]
-};
-
-block_1506 = {
-  instrs: [
-    { op:'call', ret_to:@block_1507, num_args:2 },
-  ]
-};
-
-block_1507 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1500 = {
-  instrs: [
-    { op:'if_true', then:@block_1501, else:@block_1508 },
-  ]
-};
-
-block_1508 = {
-  instrs: [
-    { op:'jump', to:@block_1509 },
-  ]
-};
-
-block_1509 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'op' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1510, num_args:2 },
-  ]
-};
-
-block_1510 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'OP_LE' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1511, num_args:2 },
-  ]
-};
-
-block_1512 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'lhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1513, num_args:2 },
-  ]
-};
-
-block_1513 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1514, num_args:2 },
-  ]
-};
-
-block_1514 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1515, num_args:2 },
-  ]
-};
-
-block_1515 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1516, num_args:2 },
-  ]
-};
-
-block_1516 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_le' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'runtimeCall' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1517, num_args:2 },
-  ]
-};
-
-block_1517 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1511 = {
-  instrs: [
-    { op:'if_true', then:@block_1512, else:@block_1518 },
-  ]
-};
-
-block_1518 = {
-  instrs: [
-    { op:'jump', to:@block_1519 },
-  ]
-};
-
-block_1519 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'op' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1520, num_args:2 },
-  ]
-};
-
-block_1520 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'OP_GT' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1521, num_args:2 },
-  ]
-};
-
-block_1522 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'lhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1523, num_args:2 },
-  ]
-};
-
-block_1523 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1524, num_args:2 },
-  ]
-};
-
-block_1524 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1525, num_args:2 },
-  ]
-};
-
-block_1525 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1526, num_args:2 },
-  ]
-};
-
-block_1526 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:'gt_i32' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addOp' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1527, num_args:2 },
-  ]
-};
-
-block_1527 = {
-  instrs: [
-    { op:'call', ret_to:@block_1528, num_args:2 },
-  ]
-};
-
-block_1528 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1521 = {
-  instrs: [
-    { op:'if_true', then:@block_1522, else:@block_1529 },
-  ]
-};
-
-block_1529 = {
-  instrs: [
-    { op:'jump', to:@block_1530 },
-  ]
-};
-
-block_1530 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'op' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1531, num_args:2 },
-  ]
-};
-
-block_1531 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'OP_GE' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1532, num_args:2 },
-  ]
-};
-
-block_1533 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'lhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1534, num_args:2 },
-  ]
-};
-
-block_1534 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1535, num_args:2 },
-  ]
-};
-
-block_1535 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1536, num_args:2 },
-  ]
-};
-
-block_1536 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1537, num_args:2 },
-  ]
-};
-
-block_1537 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_ge' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'runtimeCall' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1538, num_args:2 },
-  ]
-};
-
-block_1538 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1532 = {
-  instrs: [
-    { op:'if_true', then:@block_1533, else:@block_1539 },
-  ]
-};
-
-block_1539 = {
-  instrs: [
-    { op:'jump', to:@block_1540 },
-  ]
-};
-
-block_1540 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'op' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1541, num_args:2 },
-  ]
-};
-
-block_1541 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'OP_IN' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1542, num_args:2 },
-  ]
-};
-
-block_1543 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'lhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1544, num_args:2 },
-  ]
-};
-
-block_1544 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1545, num_args:2 },
-  ]
-};
-
-block_1545 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1546, num_args:2 },
-  ]
-};
-
-block_1546 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1547, num_args:2 },
-  ]
-};
-
-block_1547 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_in' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'runtimeCall' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1548, num_args:2 },
-  ]
-};
-
-block_1548 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1542 = {
-  instrs: [
-    { op:'if_true', then:@block_1543, else:@block_1549 },
-  ]
-};
-
-block_1549 = {
-  instrs: [
-    { op:'jump', to:@block_1550 },
-  ]
-};
-
-block_1550 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'op' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1551, num_args:2 },
-  ]
-};
-
-block_1551 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'OP_ADD' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1552, num_args:2 },
-  ]
-};
-
-block_1553 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'lhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1554, num_args:2 },
-  ]
-};
-
-block_1554 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1555, num_args:2 },
-  ]
-};
-
-block_1555 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1556, num_args:2 },
-  ]
-};
-
-block_1556 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1557, num_args:2 },
-  ]
-};
-
-block_1557 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_add' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'runtimeCall' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1558, num_args:2 },
-  ]
-};
-
-block_1558 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1552 = {
-  instrs: [
-    { op:'if_true', then:@block_1553, else:@block_1559 },
-  ]
-};
-
-block_1559 = {
-  instrs: [
-    { op:'jump', to:@block_1560 },
-  ]
-};
-
-block_1560 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'op' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1561, num_args:2 },
-  ]
-};
-
-block_1561 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'OP_SUB' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1562, num_args:2 },
-  ]
-};
-
-block_1563 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'lhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1564, num_args:2 },
-  ]
-};
-
-block_1564 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1565, num_args:2 },
-  ]
-};
-
-block_1565 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1566, num_args:2 },
-  ]
-};
-
-block_1566 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1567, num_args:2 },
-  ]
-};
-
-block_1567 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_sub' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'runtimeCall' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1568, num_args:2 },
-  ]
-};
-
-block_1568 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1562 = {
-  instrs: [
-    { op:'if_true', then:@block_1563, else:@block_1569 },
-  ]
-};
-
-block_1569 = {
-  instrs: [
-    { op:'jump', to:@block_1570 },
-  ]
-};
-
-block_1570 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'op' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1571, num_args:2 },
-  ]
-};
-
-block_1571 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'OP_MUL' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1572, num_args:2 },
-  ]
-};
-
-block_1573 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'lhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1574, num_args:2 },
-  ]
-};
-
-block_1574 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1575, num_args:2 },
-  ]
-};
-
-block_1575 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1576, num_args:2 },
-  ]
-};
-
-block_1576 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1577, num_args:2 },
-  ]
-};
-
-block_1577 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:'mul_i32' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addOp' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1578, num_args:2 },
-  ]
-};
-
-block_1578 = {
-  instrs: [
-    { op:'call', ret_to:@block_1579, num_args:2 },
-  ]
-};
-
-block_1579 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1572 = {
-  instrs: [
-    { op:'if_true', then:@block_1573, else:@block_1580 },
-  ]
-};
-
-block_1580 = {
-  instrs: [
-    { op:'jump', to:@block_1581 },
+    { op:'call', ret_to:@block_1581, num_args:2 },
   ]
 };
 
 block_1581 = {
   instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'op' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addPush' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -14804,21 +14431,27 @@ block_1581 = {
 
 block_1582 = {
   instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'OP_MEMBER' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
     { op:'call', ret_to:@block_1583, num_args:2 },
+  ]
+};
+
+block_1583 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'name' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1584, num_args:2 },
   ]
 };
 
 block_1584 = {
   instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'lhsExpr' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addPush' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -14828,9 +14461,6 @@ block_1584 = {
 
 block_1585 = {
   instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
     { op:'call', ret_to:@block_1586, num_args:2 },
   ]
 };
@@ -14838,8 +14468,10 @@ block_1585 = {
 block_1586 = {
   instrs: [
     { op:'pop' },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:'get_field' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addOp' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -14849,104 +14481,82 @@ block_1586 = {
 
 block_1587 = {
   instrs: [
-    { op:'set_local', idx:4 },
-    { op:'get_local', idx:4 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'IdentExpr' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_instOf' },
-    { op:'get_field' },
     { op:'call', ret_to:@block_1588, num_args:2 },
   ]
 };
 
 block_1588 = {
   instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_not' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1589, num_args:1 },
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
   ]
 };
 
-block_1590 = {
+block_1537 = {
   instrs: [
-    { op:'push', val:$false },
-    { op:'push', val:'invalid rhs in member expression' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'parseError' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1591, num_args:2 },
+    { op:'if_true', then:@block_1538, else:@block_1589 },
   ]
 };
 
 block_1589 = {
   instrs: [
-    { op:'if_true', then:@block_1590, else:@block_1592 },
+    { op:'jump', to:@block_1590 },
   ]
 };
 
-block_1591 = {
+block_1590 = {
   instrs: [
-    { op:'pop' },
-    { op:'jump', to:@block_1593 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'UnOpExpr' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_instOf' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1591, num_args:2 },
   ]
 };
 
 block_1592 = {
   instrs: [
-    { op:'jump', to:@block_1593 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'op' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1593, num_args:2 },
   ]
 };
 
 block_1593 = {
   instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:2 },
-    { op:'new_object' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'op' },
-    { op:'push', val:'push' },
-    { op:'set_field' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'val' },
-    { op:'get_local', idx:4 },
-    { op:'push', val:'name' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'OP_NOT' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1594, num_args:2 },
   ]
 };
 
-block_1594 = {
+block_1595 = {
   instrs: [
-    { op:'set_field' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addInstr' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'expr' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1595, num_args:2 },
-  ]
-};
-
-block_1595 = {
-  instrs: [
     { op:'call', ret_to:@block_1596, num_args:2 },
   ]
 };
 
 block_1596 = {
   instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'runtimeCall' },
+    { op:'push', val:'genExpr' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1597, num_args:2 },
   ]
@@ -14955,62 +14565,68 @@ block_1596 = {
 block_1597 = {
   instrs: [
     { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1583 = {
-  instrs: [
-    { op:'if_true', then:@block_1584, else:@block_1598 },
+    { op:'get_local', idx:0 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_not' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'runtimeCall' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1598, num_args:2 },
   ]
 };
 
 block_1598 = {
   instrs: [
-    { op:'jump', to:@block_1599 },
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1594 = {
+  instrs: [
+    { op:'if_true', then:@block_1595, else:@block_1599 },
   ]
 };
 
 block_1599 = {
+  instrs: [
+    { op:'jump', to:@block_1600 },
+  ]
+};
+
+block_1600 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'op' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1600, num_args:2 },
-  ]
-};
-
-block_1600 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'OP_INDEX' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
     { op:'call', ret_to:@block_1601, num_args:2 },
   ]
 };
 
-block_1602 = {
+block_1601 = {
   instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'lhsExpr' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'OP_NEG' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1603, num_args:2 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1602, num_args:2 },
   ]
 };
 
 block_1603 = {
   instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:0 },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addPush' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
+    { op:'push', val:'rt_getProp' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1604, num_args:2 },
   ]
@@ -15018,21 +14634,18 @@ block_1603 = {
 
 block_1604 = {
   instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
     { op:'call', ret_to:@block_1605, num_args:2 },
   ]
 };
 
 block_1605 = {
   instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'expr' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
+    { op:'push', val:'rt_getProp' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1606, num_args:2 },
   ]
@@ -15040,13 +14653,8 @@ block_1605 = {
 
 block_1606 = {
   instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getElem' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'runtimeCall' },
+    { op:'push', val:'genExpr' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1607, num_args:2 },
   ]
@@ -15055,119 +14663,109 @@ block_1606 = {
 block_1607 = {
   instrs: [
     { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1601 = {
-  instrs: [
-    { op:'if_true', then:@block_1602, else:@block_1608 },
+    { op:'get_local', idx:0 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_sub' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'runtimeCall' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1608, num_args:2 },
   ]
 };
 
 block_1608 = {
   instrs: [
-    { op:'jump', to:@block_1609 },
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1602 = {
+  instrs: [
+    { op:'if_true', then:@block_1603, else:@block_1609 },
   ]
 };
 
 block_1609 = {
+  instrs: [
+    { op:'jump', to:@block_1610 },
+  ]
+};
+
+block_1610 = {
+  instrs: [
+    { op:'push', val:$false },
+    { op:'if_true', then:@block_1611, else:@block_1612 },
+  ]
+};
+
+block_1611 = {
+  instrs: [
+    { op:'jump', to:@block_1613 },
+  ]
+};
+
+block_1612 = {
+  instrs: [
+    { op:'push', val:'unhandled unary op' },
+    { op:'abort' },
+    { op:'jump', to:@block_1613 },
+  ]
+};
+
+block_1591 = {
+  instrs: [
+    { op:'if_true', then:@block_1592, else:@block_1614 },
+  ]
+};
+
+block_1613 = {
+  instrs: [
+    { op:'jump', to:@block_1615 },
+  ]
+};
+
+block_1614 = {
+  instrs: [
+    { op:'jump', to:@block_1615 },
+  ]
+};
+
+block_1615 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'BinOpExpr' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_instOf' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1616, num_args:2 },
+  ]
+};
+
+block_1617 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'op' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1610, num_args:2 },
-  ]
-};
-
-block_1610 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'OP_OBJ_EXT' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1611, num_args:2 },
-  ]
-};
-
-block_1612 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1613, num_args:2 },
-  ]
-};
-
-block_1613 = {
-  instrs: [
-    { op:'set_local', idx:5 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1614, num_args:2 },
-  ]
-};
-
-block_1614 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'ObjectExpr' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_instOf' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1615, num_args:2 },
-  ]
-};
-
-block_1615 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_not' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1616, num_args:1 },
-  ]
-};
-
-block_1617 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'input' },
-    { op:'get_field' },
-    { op:'push', val:'invalid rhs in objext extension expression' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'parseError' },
-    { op:'get_field' },
     { op:'call', ret_to:@block_1618, num_args:2 },
-  ]
-};
-
-block_1616 = {
-  instrs: [
-    { op:'if_true', then:@block_1617, else:@block_1619 },
   ]
 };
 
 block_1618 = {
   instrs: [
-    { op:'pop' },
-    { op:'jump', to:@block_1620 },
-  ]
-};
-
-block_1619 = {
-  instrs: [
-    { op:'jump', to:@block_1620 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'OP_ASSIGN' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1619, num_args:2 },
   ]
 };
 
@@ -15197,7 +14795,7 @@ block_1621 = {
 block_1622 = {
   instrs: [
     { op:'push', val:@global_obj },
-    { op:'push', val:'genObjExpr' },
+    { op:'push', val:'genAssign' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1623, num_args:3 },
   ]
@@ -15211,9 +14809,9 @@ block_1623 = {
   ]
 };
 
-block_1611 = {
+block_1619 = {
   instrs: [
-    { op:'if_true', then:@block_1612, else:@block_1624 },
+    { op:'if_true', then:@block_1620, else:@block_1624 },
   ]
 };
 
@@ -15223,21 +14821,34 @@ block_1624 = {
   ]
 };
 
-block_1627 = {
+block_1625 = {
   instrs: [
-    { op:'push', val:'unhandled binary op ' },
     { op:'get_local', idx:1 },
     { op:'push', val:'op' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1628, num_args:2 },
+    { op:'call', ret_to:@block_1626, num_args:2 },
+  ]
+};
+
+block_1626 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'OP_AND' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1627, num_args:2 },
   ]
 };
 
 block_1628 = {
   instrs: [
-    { op:'push', val:'str' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'lhsExpr' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -15247,42 +14858,35 @@ block_1628 = {
 
 block_1629 = {
   instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'rhsExpr' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_add' },
+    { op:'push', val:'rt_getProp' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1630, num_args:2 },
   ]
 };
 
-block_1625 = {
-  instrs: [
-    { op:'push', val:$false },
-    { op:'if_true', then:@block_1626, else:@block_1627 },
-  ]
-};
-
-block_1626 = {
-  instrs: [
-    { op:'jump', to:@block_1631 },
-  ]
-};
-
 block_1630 = {
   instrs: [
-    { op:'abort' },
-    { op:'jump', to:@block_1631 },
-  ]
-};
-
-block_1430 = {
-  instrs: [
-    { op:'if_true', then:@block_1431, else:@block_1632 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genLogicalAnd' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1631, num_args:3 },
   ]
 };
 
 block_1631 = {
   instrs: [
-    { op:'jump', to:@block_1633 },
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1627 = {
+  instrs: [
+    { op:'if_true', then:@block_1628, else:@block_1632 },
   ]
 };
 
@@ -15295,29 +14899,59 @@ block_1632 = {
 block_1633 = {
   instrs: [
     { op:'get_local', idx:1 },
+    { op:'push', val:'op' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'ObjectExpr' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_instOf' },
+    { op:'push', val:'rt_getProp' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1634, num_args:2 },
   ]
 };
 
-block_1635 = {
+block_1634 = {
   instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:$false },
-    { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
-    { op:'push', val:'genObjExpr' },
+    { op:'push', val:'OP_OR' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1636, num_args:3 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1635, num_args:2 },
   ]
 };
 
 block_1636 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'lhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1637, num_args:2 },
+  ]
+};
+
+block_1637 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'rhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1638, num_args:2 },
+  ]
+};
+
+block_1638 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genLogicalOr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1639, num_args:3 },
+  ]
+};
+
+block_1639 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -15325,54 +14959,22 @@ block_1636 = {
   ]
 };
 
-block_1634 = {
+block_1635 = {
   instrs: [
-    { op:'if_true', then:@block_1635, else:@block_1637 },
-  ]
-};
-
-block_1637 = {
-  instrs: [
-    { op:'jump', to:@block_1638 },
-  ]
-};
-
-block_1638 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'ArrayExpr' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_instOf' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1639, num_args:2 },
+    { op:'if_true', then:@block_1636, else:@block_1640 },
   ]
 };
 
 block_1640 = {
   instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:2 },
-    { op:'new_object' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'op' },
-    { op:'push', val:'push' },
-    { op:'set_field' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'val' },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'exprs' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1641, num_args:2 },
+    { op:'jump', to:@block_1641 },
   ]
 };
 
 block_1641 = {
   instrs: [
-    { op:'push', val:'length' },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'op' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -15382,29 +14984,20 @@ block_1641 = {
 
 block_1642 = {
   instrs: [
-    { op:'set_field' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addInstr' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'OP_EQ' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1643, num_args:2 },
   ]
 };
 
-block_1643 = {
-  instrs: [
-    { op:'call', ret_to:@block_1644, num_args:2 },
-  ]
-};
-
 block_1644 = {
   instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:'new_array' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addOp' },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'lhsExpr' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -15414,34 +15007,53 @@ block_1644 = {
 
 block_1645 = {
   instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'UnOpExpr' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_instOf' },
+    { op:'get_field' },
     { op:'call', ret_to:@block_1646, num_args:2 },
-  ]
-};
-
-block_1646 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:0 },
-    { op:'set_local', idx:6 },
-    { op:'jump', to:@block_1647 },
   ]
 };
 
 block_1647 = {
   instrs: [
-    { op:'get_local', idx:6 },
     { op:'get_local', idx:1 },
-    { op:'push', val:'exprs' },
+    { op:'push', val:'lhsExpr' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1651, num_args:2 },
+    { op:'call', ret_to:@block_1648, num_args:2 },
+  ]
+};
+
+block_1648 = {
+  instrs: [
+    { op:'push', val:'op' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1649, num_args:2 },
+  ]
+};
+
+block_1649 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'OP_TYPEOF' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1650, num_args:2 },
   ]
 };
 
 block_1651 = {
   instrs: [
-    { op:'push', val:'length' },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'rhsExpr' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -15451,45 +15063,20 @@ block_1651 = {
 
 block_1652 = {
   instrs: [
-    { op:'lt_i32' },
-    { op:'if_true', then:@block_1648, else:@block_1650 },
-  ]
-};
-
-block_1648 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:2 },
-    { op:'new_object' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'op' },
-    { op:'push', val:'dup' },
-    { op:'set_field' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'idx' },
-    { op:'push', val:0 },
-    { op:'set_field' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addInstr' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'StringExpr' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_instOf' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1653, num_args:2 },
   ]
 };
 
-block_1653 = {
-  instrs: [
-    { op:'call', ret_to:@block_1654, num_args:2 },
-  ]
-};
-
 block_1654 = {
   instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
-    { op:'push', val:'exprs' },
+    { op:'push', val:'rhsExpr' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -15499,9 +15086,9 @@ block_1654 = {
 
 block_1655 = {
   instrs: [
-    { op:'get_local', idx:6 },
+    { op:'push', val:'val' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getElem' },
+    { op:'push', val:'rt_getProp' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1656, num_args:2 },
   ]
@@ -15509,8 +15096,12 @@ block_1655 = {
 
 block_1656 = {
   instrs: [
+    { op:'set_local', idx:3 },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'lhsExpr' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
+    { op:'push', val:'rt_getProp' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1657, num_args:2 },
   ]
@@ -15518,11 +15109,7 @@ block_1656 = {
 
 block_1657 = {
   instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:'array_push' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addOp' },
+    { op:'push', val:'expr' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -15532,6 +15119,9 @@ block_1657 = {
 
 block_1658 = {
   instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
     { op:'call', ret_to:@block_1659, num_args:2 },
   ]
 };
@@ -15539,16 +15129,21 @@ block_1658 = {
 block_1659 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_1649 },
-  ]
-};
-
-block_1649 = {
-  instrs: [
-    { op:'get_local', idx:6 },
-    { op:'push', val:1 },
+    { op:'get_local', idx:0 },
+    { op:'push', val:2 },
+    { op:'new_object' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'op' },
+    { op:'push', val:'has_tag' },
+    { op:'set_field' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'tag' },
+    { op:'get_local', idx:3 },
+    { op:'set_field' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addInstr' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_add' },
+    { op:'push', val:'rt_getProp' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1660, num_args:2 },
   ]
@@ -15556,79 +15151,71 @@ block_1649 = {
 
 block_1660 = {
   instrs: [
-    { op:'dup', idx:0 },
-    { op:'set_local', idx:6 },
-    { op:'pop' },
-    { op:'jump', to:@block_1647 },
-  ]
-};
-
-block_1650 = {
-  instrs: [
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1639 = {
-  instrs: [
-    { op:'if_true', then:@block_1640, else:@block_1661 },
+    { op:'call', ret_to:@block_1661, num_args:2 },
   ]
 };
 
 block_1661 = {
   instrs: [
-    { op:'jump', to:@block_1662 },
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1653 = {
+  instrs: [
+    { op:'if_true', then:@block_1654, else:@block_1662 },
   ]
 };
 
 block_1662 = {
   instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'FunExpr' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_instOf' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1663, num_args:2 },
+    { op:'jump', to:@block_1663 },
+  ]
+};
+
+block_1650 = {
+  instrs: [
+    { op:'if_true', then:@block_1651, else:@block_1664 },
+  ]
+};
+
+block_1663 = {
+  instrs: [
+    { op:'jump', to:@block_1665 },
   ]
 };
 
 block_1664 = {
   instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'Block' },
-    { op:'get_field' },
-    { op:'push', val:'new' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1665, num_args:2 },
+    { op:'jump', to:@block_1665 },
+  ]
+};
+
+block_1646 = {
+  instrs: [
+    { op:'if_true', then:@block_1647, else:@block_1666 },
   ]
 };
 
 block_1665 = {
   instrs: [
-    { op:'call', ret_to:@block_1666, num_args:0 },
+    { op:'jump', to:@block_1667 },
   ]
 };
 
 block_1666 = {
   instrs: [
-    { op:'set_local', idx:7 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'params' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1667, num_args:2 },
+    { op:'jump', to:@block_1667 },
   ]
 };
 
 block_1667 = {
   instrs: [
-    { op:'push', val:'length' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'lhsExpr' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -15638,13 +15225,8 @@ block_1667 = {
 
 block_1668 = {
   instrs: [
-    { op:'get_local', idx:7 },
     { op:'push', val:@global_obj },
-    { op:'push', val:'Function' },
-    { op:'get_field' },
-    { op:'push', val:'new' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'genExpr' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1669, num_args:2 },
   ]
@@ -15652,24 +15234,64 @@ block_1668 = {
 
 block_1669 = {
   instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'rhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
     { op:'call', ret_to:@block_1670, num_args:2 },
   ]
 };
 
 block_1670 = {
   instrs: [
-    { op:'set_local', idx:8 },
-    { op:'push', val:0 },
-    { op:'set_local', idx:6 },
-    { op:'jump', to:@block_1671 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1671, num_args:2 },
   ]
 };
 
 block_1671 = {
   instrs: [
-    { op:'get_local', idx:6 },
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'runtimeCall' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1672, num_args:2 },
+  ]
+};
+
+block_1672 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1643 = {
+  instrs: [
+    { op:'if_true', then:@block_1644, else:@block_1673 },
+  ]
+};
+
+block_1673 = {
+  instrs: [
+    { op:'jump', to:@block_1674 },
+  ]
+};
+
+block_1674 = {
+  instrs: [
     { op:'get_local', idx:1 },
-    { op:'push', val:'params' },
+    { op:'push', val:'op' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -15679,38 +15301,23 @@ block_1671 = {
 
 block_1675 = {
   instrs: [
-    { op:'push', val:'length' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'OP_NE' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1676, num_args:2 },
   ]
 };
 
-block_1676 = {
-  instrs: [
-    { op:'lt_i32' },
-    { op:'if_true', then:@block_1672, else:@block_1674 },
-  ]
-};
-
-block_1672 = {
-  instrs: [
-    { op:'get_local', idx:8 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'params' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1677, num_args:2 },
-  ]
-};
-
 block_1677 = {
   instrs: [
-    { op:'get_local', idx:6 },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'lhsExpr' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getElem' },
+    { op:'push', val:'rt_getProp' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1678, num_args:2 },
   ]
@@ -15718,10 +15325,8 @@ block_1677 = {
 
 block_1678 = {
   instrs: [
-    { op:'dup', idx:1 },
-    { op:'push', val:'registerDecl' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'genExpr' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1679, num_args:2 },
   ]
@@ -15729,23 +15334,21 @@ block_1678 = {
 
 block_1679 = {
   instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'rhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
     { op:'call', ret_to:@block_1680, num_args:2 },
   ]
 };
 
 block_1680 = {
   instrs: [
-    { op:'pop' },
-    { op:'jump', to:@block_1673 },
-  ]
-};
-
-block_1673 = {
-  instrs: [
-    { op:'get_local', idx:6 },
-    { op:'push', val:1 },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_add' },
+    { op:'push', val:'genExpr' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1681, num_args:2 },
   ]
@@ -15753,20 +15356,13 @@ block_1673 = {
 
 block_1681 = {
   instrs: [
-    { op:'dup', idx:0 },
-    { op:'set_local', idx:6 },
     { op:'pop' },
-    { op:'jump', to:@block_1671 },
-  ]
-};
-
-block_1674 = {
-  instrs: [
-    { op:'get_local', idx:8 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'body' },
+    { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'rt_ne' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'runtimeCall' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1682, num_args:2 },
   ]
@@ -15774,30 +15370,28 @@ block_1674 = {
 
 block_1682 = {
   instrs: [
-    { op:'push', val:$false },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'registerDecls' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1683, num_args:3 },
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1676 = {
+  instrs: [
+    { op:'if_true', then:@block_1677, else:@block_1683 },
   ]
 };
 
 block_1683 = {
   instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:'exportsObj' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1684, num_args:2 },
+    { op:'jump', to:@block_1684 },
   ]
 };
 
 block_1684 = {
   instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'globalObj' },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'op' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -15807,32 +15401,21 @@ block_1684 = {
 
 block_1685 = {
   instrs: [
-    { op:'get_local', idx:8 },
-    { op:'push', val:$false },
-    { op:'get_local', idx:7 },
     { op:'push', val:@global_obj },
-    { op:'push', val:'CodeGenCtx' },
+    { op:'push', val:'OP_LT' },
     { op:'get_field' },
-    { op:'push', val:'new' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'rt_eq' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1686, num_args:2 },
   ]
 };
 
-block_1686 = {
-  instrs: [
-    { op:'call', ret_to:@block_1687, num_args:5 },
-  ]
-};
-
 block_1687 = {
   instrs: [
-    { op:'set_local', idx:9 },
-    { op:'get_local', idx:9 },
+    { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
-    { op:'push', val:'body' },
+    { op:'push', val:'lhsExpr' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -15843,7 +15426,7 @@ block_1687 = {
 block_1688 = {
   instrs: [
     { op:'push', val:@global_obj },
-    { op:'push', val:'genStmt' },
+    { op:'push', val:'genExpr' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1689, num_args:2 },
   ]
@@ -15852,8 +15435,9 @@ block_1688 = {
 block_1689 = {
   instrs: [
     { op:'pop' },
-    { op:'get_local', idx:9 },
-    { op:'push', val:'curBlock' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'rhsExpr' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -15863,10 +15447,8 @@ block_1689 = {
 
 block_1690 = {
   instrs: [
-    { op:'dup', idx:0 },
-    { op:'push', val:'hasBranch' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'genExpr' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1691, num_args:2 },
   ]
@@ -15874,101 +15456,94 @@ block_1690 = {
 
 block_1691 = {
   instrs: [
-    { op:'call', ret_to:@block_1692, num_args:1 },
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:'lt_i32' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addOp' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1692, num_args:2 },
   ]
 };
 
 block_1692 = {
   instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_not' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1693, num_args:1 },
+    { op:'call', ret_to:@block_1693, num_args:2 },
+  ]
+};
+
+block_1693 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1686 = {
+  instrs: [
+    { op:'if_true', then:@block_1687, else:@block_1694 },
   ]
 };
 
 block_1694 = {
   instrs: [
-    { op:'get_local', idx:9 },
-    { op:'push', val:2 },
-    { op:'new_object' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'op' },
-    { op:'push', val:'push' },
-    { op:'set_field' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'val' },
-    { op:'push', val:$undef },
-    { op:'set_field' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addInstr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1695, num_args:2 },
+    { op:'jump', to:@block_1695 },
   ]
 };
 
 block_1695 = {
   instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'op' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
     { op:'call', ret_to:@block_1696, num_args:2 },
   ]
 };
 
 block_1696 = {
   instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:9 },
-    { op:'push', val:'ret' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addOp' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'OP_LE' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1697, num_args:2 },
   ]
 };
 
-block_1697 = {
-  instrs: [
-    { op:'call', ret_to:@block_1698, num_args:2 },
-  ]
-};
-
-block_1693 = {
-  instrs: [
-    { op:'if_true', then:@block_1694, else:@block_1699 },
-  ]
-};
-
 block_1698 = {
   instrs: [
-    { op:'pop' },
-    { op:'jump', to:@block_1700 },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'lhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1699, num_args:2 },
   ]
 };
 
 block_1699 = {
   instrs: [
-    { op:'jump', to:@block_1700 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1700, num_args:2 },
   ]
 };
 
 block_1700 = {
   instrs: [
+    { op:'pop' },
     { op:'get_local', idx:0 },
-    { op:'push', val:2 },
-    { op:'new_object' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'op' },
-    { op:'push', val:'push' },
-    { op:'set_field' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'val' },
-    { op:'get_local', idx:8 },
-    { op:'set_field' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addInstr' },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'rhsExpr' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -15978,6 +15553,9 @@ block_1700 = {
 
 block_1701 = {
   instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
     { op:'call', ret_to:@block_1702, num_args:2 },
   ]
 };
@@ -15985,63 +15563,98 @@ block_1701 = {
 block_1702 = {
   instrs: [
     { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1663 = {
-  instrs: [
-    { op:'if_true', then:@block_1664, else:@block_1703 },
+    { op:'get_local', idx:0 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_le' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'runtimeCall' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1703, num_args:2 },
   ]
 };
 
 block_1703 = {
   instrs: [
-    { op:'jump', to:@block_1704 },
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1697 = {
+  instrs: [
+    { op:'if_true', then:@block_1698, else:@block_1704 },
   ]
 };
 
 block_1704 = {
   instrs: [
+    { op:'jump', to:@block_1705 },
+  ]
+};
+
+block_1705 = {
+  instrs: [
     { op:'get_local', idx:1 },
+    { op:'push', val:'op' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'CallExpr' },
+    { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_instOf' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1705, num_args:2 },
+    { op:'call', ret_to:@block_1706, num_args:2 },
   ]
 };
 
 block_1706 = {
   instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'argExprs' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'OP_GT' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1707, num_args:2 },
   ]
 };
 
-block_1707 = {
+block_1708 = {
   instrs: [
-    { op:'set_local', idx:10 },
-    { op:'push', val:0 },
-    { op:'set_local', idx:6 },
-    { op:'jump', to:@block_1708 },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'lhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1709, num_args:2 },
   ]
 };
 
-block_1708 = {
+block_1709 = {
   instrs: [
-    { op:'get_local', idx:6 },
-    { op:'get_local', idx:10 },
-    { op:'push', val:'length' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1710, num_args:2 },
+  ]
+};
+
+block_1710 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'rhsExpr' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1711, num_args:2 },
+  ]
+};
+
+block_1711 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1712, num_args:2 },
   ]
@@ -16049,18 +15662,13 @@ block_1708 = {
 
 block_1712 = {
   instrs: [
-    { op:'lt_i32' },
-    { op:'if_true', then:@block_1709, else:@block_1711 },
-  ]
-};
-
-block_1709 = {
-  instrs: [
+    { op:'pop' },
     { op:'get_local', idx:0 },
-    { op:'get_local', idx:10 },
-    { op:'get_local', idx:6 },
+    { op:'push', val:'gt_i32' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addOp' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getElem' },
+    { op:'push', val:'rt_getProp' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1713, num_args:2 },
   ]
@@ -16068,9 +15676,6 @@ block_1709 = {
 
 block_1713 = {
   instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
     { op:'call', ret_to:@block_1714, num_args:2 },
   ]
 };
@@ -16078,46 +15683,29 @@ block_1713 = {
 block_1714 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_1710 },
+    { op:'push', val:$undef },
+    { op:'ret' },
   ]
 };
 
-block_1710 = {
+block_1707 = {
   instrs: [
-    { op:'get_local', idx:6 },
-    { op:'push', val:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_add' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1715, num_args:2 },
+    { op:'if_true', then:@block_1708, else:@block_1715 },
   ]
 };
 
 block_1715 = {
   instrs: [
-    { op:'dup', idx:0 },
-    { op:'set_local', idx:6 },
-    { op:'pop' },
-    { op:'jump', to:@block_1708 },
-  ]
-};
-
-block_1711 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'funExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1716, num_args:2 },
+    { op:'jump', to:@block_1716 },
   ]
 };
 
 block_1716 = {
   instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'op' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
+    { op:'push', val:'rt_getProp' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1717, num_args:2 },
   ]
@@ -16125,42 +15713,21 @@ block_1716 = {
 
 block_1717 = {
   instrs: [
-    { op:'pop' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'Block' },
+    { op:'push', val:'OP_GE' },
     { op:'get_field' },
-    { op:'push', val:'new' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'rt_eq' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1718, num_args:2 },
   ]
 };
 
-block_1718 = {
-  instrs: [
-    { op:'call', ret_to:@block_1719, num_args:0 },
-  ]
-};
-
 block_1719 = {
   instrs: [
-    { op:'set_local', idx:11 },
     { op:'get_local', idx:0 },
-    { op:'push', val:4 },
-    { op:'new_object' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'op' },
-    { op:'push', val:'call' },
-    { op:'set_field' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'ret_to' },
-    { op:'get_local', idx:11 },
-    { op:'set_field' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'num_args' },
-    { op:'get_local', idx:10 },
-    { op:'push', val:'length' },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'lhsExpr' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -16170,13 +15737,8 @@ block_1719 = {
 
 block_1720 = {
   instrs: [
-    { op:'set_field' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'src_pos' },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'srcPos' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'genExpr' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1721, num_args:2 },
   ]
@@ -16184,9 +15746,10 @@ block_1720 = {
 
 block_1721 = {
   instrs: [
-    { op:'set_field' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addInstr' },
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'rhsExpr' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -16196,6 +15759,9 @@ block_1721 = {
 
 block_1722 = {
   instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
     { op:'call', ret_to:@block_1723, num_args:2 },
   ]
 };
@@ -16204,11 +15770,11 @@ block_1723 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
-    { op:'get_local', idx:11 },
-    { op:'dup', idx:1 },
-    { op:'push', val:'merge' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'rt_ge' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'runtimeCall' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1724, num_args:2 },
   ]
@@ -16216,38 +15782,42 @@ block_1723 = {
 
 block_1724 = {
   instrs: [
-    { op:'call', ret_to:@block_1725, num_args:2 },
-  ]
-};
-
-block_1725 = {
-  instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-block_1705 = {
+block_1718 = {
   instrs: [
-    { op:'if_true', then:@block_1706, else:@block_1726 },
+    { op:'if_true', then:@block_1719, else:@block_1725 },
+  ]
+};
+
+block_1725 = {
+  instrs: [
+    { op:'jump', to:@block_1726 },
   ]
 };
 
 block_1726 = {
   instrs: [
-    { op:'jump', to:@block_1727 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'op' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1727, num_args:2 },
   ]
 };
 
 block_1727 = {
   instrs: [
-    { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
-    { op:'push', val:'MethodCallExpr' },
+    { op:'push', val:'OP_IN' },
     { op:'get_field' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_instOf' },
+    { op:'push', val:'rt_eq' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1728, num_args:2 },
   ]
@@ -16255,8 +15825,9 @@ block_1727 = {
 
 block_1729 = {
   instrs: [
+    { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
-    { op:'push', val:'argExprs' },
+    { op:'push', val:'lhsExpr' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -16266,12 +15837,8 @@ block_1729 = {
 
 block_1730 = {
   instrs: [
-    { op:'set_local', idx:10 },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'baseExpr' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'genExpr' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1731, num_args:2 },
   ]
@@ -16279,8 +15846,12 @@ block_1730 = {
 
 block_1731 = {
   instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'rhsExpr' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
+    { op:'push', val:'rt_getProp' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1732, num_args:2 },
   ]
@@ -16288,18 +15859,51 @@ block_1731 = {
 
 block_1732 = {
   instrs: [
-    { op:'pop' },
-    { op:'push', val:0 },
-    { op:'set_local', idx:6 },
-    { op:'jump', to:@block_1733 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1733, num_args:2 },
   ]
 };
 
 block_1733 = {
   instrs: [
-    { op:'get_local', idx:6 },
-    { op:'get_local', idx:10 },
-    { op:'push', val:'length' },
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_in' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'runtimeCall' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1734, num_args:2 },
+  ]
+};
+
+block_1734 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1728 = {
+  instrs: [
+    { op:'if_true', then:@block_1729, else:@block_1735 },
+  ]
+};
+
+block_1735 = {
+  instrs: [
+    { op:'jump', to:@block_1736 },
+  ]
+};
+
+block_1736 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'op' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -16309,45 +15913,23 @@ block_1733 = {
 
 block_1737 = {
   instrs: [
-    { op:'lt_i32' },
-    { op:'if_true', then:@block_1734, else:@block_1736 },
-  ]
-};
-
-block_1734 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:10 },
-    { op:'get_local', idx:6 },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getElem' },
+    { op:'push', val:'OP_ADD' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1738, num_args:2 },
   ]
 };
 
-block_1738 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1739, num_args:2 },
-  ]
-};
-
 block_1739 = {
   instrs: [
-    { op:'pop' },
-    { op:'jump', to:@block_1735 },
-  ]
-};
-
-block_1735 = {
-  instrs: [
-    { op:'get_local', idx:6 },
-    { op:'push', val:1 },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'lhsExpr' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_add' },
+    { op:'push', val:'rt_getProp' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1740, num_args:2 },
   ]
@@ -16355,28 +15937,8 @@ block_1735 = {
 
 block_1740 = {
   instrs: [
-    { op:'dup', idx:0 },
-    { op:'set_local', idx:6 },
-    { op:'pop' },
-    { op:'jump', to:@block_1733 },
-  ]
-};
-
-block_1736 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:2 },
-    { op:'new_object' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'op' },
-    { op:'push', val:'dup' },
-    { op:'set_field' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'idx' },
-    { op:'get_local', idx:10 },
-    { op:'push', val:'length' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'genExpr' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1741, num_args:2 },
   ]
@@ -16384,9 +15946,10 @@ block_1736 = {
 
 block_1741 = {
   instrs: [
-    { op:'set_field' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addInstr' },
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'rhsExpr' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -16396,6 +15959,9 @@ block_1741 = {
 
 block_1742 = {
   instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
     { op:'call', ret_to:@block_1743, num_args:2 },
   ]
 };
@@ -16403,6 +15969,804 @@ block_1742 = {
 block_1743 = {
   instrs: [
     { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_add' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'runtimeCall' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1744, num_args:2 },
+  ]
+};
+
+block_1744 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1738 = {
+  instrs: [
+    { op:'if_true', then:@block_1739, else:@block_1745 },
+  ]
+};
+
+block_1745 = {
+  instrs: [
+    { op:'jump', to:@block_1746 },
+  ]
+};
+
+block_1746 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'op' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1747, num_args:2 },
+  ]
+};
+
+block_1747 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'OP_SUB' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1748, num_args:2 },
+  ]
+};
+
+block_1749 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'lhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1750, num_args:2 },
+  ]
+};
+
+block_1750 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1751, num_args:2 },
+  ]
+};
+
+block_1751 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'rhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1752, num_args:2 },
+  ]
+};
+
+block_1752 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1753, num_args:2 },
+  ]
+};
+
+block_1753 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_sub' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'runtimeCall' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1754, num_args:2 },
+  ]
+};
+
+block_1754 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1748 = {
+  instrs: [
+    { op:'if_true', then:@block_1749, else:@block_1755 },
+  ]
+};
+
+block_1755 = {
+  instrs: [
+    { op:'jump', to:@block_1756 },
+  ]
+};
+
+block_1756 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'op' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1757, num_args:2 },
+  ]
+};
+
+block_1757 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'OP_MUL' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1758, num_args:2 },
+  ]
+};
+
+block_1759 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'lhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1760, num_args:2 },
+  ]
+};
+
+block_1760 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1761, num_args:2 },
+  ]
+};
+
+block_1761 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'rhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1762, num_args:2 },
+  ]
+};
+
+block_1762 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1763, num_args:2 },
+  ]
+};
+
+block_1763 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:'mul_i32' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addOp' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1764, num_args:2 },
+  ]
+};
+
+block_1764 = {
+  instrs: [
+    { op:'call', ret_to:@block_1765, num_args:2 },
+  ]
+};
+
+block_1765 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1758 = {
+  instrs: [
+    { op:'if_true', then:@block_1759, else:@block_1766 },
+  ]
+};
+
+block_1766 = {
+  instrs: [
+    { op:'jump', to:@block_1767 },
+  ]
+};
+
+block_1767 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'op' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1768, num_args:2 },
+  ]
+};
+
+block_1768 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'OP_MEMBER' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1769, num_args:2 },
+  ]
+};
+
+block_1770 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'lhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1771, num_args:2 },
+  ]
+};
+
+block_1771 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1772, num_args:2 },
+  ]
+};
+
+block_1772 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'rhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1773, num_args:2 },
+  ]
+};
+
+block_1773 = {
+  instrs: [
+    { op:'set_local', idx:4 },
+    { op:'get_local', idx:4 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'IdentExpr' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_instOf' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1774, num_args:2 },
+  ]
+};
+
+block_1774 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_not' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1775, num_args:1 },
+  ]
+};
+
+block_1776 = {
+  instrs: [
+    { op:'push', val:$false },
+    { op:'push', val:'invalid rhs in member expression' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'parseError' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1777, num_args:2 },
+  ]
+};
+
+block_1775 = {
+  instrs: [
+    { op:'if_true', then:@block_1776, else:@block_1778 },
+  ]
+};
+
+block_1777 = {
+  instrs: [
+    { op:'pop' },
+    { op:'jump', to:@block_1779 },
+  ]
+};
+
+block_1778 = {
+  instrs: [
+    { op:'jump', to:@block_1779 },
+  ]
+};
+
+block_1779 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:2 },
+    { op:'new_object' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'op' },
+    { op:'push', val:'push' },
+    { op:'set_field' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'val' },
+    { op:'get_local', idx:4 },
+    { op:'push', val:'name' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1780, num_args:2 },
+  ]
+};
+
+block_1780 = {
+  instrs: [
+    { op:'set_field' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addInstr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1781, num_args:2 },
+  ]
+};
+
+block_1781 = {
+  instrs: [
+    { op:'call', ret_to:@block_1782, num_args:2 },
+  ]
+};
+
+block_1782 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'runtimeCall' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1783, num_args:2 },
+  ]
+};
+
+block_1783 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1769 = {
+  instrs: [
+    { op:'if_true', then:@block_1770, else:@block_1784 },
+  ]
+};
+
+block_1784 = {
+  instrs: [
+    { op:'jump', to:@block_1785 },
+  ]
+};
+
+block_1785 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'op' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1786, num_args:2 },
+  ]
+};
+
+block_1786 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'OP_INDEX' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1787, num_args:2 },
+  ]
+};
+
+block_1788 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'lhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1789, num_args:2 },
+  ]
+};
+
+block_1789 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1790, num_args:2 },
+  ]
+};
+
+block_1790 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'rhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1791, num_args:2 },
+  ]
+};
+
+block_1791 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1792, num_args:2 },
+  ]
+};
+
+block_1792 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getElem' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'runtimeCall' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1793, num_args:2 },
+  ]
+};
+
+block_1793 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1787 = {
+  instrs: [
+    { op:'if_true', then:@block_1788, else:@block_1794 },
+  ]
+};
+
+block_1794 = {
+  instrs: [
+    { op:'jump', to:@block_1795 },
+  ]
+};
+
+block_1795 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'op' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1796, num_args:2 },
+  ]
+};
+
+block_1796 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'OP_OBJ_EXT' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1797, num_args:2 },
+  ]
+};
+
+block_1798 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'rhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1799, num_args:2 },
+  ]
+};
+
+block_1799 = {
+  instrs: [
+    { op:'set_local', idx:5 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'rhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1800, num_args:2 },
+  ]
+};
+
+block_1800 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'ObjectExpr' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_instOf' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1801, num_args:2 },
+  ]
+};
+
+block_1801 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_not' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1802, num_args:1 },
+  ]
+};
+
+block_1803 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'input' },
+    { op:'get_field' },
+    { op:'push', val:'invalid rhs in objext extension expression' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'parseError' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1804, num_args:2 },
+  ]
+};
+
+block_1802 = {
+  instrs: [
+    { op:'if_true', then:@block_1803, else:@block_1805 },
+  ]
+};
+
+block_1804 = {
+  instrs: [
+    { op:'pop' },
+    { op:'jump', to:@block_1806 },
+  ]
+};
+
+block_1805 = {
+  instrs: [
+    { op:'jump', to:@block_1806 },
+  ]
+};
+
+block_1806 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'lhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1807, num_args:2 },
+  ]
+};
+
+block_1807 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'rhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1808, num_args:2 },
+  ]
+};
+
+block_1808 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genObjExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1809, num_args:3 },
+  ]
+};
+
+block_1809 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1797 = {
+  instrs: [
+    { op:'if_true', then:@block_1798, else:@block_1810 },
+  ]
+};
+
+block_1810 = {
+  instrs: [
+    { op:'jump', to:@block_1811 },
+  ]
+};
+
+block_1813 = {
+  instrs: [
+    { op:'push', val:'unhandled binary op ' },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'op' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1814, num_args:2 },
+  ]
+};
+
+block_1814 = {
+  instrs: [
+    { op:'push', val:'str' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1815, num_args:2 },
+  ]
+};
+
+block_1815 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_add' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1816, num_args:2 },
+  ]
+};
+
+block_1811 = {
+  instrs: [
+    { op:'push', val:$false },
+    { op:'if_true', then:@block_1812, else:@block_1813 },
+  ]
+};
+
+block_1812 = {
+  instrs: [
+    { op:'jump', to:@block_1817 },
+  ]
+};
+
+block_1816 = {
+  instrs: [
+    { op:'abort' },
+    { op:'jump', to:@block_1817 },
+  ]
+};
+
+block_1616 = {
+  instrs: [
+    { op:'if_true', then:@block_1617, else:@block_1818 },
+  ]
+};
+
+block_1817 = {
+  instrs: [
+    { op:'jump', to:@block_1819 },
+  ]
+};
+
+block_1818 = {
+  instrs: [
+    { op:'jump', to:@block_1819 },
+  ]
+};
+
+block_1819 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'ObjectExpr' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_instOf' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1820, num_args:2 },
+  ]
+};
+
+block_1821 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:$false },
+    { op:'get_local', idx:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genObjExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1822, num_args:3 },
+  ]
+};
+
+block_1822 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1820 = {
+  instrs: [
+    { op:'if_true', then:@block_1821, else:@block_1823 },
+  ]
+};
+
+block_1823 = {
+  instrs: [
+    { op:'jump', to:@block_1824 },
+  ]
+};
+
+block_1824 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'ArrayExpr' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_instOf' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1825, num_args:2 },
+  ]
+};
+
+block_1826 = {
+  instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:2 },
     { op:'new_object' },
@@ -16413,788 +16777,17 @@ block_1743 = {
     { op:'dup', idx:0 },
     { op:'push', val:'val' },
     { op:'get_local', idx:1 },
-    { op:'push', val:'nameStr' },
+    { op:'push', val:'exprs' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1744, num_args:2 },
-  ]
-};
-
-block_1744 = {
-  instrs: [
-    { op:'set_field' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addInstr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1745, num_args:2 },
-  ]
-};
-
-block_1745 = {
-  instrs: [
-    { op:'call', ret_to:@block_1746, num_args:2 },
-  ]
-};
-
-block_1746 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'runtimeCall' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1747, num_args:2 },
-  ]
-};
-
-block_1747 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'Block' },
-    { op:'get_field' },
-    { op:'push', val:'new' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1748, num_args:2 },
-  ]
-};
-
-block_1748 = {
-  instrs: [
-    { op:'call', ret_to:@block_1749, num_args:0 },
-  ]
-};
-
-block_1749 = {
-  instrs: [
-    { op:'set_local', idx:11 },
-    { op:'get_local', idx:0 },
-    { op:'push', val:4 },
-    { op:'new_object' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'op' },
-    { op:'push', val:'call' },
-    { op:'set_field' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'ret_to' },
-    { op:'get_local', idx:11 },
-    { op:'set_field' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'num_args' },
-    { op:'get_local', idx:10 },
-    { op:'push', val:'length' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1750, num_args:2 },
-  ]
-};
-
-block_1750 = {
-  instrs: [
-    { op:'push', val:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_add' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1751, num_args:2 },
-  ]
-};
-
-block_1751 = {
-  instrs: [
-    { op:'set_field' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'src_pos' },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'srcPos' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1752, num_args:2 },
-  ]
-};
-
-block_1752 = {
-  instrs: [
-    { op:'set_field' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addInstr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1753, num_args:2 },
-  ]
-};
-
-block_1753 = {
-  instrs: [
-    { op:'call', ret_to:@block_1754, num_args:2 },
-  ]
-};
-
-block_1754 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:11 },
-    { op:'dup', idx:1 },
-    { op:'push', val:'merge' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1755, num_args:2 },
-  ]
-};
-
-block_1755 = {
-  instrs: [
-    { op:'call', ret_to:@block_1756, num_args:2 },
-  ]
-};
-
-block_1756 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1728 = {
-  instrs: [
-    { op:'if_true', then:@block_1729, else:@block_1757 },
-  ]
-};
-
-block_1757 = {
-  instrs: [
-    { op:'jump', to:@block_1758 },
-  ]
-};
-
-block_1758 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'IRExpr' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_instOf' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1759, num_args:2 },
-  ]
-};
-
-block_1760 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'argExprs' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1761, num_args:2 },
-  ]
-};
-
-block_1761 = {
-  instrs: [
-    { op:'set_local', idx:10 },
-    { op:'push', val:0 },
-    { op:'set_local', idx:6 },
-    { op:'jump', to:@block_1762 },
-  ]
-};
-
-block_1762 = {
-  instrs: [
-    { op:'get_local', idx:6 },
-    { op:'get_local', idx:10 },
-    { op:'push', val:'length' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1766, num_args:2 },
-  ]
-};
-
-block_1766 = {
-  instrs: [
-    { op:'lt_i32' },
-    { op:'if_true', then:@block_1763, else:@block_1765 },
-  ]
-};
-
-block_1763 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:10 },
-    { op:'get_local', idx:6 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getElem' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1767, num_args:2 },
-  ]
-};
-
-block_1767 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1768, num_args:2 },
-  ]
-};
-
-block_1768 = {
-  instrs: [
-    { op:'pop' },
-    { op:'jump', to:@block_1764 },
-  ]
-};
-
-block_1764 = {
-  instrs: [
-    { op:'get_local', idx:6 },
-    { op:'push', val:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_add' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1769, num_args:2 },
-  ]
-};
-
-block_1769 = {
-  instrs: [
-    { op:'dup', idx:0 },
-    { op:'set_local', idx:6 },
-    { op:'pop' },
-    { op:'jump', to:@block_1762 },
-  ]
-};
-
-block_1765 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'opName' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1770, num_args:2 },
-  ]
-};
-
-block_1770 = {
-  instrs: [
-    { op:'dup', idx:1 },
-    { op:'push', val:'addOp' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1771, num_args:2 },
-  ]
-};
-
-block_1771 = {
-  instrs: [
-    { op:'call', ret_to:@block_1772, num_args:2 },
-  ]
-};
-
-block_1772 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1759 = {
-  instrs: [
-    { op:'if_true', then:@block_1760, else:@block_1773 },
-  ]
-};
-
-block_1773 = {
-  instrs: [
-    { op:'jump', to:@block_1774 },
-  ]
-};
-
-block_1774 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'ImportExpr' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_instOf' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1775, num_args:2 },
-  ]
-};
-
-block_1776 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'pkgName' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1777, num_args:2 },
-  ]
-};
-
-block_1777 = {
-  instrs: [
-    { op:'dup', idx:1 },
-    { op:'push', val:'addPush' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1778, num_args:2 },
-  ]
-};
-
-block_1778 = {
-  instrs: [
-    { op:'call', ret_to:@block_1779, num_args:2 },
-  ]
-};
-
-block_1779 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:'import' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addOp' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1780, num_args:2 },
-  ]
-};
-
-block_1780 = {
-  instrs: [
-    { op:'call', ret_to:@block_1781, num_args:2 },
-  ]
-};
-
-block_1781 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1775 = {
-  instrs: [
-    { op:'if_true', then:@block_1776, else:@block_1782 },
-  ]
-};
-
-block_1782 = {
-  instrs: [
-    { op:'jump', to:@block_1783 },
-  ]
-};
-
-block_1783 = {
-  instrs: [
-    { op:'push', val:$false },
-    { op:'if_true', then:@block_1784, else:@block_1785 },
-  ]
-};
-
-block_1784 = {
-  instrs: [
-    { op:'jump', to:@block_1786 },
-  ]
-};
-
-block_1785 = {
-  instrs: [
-    { op:'push', val:'unknown expression type in genExpr' },
-    { op:'abort' },
-    { op:'jump', to:@block_1786 },
-  ]
-};
-
-block_1786 = {
-  instrs: [
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-fun_1336 = {
-  entry:@block_1335,
-  num_params:2,
-  num_locals:12,
-};
-
-block_1787 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'BlockStmt' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_instOf' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1789, num_args:2 },
-  ]
-};
-
-block_1790 = {
-  instrs: [
-    { op:'push', val:0 },
-    { op:'set_local', idx:2 },
-    { op:'jump', to:@block_1791 },
-  ]
-};
-
-block_1791 = {
-  instrs: [
-    { op:'get_local', idx:2 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'stmts' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1795, num_args:2 },
-  ]
-};
-
-block_1795 = {
-  instrs: [
-    { op:'push', val:'length' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1796, num_args:2 },
-  ]
-};
-
-block_1796 = {
-  instrs: [
-    { op:'lt_i32' },
-    { op:'if_true', then:@block_1792, else:@block_1794 },
-  ]
-};
-
-block_1792 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'stmts' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1797, num_args:2 },
-  ]
-};
-
-block_1797 = {
-  instrs: [
-    { op:'get_local', idx:2 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getElem' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1798, num_args:2 },
-  ]
-};
-
-block_1798 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genStmt' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1799, num_args:2 },
-  ]
-};
-
-block_1799 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:'curBlock' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1800, num_args:2 },
-  ]
-};
-
-block_1800 = {
-  instrs: [
-    { op:'dup', idx:0 },
-    { op:'push', val:'hasBranch' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1801, num_args:2 },
-  ]
-};
-
-block_1801 = {
-  instrs: [
-    { op:'call', ret_to:@block_1802, num_args:1 },
-  ]
-};
-
-block_1803 = {
-  instrs: [
-    { op:'jump', to:@block_1794 },
-  ]
-};
-
-block_1802 = {
-  instrs: [
-    { op:'if_true', then:@block_1803, else:@block_1804 },
-  ]
-};
-
-block_1804 = {
-  instrs: [
-    { op:'jump', to:@block_1805 },
-  ]
-};
-
-block_1805 = {
-  instrs: [
-    { op:'jump', to:@block_1793 },
-  ]
-};
-
-block_1793 = {
-  instrs: [
-    { op:'get_local', idx:2 },
-    { op:'push', val:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_add' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1806, num_args:2 },
-  ]
-};
-
-block_1806 = {
-  instrs: [
-    { op:'dup', idx:0 },
-    { op:'set_local', idx:2 },
-    { op:'pop' },
-    { op:'jump', to:@block_1791 },
-  ]
-};
-
-block_1794 = {
-  instrs: [
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1789 = {
-  instrs: [
-    { op:'if_true', then:@block_1790, else:@block_1807 },
-  ]
-};
-
-block_1807 = {
-  instrs: [
-    { op:'jump', to:@block_1808 },
-  ]
-};
-
-block_1808 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'VarStmt' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_instOf' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1809, num_args:2 },
-  ]
-};
-
-block_1810 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'fun' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1811, num_args:2 },
-  ]
-};
-
-block_1811 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'identName' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1812, num_args:2 },
-  ]
-};
-
-block_1812 = {
-  instrs: [
-    { op:'dup', idx:1 },
-    { op:'push', val:'hasLocal' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1813, num_args:2 },
-  ]
-};
-
-block_1813 = {
-  instrs: [
-    { op:'call', ret_to:@block_1814, num_args:2 },
-  ]
-};
-
-block_1815 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'initExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1816, num_args:2 },
-  ]
-};
-
-block_1816 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1817, num_args:2 },
-  ]
-};
-
-block_1817 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:'fun' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1818, num_args:2 },
-  ]
-};
-
-block_1818 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'identName' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1819, num_args:2 },
-  ]
-};
-
-block_1819 = {
-  instrs: [
-    { op:'dup', idx:1 },
-    { op:'push', val:'getLocalIdx' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1820, num_args:2 },
-  ]
-};
-
-block_1820 = {
-  instrs: [
-    { op:'call', ret_to:@block_1821, num_args:2 },
-  ]
-};
-
-block_1821 = {
-  instrs: [
-    { op:'set_local', idx:3 },
-    { op:'get_local', idx:0 },
-    { op:'push', val:2 },
-    { op:'new_object' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'op' },
-    { op:'push', val:'set_local' },
-    { op:'set_field' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'idx' },
-    { op:'get_local', idx:3 },
-    { op:'set_field' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addInstr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1822, num_args:2 },
-  ]
-};
-
-block_1822 = {
-  instrs: [
-    { op:'call', ret_to:@block_1823, num_args:2 },
-  ]
-};
-
-block_1824 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:0 },
-    { op:'push', val:'globalObj' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1825, num_args:2 },
-  ]
-};
-
-block_1825 = {
-  instrs: [
-    { op:'dup', idx:1 },
-    { op:'push', val:'addPush' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1826, num_args:2 },
-  ]
-};
-
-block_1826 = {
-  instrs: [
     { op:'call', ret_to:@block_1827, num_args:2 },
   ]
 };
 
 block_1827 = {
   instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'identName' },
+    { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -17204,8 +16797,9 @@ block_1827 = {
 
 block_1828 = {
   instrs: [
+    { op:'set_field' },
     { op:'dup', idx:1 },
-    { op:'push', val:'addPush' },
+    { op:'push', val:'addInstr' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -17223,8 +16817,9 @@ block_1830 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'initExpr' },
+    { op:'push', val:'new_array' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addOp' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -17234,9 +16829,6 @@ block_1830 = {
 
 block_1831 = {
   instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
     { op:'call', ret_to:@block_1832, num_args:2 },
   ]
 };
@@ -17244,80 +16836,64 @@ block_1831 = {
 block_1832 = {
   instrs: [
     { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:'set_field' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addOp' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1833, num_args:2 },
+    { op:'push', val:0 },
+    { op:'set_local', idx:6 },
+    { op:'jump', to:@block_1833 },
   ]
 };
 
 block_1833 = {
   instrs: [
-    { op:'call', ret_to:@block_1834, num_args:2 },
-  ]
-};
-
-block_1814 = {
-  instrs: [
-    { op:'if_true', then:@block_1815, else:@block_1824 },
-  ]
-};
-
-block_1823 = {
-  instrs: [
-    { op:'pop' },
-    { op:'jump', to:@block_1835 },
-  ]
-};
-
-block_1834 = {
-  instrs: [
-    { op:'pop' },
-    { op:'jump', to:@block_1835 },
-  ]
-};
-
-block_1835 = {
-  instrs: [
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1809 = {
-  instrs: [
-    { op:'if_true', then:@block_1810, else:@block_1836 },
-  ]
-};
-
-block_1836 = {
-  instrs: [
-    { op:'jump', to:@block_1837 },
+    { op:'get_local', idx:6 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'exprs' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1837, num_args:2 },
   ]
 };
 
 block_1837 = {
   instrs: [
-    { op:'get_local', idx:1 },
+    { op:'push', val:'length' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'ReturnStmt' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_instOf' },
+    { op:'push', val:'rt_getProp' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1838, num_args:2 },
   ]
 };
 
+block_1838 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_lt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1839, num_args:2 },
+  ]
+};
+
 block_1839 = {
   instrs: [
+    { op:'if_true', then:@block_1834, else:@block_1836 },
+  ]
+};
+
+block_1834 = {
+  instrs: [
     { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'expr' },
+    { op:'push', val:2 },
+    { op:'new_object' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'op' },
+    { op:'push', val:'dup' },
+    { op:'set_field' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'idx' },
+    { op:'push', val:0 },
+    { op:'set_field' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addInstr' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -17327,9 +16903,6 @@ block_1839 = {
 
 block_1840 = {
   instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
     { op:'call', ret_to:@block_1841, num_args:2 },
   ]
 };
@@ -17338,9 +16911,8 @@ block_1841 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
-    { op:'push', val:'ret' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addOp' },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'exprs' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -17350,122 +16922,150 @@ block_1841 = {
 
 block_1842 = {
   instrs: [
+    { op:'get_local', idx:6 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getElem' },
+    { op:'get_field' },
     { op:'call', ret_to:@block_1843, num_args:2 },
   ]
 };
 
 block_1843 = {
   instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1838 = {
-  instrs: [
-    { op:'if_true', then:@block_1839, else:@block_1844 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1844, num_args:2 },
   ]
 };
 
 block_1844 = {
   instrs: [
-    { op:'jump', to:@block_1845 },
-  ]
-};
-
-block_1845 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'ExprStmt' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_instOf' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1846, num_args:2 },
-  ]
-};
-
-block_1847 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'expr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1848, num_args:2 },
-  ]
-};
-
-block_1848 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1849, num_args:2 },
-  ]
-};
-
-block_1849 = {
-  instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
-    { op:'push', val:'pop' },
+    { op:'push', val:'array_push' },
     { op:'dup', idx:1 },
     { op:'push', val:'addOp' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1850, num_args:2 },
+    { op:'call', ret_to:@block_1845, num_args:2 },
   ]
 };
 
-block_1850 = {
+block_1845 = {
   instrs: [
-    { op:'call', ret_to:@block_1851, num_args:2 },
-  ]
-};
-
-block_1851 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
+    { op:'call', ret_to:@block_1846, num_args:2 },
   ]
 };
 
 block_1846 = {
   instrs: [
-    { op:'if_true', then:@block_1847, else:@block_1852 },
+    { op:'pop' },
+    { op:'jump', to:@block_1835 },
+  ]
+};
+
+block_1835 = {
+  instrs: [
+    { op:'get_local', idx:6 },
+    { op:'push', val:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_add' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1847, num_args:2 },
+  ]
+};
+
+block_1847 = {
+  instrs: [
+    { op:'dup', idx:0 },
+    { op:'set_local', idx:6 },
+    { op:'pop' },
+    { op:'jump', to:@block_1833 },
+  ]
+};
+
+block_1836 = {
+  instrs: [
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1825 = {
+  instrs: [
+    { op:'if_true', then:@block_1826, else:@block_1848 },
+  ]
+};
+
+block_1848 = {
+  instrs: [
+    { op:'jump', to:@block_1849 },
+  ]
+};
+
+block_1849 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'FunExpr' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_instOf' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1850, num_args:2 },
+  ]
+};
+
+block_1851 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'Block' },
+    { op:'get_field' },
+    { op:'push', val:'new' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1852, num_args:2 },
   ]
 };
 
 block_1852 = {
   instrs: [
-    { op:'jump', to:@block_1853 },
+    { op:'call', ret_to:@block_1853, num_args:0 },
   ]
 };
 
 block_1853 = {
   instrs: [
+    { op:'set_local', idx:7 },
     { op:'get_local', idx:1 },
+    { op:'push', val:'params' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'IfStmt' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_instOf' },
+    { op:'push', val:'rt_getProp' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1854, num_args:2 },
   ]
 };
 
+block_1854 = {
+  instrs: [
+    { op:'push', val:'length' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1855, num_args:2 },
+  ]
+};
+
 block_1855 = {
   instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'testExpr' },
+    { op:'get_local', idx:7 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'Function' },
+    { op:'get_field' },
+    { op:'push', val:'new' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -17475,59 +17075,24 @@ block_1855 = {
 
 block_1856 = {
   instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
     { op:'call', ret_to:@block_1857, num_args:2 },
   ]
 };
 
 block_1857 = {
   instrs: [
-    { op:'pop' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'Block' },
-    { op:'get_field' },
-    { op:'push', val:'new' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1858, num_args:2 },
+    { op:'set_local', idx:8 },
+    { op:'push', val:0 },
+    { op:'set_local', idx:6 },
+    { op:'jump', to:@block_1858 },
   ]
 };
 
 block_1858 = {
   instrs: [
-    { op:'call', ret_to:@block_1859, num_args:0 },
-  ]
-};
-
-block_1859 = {
-  instrs: [
-    { op:'set_local', idx:4 },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:4 },
-    { op:'dup', idx:1 },
-    { op:'push', val:'subCtx' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1860, num_args:2 },
-  ]
-};
-
-block_1860 = {
-  instrs: [
-    { op:'call', ret_to:@block_1861, num_args:2 },
-  ]
-};
-
-block_1861 = {
-  instrs: [
-    { op:'set_local', idx:5 },
-    { op:'get_local', idx:5 },
+    { op:'get_local', idx:6 },
     { op:'get_local', idx:1 },
-    { op:'push', val:'thenStmt' },
+    { op:'push', val:'params' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -17537,8 +17102,9 @@ block_1861 = {
 
 block_1862 = {
   instrs: [
+    { op:'push', val:'length' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'genStmt' },
+    { op:'push', val:'rt_getProp' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1863, num_args:2 },
   ]
@@ -17546,13 +17112,8 @@ block_1862 = {
 
 block_1863 = {
   instrs: [
-    { op:'pop' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'Block' },
-    { op:'get_field' },
-    { op:'push', val:'new' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'rt_lt' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1864, num_args:2 },
   ]
@@ -17560,19 +17121,27 @@ block_1863 = {
 
 block_1864 = {
   instrs: [
-    { op:'call', ret_to:@block_1865, num_args:0 },
+    { op:'if_true', then:@block_1859, else:@block_1861 },
+  ]
+};
+
+block_1859 = {
+  instrs: [
+    { op:'get_local', idx:8 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'params' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1865, num_args:2 },
   ]
 };
 
 block_1865 = {
   instrs: [
-    { op:'set_local', idx:6 },
-    { op:'get_local', idx:0 },
     { op:'get_local', idx:6 },
-    { op:'dup', idx:1 },
-    { op:'push', val:'subCtx' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'rt_getElem' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1866, num_args:2 },
   ]
@@ -17580,27 +17149,34 @@ block_1865 = {
 
 block_1866 = {
   instrs: [
+    { op:'dup', idx:1 },
+    { op:'push', val:'registerDecl' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
     { op:'call', ret_to:@block_1867, num_args:2 },
   ]
 };
 
 block_1867 = {
   instrs: [
-    { op:'set_local', idx:7 },
-    { op:'get_local', idx:7 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'elseStmt' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
     { op:'call', ret_to:@block_1868, num_args:2 },
   ]
 };
 
 block_1868 = {
   instrs: [
+    { op:'pop' },
+    { op:'jump', to:@block_1860 },
+  ]
+};
+
+block_1860 = {
+  instrs: [
+    { op:'get_local', idx:6 },
+    { op:'push', val:1 },
     { op:'push', val:@global_obj },
-    { op:'push', val:'genStmt' },
+    { op:'push', val:'rt_add' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1869, num_args:2 },
   ]
@@ -17608,24 +17184,18 @@ block_1868 = {
 
 block_1869 = {
   instrs: [
+    { op:'dup', idx:0 },
+    { op:'set_local', idx:6 },
     { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:3 },
-    { op:'new_object' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'op' },
-    { op:'push', val:'if_true' },
-    { op:'set_field' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'then' },
-    { op:'get_local', idx:4 },
-    { op:'set_field' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'else' },
-    { op:'get_local', idx:6 },
-    { op:'set_field' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addInstr' },
+    { op:'jump', to:@block_1858 },
+  ]
+};
+
+block_1861 = {
+  instrs: [
+    { op:'get_local', idx:8 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'body' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -17635,17 +17205,19 @@ block_1869 = {
 
 block_1870 = {
   instrs: [
-    { op:'call', ret_to:@block_1871, num_args:2 },
+    { op:'push', val:$false },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'registerDecls' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1871, num_args:3 },
   ]
 };
 
 block_1871 = {
   instrs: [
     { op:'pop' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'Block' },
-    { op:'get_field' },
-    { op:'push', val:'new' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:'exportsObj' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -17655,17 +17227,24 @@ block_1871 = {
 
 block_1872 = {
   instrs: [
-    { op:'call', ret_to:@block_1873, num_args:0 },
+    { op:'get_local', idx:0 },
+    { op:'push', val:'globalObj' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1873, num_args:2 },
   ]
 };
 
 block_1873 = {
   instrs: [
-    { op:'set_local', idx:8 },
-    { op:'get_local', idx:0 },
     { op:'get_local', idx:8 },
-    { op:'dup', idx:1 },
-    { op:'push', val:'merge' },
+    { op:'push', val:$false },
+    { op:'get_local', idx:7 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'CodeGenCtx' },
+    { op:'get_field' },
+    { op:'push', val:'new' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -17675,15 +17254,16 @@ block_1873 = {
 
 block_1874 = {
   instrs: [
-    { op:'call', ret_to:@block_1875, num_args:2 },
+    { op:'call', ret_to:@block_1875, num_args:5 },
   ]
 };
 
 block_1875 = {
   instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:5 },
-    { op:'push', val:'curBlock' },
+    { op:'set_local', idx:9 },
+    { op:'get_local', idx:9 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'body' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -17693,10 +17273,8 @@ block_1875 = {
 
 block_1876 = {
   instrs: [
-    { op:'dup', idx:0 },
-    { op:'push', val:'hasBranch' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'genStmt' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1877, num_args:2 },
   ]
@@ -17704,70 +17282,77 @@ block_1876 = {
 
 block_1877 = {
   instrs: [
-    { op:'call', ret_to:@block_1878, num_args:1 },
+    { op:'pop' },
+    { op:'get_local', idx:9 },
+    { op:'push', val:'curBlock' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1878, num_args:2 },
   ]
 };
 
 block_1878 = {
   instrs: [
+    { op:'dup', idx:0 },
+    { op:'push', val:'hasBranch' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_not' },
+    { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1879, num_args:1 },
+    { op:'call', ret_to:@block_1879, num_args:2 },
+  ]
+};
+
+block_1879 = {
+  instrs: [
+    { op:'call', ret_to:@block_1880, num_args:1 },
   ]
 };
 
 block_1880 = {
   instrs: [
-    { op:'get_local', idx:5 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_not' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1881, num_args:1 },
+  ]
+};
+
+block_1882 = {
+  instrs: [
+    { op:'get_local', idx:9 },
     { op:'push', val:2 },
     { op:'new_object' },
     { op:'dup', idx:0 },
     { op:'push', val:'op' },
-    { op:'push', val:'jump' },
+    { op:'push', val:'push' },
     { op:'set_field' },
     { op:'dup', idx:0 },
-    { op:'push', val:'to' },
-    { op:'get_local', idx:8 },
+    { op:'push', val:'val' },
+    { op:'push', val:$undef },
     { op:'set_field' },
     { op:'dup', idx:1 },
     { op:'push', val:'addInstr' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1881, num_args:2 },
-  ]
-};
-
-block_1881 = {
-  instrs: [
-    { op:'call', ret_to:@block_1882, num_args:2 },
-  ]
-};
-
-block_1879 = {
-  instrs: [
-    { op:'if_true', then:@block_1880, else:@block_1883 },
-  ]
-};
-
-block_1882 = {
-  instrs: [
-    { op:'pop' },
-    { op:'jump', to:@block_1884 },
+    { op:'call', ret_to:@block_1883, num_args:2 },
   ]
 };
 
 block_1883 = {
   instrs: [
-    { op:'jump', to:@block_1884 },
+    { op:'call', ret_to:@block_1884, num_args:2 },
   ]
 };
 
 block_1884 = {
   instrs: [
-    { op:'get_local', idx:7 },
-    { op:'push', val:'curBlock' },
+    { op:'pop' },
+    { op:'get_local', idx:9 },
+    { op:'push', val:'ret' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addOp' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -17777,41 +17362,40 @@ block_1884 = {
 
 block_1885 = {
   instrs: [
-    { op:'dup', idx:0 },
-    { op:'push', val:'hasBranch' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
     { op:'call', ret_to:@block_1886, num_args:2 },
+  ]
+};
+
+block_1881 = {
+  instrs: [
+    { op:'if_true', then:@block_1882, else:@block_1887 },
   ]
 };
 
 block_1886 = {
   instrs: [
-    { op:'call', ret_to:@block_1887, num_args:1 },
+    { op:'pop' },
+    { op:'jump', to:@block_1888 },
   ]
 };
 
 block_1887 = {
   instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_not' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1888, num_args:1 },
+    { op:'jump', to:@block_1888 },
   ]
 };
 
-block_1889 = {
+block_1888 = {
   instrs: [
-    { op:'get_local', idx:7 },
+    { op:'get_local', idx:0 },
     { op:'push', val:2 },
     { op:'new_object' },
     { op:'dup', idx:0 },
     { op:'push', val:'op' },
-    { op:'push', val:'jump' },
+    { op:'push', val:'push' },
     { op:'set_field' },
     { op:'dup', idx:0 },
-    { op:'push', val:'to' },
+    { op:'push', val:'val' },
     { op:'get_local', idx:8 },
     { op:'set_field' },
     { op:'dup', idx:1 },
@@ -17819,93 +17403,74 @@ block_1889 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
+    { op:'call', ret_to:@block_1889, num_args:2 },
+  ]
+};
+
+block_1889 = {
+  instrs: [
     { op:'call', ret_to:@block_1890, num_args:2 },
   ]
 };
 
 block_1890 = {
   instrs: [
-    { op:'call', ret_to:@block_1891, num_args:2 },
-  ]
-};
-
-block_1888 = {
-  instrs: [
-    { op:'if_true', then:@block_1889, else:@block_1892 },
-  ]
-};
-
-block_1891 = {
-  instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_1893 },
-  ]
-};
-
-block_1892 = {
-  instrs: [
-    { op:'jump', to:@block_1893 },
-  ]
-};
-
-block_1893 = {
-  instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-block_1854 = {
+block_1850 = {
   instrs: [
-    { op:'if_true', then:@block_1855, else:@block_1894 },
+    { op:'if_true', then:@block_1851, else:@block_1891 },
+  ]
+};
+
+block_1891 = {
+  instrs: [
+    { op:'jump', to:@block_1892 },
+  ]
+};
+
+block_1892 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'CallExpr' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_instOf' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1893, num_args:2 },
   ]
 };
 
 block_1894 = {
   instrs: [
-    { op:'jump', to:@block_1895 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'argExprs' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1895, num_args:2 },
   ]
 };
 
 block_1895 = {
   instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'ForStmt' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_instOf' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1896, num_args:2 },
+    { op:'set_local', idx:10 },
+    { op:'push', val:0 },
+    { op:'set_local', idx:6 },
+    { op:'jump', to:@block_1896 },
   ]
 };
 
-block_1897 = {
+block_1896 = {
   instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'Block' },
-    { op:'get_field' },
-    { op:'push', val:'new' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1898, num_args:2 },
-  ]
-};
-
-block_1898 = {
-  instrs: [
-    { op:'call', ret_to:@block_1899, num_args:0 },
-  ]
-};
-
-block_1899 = {
-  instrs: [
-    { op:'set_local', idx:9 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'Block' },
-    { op:'get_field' },
-    { op:'push', val:'new' },
+    { op:'get_local', idx:6 },
+    { op:'get_local', idx:10 },
+    { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -17915,19 +17480,26 @@ block_1899 = {
 
 block_1900 = {
   instrs: [
-    { op:'call', ret_to:@block_1901, num_args:0 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_lt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1901, num_args:2 },
   ]
 };
 
 block_1901 = {
   instrs: [
-    { op:'set_local', idx:10 },
+    { op:'if_true', then:@block_1897, else:@block_1899 },
+  ]
+};
+
+block_1897 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:10 },
+    { op:'get_local', idx:6 },
     { op:'push', val:@global_obj },
-    { op:'push', val:'Block' },
-    { op:'get_field' },
-    { op:'push', val:'new' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'rt_getElem' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1902, num_args:2 },
   ]
@@ -17935,19 +17507,26 @@ block_1901 = {
 
 block_1902 = {
   instrs: [
-    { op:'call', ret_to:@block_1903, num_args:0 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1903, num_args:2 },
   ]
 };
 
 block_1903 = {
   instrs: [
-    { op:'set_local', idx:11 },
+    { op:'pop' },
+    { op:'jump', to:@block_1898 },
+  ]
+};
+
+block_1898 = {
+  instrs: [
+    { op:'get_local', idx:6 },
+    { op:'push', val:1 },
     { op:'push', val:@global_obj },
-    { op:'push', val:'Block' },
-    { op:'get_field' },
-    { op:'push', val:'new' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'rt_add' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1904, num_args:2 },
   ]
@@ -17955,18 +17534,29 @@ block_1903 = {
 
 block_1904 = {
   instrs: [
-    { op:'call', ret_to:@block_1905, num_args:0 },
+    { op:'dup', idx:0 },
+    { op:'set_local', idx:6 },
+    { op:'pop' },
+    { op:'jump', to:@block_1896 },
+  ]
+};
+
+block_1899 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'funExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1905, num_args:2 },
   ]
 };
 
 block_1905 = {
   instrs: [
-    { op:'set_local', idx:12 },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'initStmt' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'genExpr' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1906, num_args:2 },
   ]
@@ -17974,8 +17564,13 @@ block_1905 = {
 
 block_1906 = {
   instrs: [
+    { op:'pop' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'genStmt' },
+    { op:'push', val:'Block' },
+    { op:'get_field' },
+    { op:'push', val:'new' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1907, num_args:2 },
   ]
@@ -17983,40 +17578,42 @@ block_1906 = {
 
 block_1907 = {
   instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:2 },
-    { op:'new_object' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'op' },
-    { op:'push', val:'jump' },
-    { op:'set_field' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'to' },
-    { op:'get_local', idx:9 },
-    { op:'set_field' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addInstr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1908, num_args:2 },
+    { op:'call', ret_to:@block_1908, num_args:0 },
   ]
 };
 
 block_1908 = {
   instrs: [
+    { op:'set_local', idx:11 },
+    { op:'get_local', idx:0 },
+    { op:'push', val:4 },
+    { op:'new_object' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'op' },
+    { op:'push', val:'call' },
+    { op:'set_field' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'ret_to' },
+    { op:'get_local', idx:11 },
+    { op:'set_field' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'num_args' },
+    { op:'get_local', idx:10 },
+    { op:'push', val:'length' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
     { op:'call', ret_to:@block_1909, num_args:2 },
   ]
 };
 
 block_1909 = {
   instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:9 },
-    { op:'dup', idx:1 },
-    { op:'push', val:'subCtx' },
+    { op:'set_field' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'src_pos' },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'srcPos' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -18026,27 +17623,31 @@ block_1909 = {
 
 block_1910 = {
   instrs: [
+    { op:'set_field' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addInstr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
     { op:'call', ret_to:@block_1911, num_args:2 },
   ]
 };
 
 block_1911 = {
   instrs: [
-    { op:'set_local', idx:13 },
-    { op:'get_local', idx:13 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'testExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
     { op:'call', ret_to:@block_1912, num_args:2 },
   ]
 };
 
 block_1912 = {
   instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:11 },
+    { op:'dup', idx:1 },
+    { op:'push', val:'merge' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
+    { op:'push', val:'rt_getProp' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1913, num_args:2 },
   ]
@@ -18054,76 +17655,49 @@ block_1912 = {
 
 block_1913 = {
   instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:13 },
-    { op:'push', val:3 },
-    { op:'new_object' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'op' },
-    { op:'push', val:'if_true' },
-    { op:'set_field' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'then' },
-    { op:'get_local', idx:10 },
-    { op:'set_field' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'else' },
-    { op:'get_local', idx:12 },
-    { op:'set_field' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addInstr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
     { op:'call', ret_to:@block_1914, num_args:2 },
   ]
 };
 
 block_1914 = {
   instrs: [
-    { op:'call', ret_to:@block_1915, num_args:2 },
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1893 = {
+  instrs: [
+    { op:'if_true', then:@block_1894, else:@block_1915 },
   ]
 };
 
 block_1915 = {
   instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:10 },
-    { op:'get_local', idx:11 },
-    { op:'get_local', idx:12 },
-    { op:'dup', idx:3 },
-    { op:'push', val:'subCtxLoop' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1916, num_args:2 },
+    { op:'jump', to:@block_1916 },
   ]
 };
 
 block_1916 = {
   instrs: [
-    { op:'call', ret_to:@block_1917, num_args:4 },
-  ]
-};
-
-block_1917 = {
-  instrs: [
-    { op:'set_local', idx:14 },
-    { op:'get_local', idx:14 },
     { op:'get_local', idx:1 },
-    { op:'push', val:'bodyStmt' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'MethodCallExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1918, num_args:2 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_instOf' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1917, num_args:2 },
   ]
 };
 
 block_1918 = {
   instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'argExprs' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'genStmt' },
+    { op:'push', val:'rt_getProp' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1919, num_args:2 },
   ]
@@ -18131,9 +17705,10 @@ block_1918 = {
 
 block_1919 = {
   instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:14 },
-    { op:'push', val:'curBlock' },
+    { op:'set_local', idx:10 },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'baseExpr' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -18143,10 +17718,8 @@ block_1919 = {
 
 block_1920 = {
   instrs: [
-    { op:'dup', idx:0 },
-    { op:'push', val:'hasBranch' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'genExpr' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1921, num_args:2 },
   ]
@@ -18154,74 +17727,56 @@ block_1920 = {
 
 block_1921 = {
   instrs: [
-    { op:'call', ret_to:@block_1922, num_args:1 },
+    { op:'pop' },
+    { op:'push', val:0 },
+    { op:'set_local', idx:6 },
+    { op:'jump', to:@block_1922 },
   ]
 };
 
 block_1922 = {
   instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_not' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1923, num_args:1 },
-  ]
-};
-
-block_1924 = {
-  instrs: [
-    { op:'get_local', idx:14 },
-    { op:'push', val:2 },
-    { op:'new_object' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'op' },
-    { op:'push', val:'jump' },
-    { op:'set_field' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'to' },
-    { op:'get_local', idx:11 },
-    { op:'set_field' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addInstr' },
+    { op:'get_local', idx:6 },
+    { op:'get_local', idx:10 },
+    { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1925, num_args:2 },
-  ]
-};
-
-block_1925 = {
-  instrs: [
     { op:'call', ret_to:@block_1926, num_args:2 },
-  ]
-};
-
-block_1923 = {
-  instrs: [
-    { op:'if_true', then:@block_1924, else:@block_1927 },
   ]
 };
 
 block_1926 = {
   instrs: [
-    { op:'pop' },
-    { op:'jump', to:@block_1928 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_lt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1927, num_args:2 },
   ]
 };
 
 block_1927 = {
   instrs: [
-    { op:'jump', to:@block_1928 },
+    { op:'if_true', then:@block_1923, else:@block_1925 },
+  ]
+};
+
+block_1923 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:10 },
+    { op:'get_local', idx:6 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getElem' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1928, num_args:2 },
   ]
 };
 
 block_1928 = {
   instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:11 },
-    { op:'dup', idx:1 },
-    { op:'push', val:'subCtx' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'genExpr' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1929, num_args:2 },
   ]
@@ -18229,16 +17784,44 @@ block_1928 = {
 
 block_1929 = {
   instrs: [
+    { op:'pop' },
+    { op:'jump', to:@block_1924 },
+  ]
+};
+
+block_1924 = {
+  instrs: [
+    { op:'get_local', idx:6 },
+    { op:'push', val:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_add' },
+    { op:'get_field' },
     { op:'call', ret_to:@block_1930, num_args:2 },
   ]
 };
 
 block_1930 = {
   instrs: [
-    { op:'set_local', idx:15 },
-    { op:'get_local', idx:15 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'incrExpr' },
+    { op:'dup', idx:0 },
+    { op:'set_local', idx:6 },
+    { op:'pop' },
+    { op:'jump', to:@block_1922 },
+  ]
+};
+
+block_1925 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:2 },
+    { op:'new_object' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'op' },
+    { op:'push', val:'dup' },
+    { op:'set_field' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'idx' },
+    { op:'get_local', idx:10 },
+    { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -18248,8 +17831,11 @@ block_1930 = {
 
 block_1931 = {
   instrs: [
+    { op:'set_field' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addInstr' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
+    { op:'push', val:'rt_getProp' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1932, num_args:2 },
   ]
@@ -18257,40 +17843,36 @@ block_1931 = {
 
 block_1932 = {
   instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:15 },
-    { op:'push', val:2 },
-    { op:'new_object' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'op' },
-    { op:'push', val:'jump' },
-    { op:'set_field' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'to' },
-    { op:'get_local', idx:9 },
-    { op:'set_field' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addInstr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
     { op:'call', ret_to:@block_1933, num_args:2 },
   ]
 };
 
 block_1933 = {
   instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:2 },
+    { op:'new_object' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'op' },
+    { op:'push', val:'push' },
+    { op:'set_field' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'val' },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'nameStr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
     { op:'call', ret_to:@block_1934, num_args:2 },
   ]
 };
 
 block_1934 = {
   instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:12 },
+    { op:'set_field' },
     { op:'dup', idx:1 },
-    { op:'push', val:'merge' },
+    { op:'push', val:'addInstr' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -18307,42 +17889,67 @@ block_1935 = {
 block_1936 = {
   instrs: [
     { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1896 = {
-  instrs: [
-    { op:'if_true', then:@block_1897, else:@block_1937 },
+    { op:'get_local', idx:0 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'runtimeCall' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1937, num_args:2 },
   ]
 };
 
 block_1937 = {
   instrs: [
-    { op:'jump', to:@block_1938 },
+    { op:'pop' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'Block' },
+    { op:'get_field' },
+    { op:'push', val:'new' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1938, num_args:2 },
   ]
 };
 
 block_1938 = {
   instrs: [
-    { op:'get_local', idx:1 },
+    { op:'call', ret_to:@block_1939, num_args:0 },
+  ]
+};
+
+block_1939 = {
+  instrs: [
+    { op:'set_local', idx:11 },
+    { op:'get_local', idx:0 },
+    { op:'push', val:4 },
+    { op:'new_object' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'op' },
+    { op:'push', val:'call' },
+    { op:'set_field' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'ret_to' },
+    { op:'get_local', idx:11 },
+    { op:'set_field' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'num_args' },
+    { op:'get_local', idx:10 },
+    { op:'push', val:'length' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'ContStmt' },
+    { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_instOf' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1939, num_args:2 },
+    { op:'call', ret_to:@block_1940, num_args:2 },
   ]
 };
 
 block_1940 = {
   instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'curBlock' },
+    { op:'push', val:1 },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'rt_add' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1941, num_args:2 },
   ]
@@ -18350,8 +17957,11 @@ block_1940 = {
 
 block_1941 = {
   instrs: [
+    { op:'set_field' },
     { op:'dup', idx:0 },
-    { op:'push', val:'hasBranch' },
+    { op:'push', val:'src_pos' },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'srcPos' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -18361,20 +17971,1873 @@ block_1941 = {
 
 block_1942 = {
   instrs: [
-    { op:'call', ret_to:@block_1943, num_args:1 },
+    { op:'set_field' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addInstr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1943, num_args:2 },
   ]
 };
 
 block_1943 = {
   instrs: [
+    { op:'call', ret_to:@block_1944, num_args:2 },
+  ]
+};
+
+block_1944 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:11 },
+    { op:'dup', idx:1 },
+    { op:'push', val:'merge' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_not' },
+    { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1944, num_args:1 },
+    { op:'call', ret_to:@block_1945, num_args:2 },
   ]
 };
 
 block_1945 = {
+  instrs: [
+    { op:'call', ret_to:@block_1946, num_args:2 },
+  ]
+};
+
+block_1946 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1917 = {
+  instrs: [
+    { op:'if_true', then:@block_1918, else:@block_1947 },
+  ]
+};
+
+block_1947 = {
+  instrs: [
+    { op:'jump', to:@block_1948 },
+  ]
+};
+
+block_1948 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'IRExpr' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_instOf' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1949, num_args:2 },
+  ]
+};
+
+block_1950 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'argExprs' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1951, num_args:2 },
+  ]
+};
+
+block_1951 = {
+  instrs: [
+    { op:'set_local', idx:10 },
+    { op:'push', val:0 },
+    { op:'set_local', idx:6 },
+    { op:'jump', to:@block_1952 },
+  ]
+};
+
+block_1952 = {
+  instrs: [
+    { op:'get_local', idx:6 },
+    { op:'get_local', idx:10 },
+    { op:'push', val:'length' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1956, num_args:2 },
+  ]
+};
+
+block_1956 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_lt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1957, num_args:2 },
+  ]
+};
+
+block_1957 = {
+  instrs: [
+    { op:'if_true', then:@block_1953, else:@block_1955 },
+  ]
+};
+
+block_1953 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:10 },
+    { op:'get_local', idx:6 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getElem' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1958, num_args:2 },
+  ]
+};
+
+block_1958 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1959, num_args:2 },
+  ]
+};
+
+block_1959 = {
+  instrs: [
+    { op:'pop' },
+    { op:'jump', to:@block_1954 },
+  ]
+};
+
+block_1954 = {
+  instrs: [
+    { op:'get_local', idx:6 },
+    { op:'push', val:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_add' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1960, num_args:2 },
+  ]
+};
+
+block_1960 = {
+  instrs: [
+    { op:'dup', idx:0 },
+    { op:'set_local', idx:6 },
+    { op:'pop' },
+    { op:'jump', to:@block_1952 },
+  ]
+};
+
+block_1955 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'opName' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1961, num_args:2 },
+  ]
+};
+
+block_1961 = {
+  instrs: [
+    { op:'dup', idx:1 },
+    { op:'push', val:'addOp' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1962, num_args:2 },
+  ]
+};
+
+block_1962 = {
+  instrs: [
+    { op:'call', ret_to:@block_1963, num_args:2 },
+  ]
+};
+
+block_1963 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1949 = {
+  instrs: [
+    { op:'if_true', then:@block_1950, else:@block_1964 },
+  ]
+};
+
+block_1964 = {
+  instrs: [
+    { op:'jump', to:@block_1965 },
+  ]
+};
+
+block_1965 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'ImportExpr' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_instOf' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1966, num_args:2 },
+  ]
+};
+
+block_1967 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'pkgName' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1968, num_args:2 },
+  ]
+};
+
+block_1968 = {
+  instrs: [
+    { op:'dup', idx:1 },
+    { op:'push', val:'addPush' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1969, num_args:2 },
+  ]
+};
+
+block_1969 = {
+  instrs: [
+    { op:'call', ret_to:@block_1970, num_args:2 },
+  ]
+};
+
+block_1970 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:'import' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addOp' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1971, num_args:2 },
+  ]
+};
+
+block_1971 = {
+  instrs: [
+    { op:'call', ret_to:@block_1972, num_args:2 },
+  ]
+};
+
+block_1972 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1966 = {
+  instrs: [
+    { op:'if_true', then:@block_1967, else:@block_1973 },
+  ]
+};
+
+block_1973 = {
+  instrs: [
+    { op:'jump', to:@block_1974 },
+  ]
+};
+
+block_1974 = {
+  instrs: [
+    { op:'push', val:$false },
+    { op:'if_true', then:@block_1975, else:@block_1976 },
+  ]
+};
+
+block_1975 = {
+  instrs: [
+    { op:'jump', to:@block_1977 },
+  ]
+};
+
+block_1976 = {
+  instrs: [
+    { op:'push', val:'unknown expression type in genExpr' },
+    { op:'abort' },
+    { op:'jump', to:@block_1977 },
+  ]
+};
+
+block_1977 = {
+  instrs: [
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+fun_1522 = {
+  entry:@block_1521,
+  num_params:2,
+  num_locals:12,
+};
+
+block_1978 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'BlockStmt' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_instOf' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1980, num_args:2 },
+  ]
+};
+
+block_1981 = {
+  instrs: [
+    { op:'push', val:0 },
+    { op:'set_local', idx:2 },
+    { op:'jump', to:@block_1982 },
+  ]
+};
+
+block_1982 = {
+  instrs: [
+    { op:'get_local', idx:2 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'stmts' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1986, num_args:2 },
+  ]
+};
+
+block_1986 = {
+  instrs: [
+    { op:'push', val:'length' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1987, num_args:2 },
+  ]
+};
+
+block_1987 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_lt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1988, num_args:2 },
+  ]
+};
+
+block_1988 = {
+  instrs: [
+    { op:'if_true', then:@block_1983, else:@block_1985 },
+  ]
+};
+
+block_1983 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'stmts' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1989, num_args:2 },
+  ]
+};
+
+block_1989 = {
+  instrs: [
+    { op:'get_local', idx:2 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getElem' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1990, num_args:2 },
+  ]
+};
+
+block_1990 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genStmt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1991, num_args:2 },
+  ]
+};
+
+block_1991 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:'curBlock' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1992, num_args:2 },
+  ]
+};
+
+block_1992 = {
+  instrs: [
+    { op:'dup', idx:0 },
+    { op:'push', val:'hasBranch' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1993, num_args:2 },
+  ]
+};
+
+block_1993 = {
+  instrs: [
+    { op:'call', ret_to:@block_1994, num_args:1 },
+  ]
+};
+
+block_1995 = {
+  instrs: [
+    { op:'jump', to:@block_1985 },
+  ]
+};
+
+block_1994 = {
+  instrs: [
+    { op:'if_true', then:@block_1995, else:@block_1996 },
+  ]
+};
+
+block_1996 = {
+  instrs: [
+    { op:'jump', to:@block_1997 },
+  ]
+};
+
+block_1997 = {
+  instrs: [
+    { op:'jump', to:@block_1984 },
+  ]
+};
+
+block_1984 = {
+  instrs: [
+    { op:'get_local', idx:2 },
+    { op:'push', val:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_add' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1998, num_args:2 },
+  ]
+};
+
+block_1998 = {
+  instrs: [
+    { op:'dup', idx:0 },
+    { op:'set_local', idx:2 },
+    { op:'pop' },
+    { op:'jump', to:@block_1982 },
+  ]
+};
+
+block_1985 = {
+  instrs: [
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1980 = {
+  instrs: [
+    { op:'if_true', then:@block_1981, else:@block_1999 },
+  ]
+};
+
+block_1999 = {
+  instrs: [
+    { op:'jump', to:@block_2000 },
+  ]
+};
+
+block_2000 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'VarStmt' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_instOf' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2001, num_args:2 },
+  ]
+};
+
+block_2002 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:'fun' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2003, num_args:2 },
+  ]
+};
+
+block_2003 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'identName' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2004, num_args:2 },
+  ]
+};
+
+block_2004 = {
+  instrs: [
+    { op:'dup', idx:1 },
+    { op:'push', val:'hasLocal' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2005, num_args:2 },
+  ]
+};
+
+block_2005 = {
+  instrs: [
+    { op:'call', ret_to:@block_2006, num_args:2 },
+  ]
+};
+
+block_2007 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'initExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2008, num_args:2 },
+  ]
+};
+
+block_2008 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2009, num_args:2 },
+  ]
+};
+
+block_2009 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:'fun' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2010, num_args:2 },
+  ]
+};
+
+block_2010 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'identName' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2011, num_args:2 },
+  ]
+};
+
+block_2011 = {
+  instrs: [
+    { op:'dup', idx:1 },
+    { op:'push', val:'getLocalIdx' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2012, num_args:2 },
+  ]
+};
+
+block_2012 = {
+  instrs: [
+    { op:'call', ret_to:@block_2013, num_args:2 },
+  ]
+};
+
+block_2013 = {
+  instrs: [
+    { op:'set_local', idx:3 },
+    { op:'get_local', idx:0 },
+    { op:'push', val:2 },
+    { op:'new_object' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'op' },
+    { op:'push', val:'set_local' },
+    { op:'set_field' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'idx' },
+    { op:'get_local', idx:3 },
+    { op:'set_field' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addInstr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2014, num_args:2 },
+  ]
+};
+
+block_2014 = {
+  instrs: [
+    { op:'call', ret_to:@block_2015, num_args:2 },
+  ]
+};
+
+block_2016 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:0 },
+    { op:'push', val:'globalObj' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2017, num_args:2 },
+  ]
+};
+
+block_2017 = {
+  instrs: [
+    { op:'dup', idx:1 },
+    { op:'push', val:'addPush' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2018, num_args:2 },
+  ]
+};
+
+block_2018 = {
+  instrs: [
+    { op:'call', ret_to:@block_2019, num_args:2 },
+  ]
+};
+
+block_2019 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'identName' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2020, num_args:2 },
+  ]
+};
+
+block_2020 = {
+  instrs: [
+    { op:'dup', idx:1 },
+    { op:'push', val:'addPush' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2021, num_args:2 },
+  ]
+};
+
+block_2021 = {
+  instrs: [
+    { op:'call', ret_to:@block_2022, num_args:2 },
+  ]
+};
+
+block_2022 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'initExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2023, num_args:2 },
+  ]
+};
+
+block_2023 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2024, num_args:2 },
+  ]
+};
+
+block_2024 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:'set_field' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addOp' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2025, num_args:2 },
+  ]
+};
+
+block_2025 = {
+  instrs: [
+    { op:'call', ret_to:@block_2026, num_args:2 },
+  ]
+};
+
+block_2006 = {
+  instrs: [
+    { op:'if_true', then:@block_2007, else:@block_2016 },
+  ]
+};
+
+block_2015 = {
+  instrs: [
+    { op:'pop' },
+    { op:'jump', to:@block_2027 },
+  ]
+};
+
+block_2026 = {
+  instrs: [
+    { op:'pop' },
+    { op:'jump', to:@block_2027 },
+  ]
+};
+
+block_2027 = {
+  instrs: [
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_2001 = {
+  instrs: [
+    { op:'if_true', then:@block_2002, else:@block_2028 },
+  ]
+};
+
+block_2028 = {
+  instrs: [
+    { op:'jump', to:@block_2029 },
+  ]
+};
+
+block_2029 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'ReturnStmt' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_instOf' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2030, num_args:2 },
+  ]
+};
+
+block_2031 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'expr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2032, num_args:2 },
+  ]
+};
+
+block_2032 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2033, num_args:2 },
+  ]
+};
+
+block_2033 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:'ret' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addOp' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2034, num_args:2 },
+  ]
+};
+
+block_2034 = {
+  instrs: [
+    { op:'call', ret_to:@block_2035, num_args:2 },
+  ]
+};
+
+block_2035 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_2030 = {
+  instrs: [
+    { op:'if_true', then:@block_2031, else:@block_2036 },
+  ]
+};
+
+block_2036 = {
+  instrs: [
+    { op:'jump', to:@block_2037 },
+  ]
+};
+
+block_2037 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'ExprStmt' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_instOf' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2038, num_args:2 },
+  ]
+};
+
+block_2039 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'expr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2040, num_args:2 },
+  ]
+};
+
+block_2040 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2041, num_args:2 },
+  ]
+};
+
+block_2041 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:'pop' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addOp' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2042, num_args:2 },
+  ]
+};
+
+block_2042 = {
+  instrs: [
+    { op:'call', ret_to:@block_2043, num_args:2 },
+  ]
+};
+
+block_2043 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_2038 = {
+  instrs: [
+    { op:'if_true', then:@block_2039, else:@block_2044 },
+  ]
+};
+
+block_2044 = {
+  instrs: [
+    { op:'jump', to:@block_2045 },
+  ]
+};
+
+block_2045 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'IfStmt' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_instOf' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2046, num_args:2 },
+  ]
+};
+
+block_2047 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'testExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2048, num_args:2 },
+  ]
+};
+
+block_2048 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2049, num_args:2 },
+  ]
+};
+
+block_2049 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'Block' },
+    { op:'get_field' },
+    { op:'push', val:'new' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2050, num_args:2 },
+  ]
+};
+
+block_2050 = {
+  instrs: [
+    { op:'call', ret_to:@block_2051, num_args:0 },
+  ]
+};
+
+block_2051 = {
+  instrs: [
+    { op:'set_local', idx:4 },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:4 },
+    { op:'dup', idx:1 },
+    { op:'push', val:'subCtx' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2052, num_args:2 },
+  ]
+};
+
+block_2052 = {
+  instrs: [
+    { op:'call', ret_to:@block_2053, num_args:2 },
+  ]
+};
+
+block_2053 = {
+  instrs: [
+    { op:'set_local', idx:5 },
+    { op:'get_local', idx:5 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'thenStmt' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2054, num_args:2 },
+  ]
+};
+
+block_2054 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genStmt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2055, num_args:2 },
+  ]
+};
+
+block_2055 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'Block' },
+    { op:'get_field' },
+    { op:'push', val:'new' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2056, num_args:2 },
+  ]
+};
+
+block_2056 = {
+  instrs: [
+    { op:'call', ret_to:@block_2057, num_args:0 },
+  ]
+};
+
+block_2057 = {
+  instrs: [
+    { op:'set_local', idx:6 },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:6 },
+    { op:'dup', idx:1 },
+    { op:'push', val:'subCtx' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2058, num_args:2 },
+  ]
+};
+
+block_2058 = {
+  instrs: [
+    { op:'call', ret_to:@block_2059, num_args:2 },
+  ]
+};
+
+block_2059 = {
+  instrs: [
+    { op:'set_local', idx:7 },
+    { op:'get_local', idx:7 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'elseStmt' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2060, num_args:2 },
+  ]
+};
+
+block_2060 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genStmt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2061, num_args:2 },
+  ]
+};
+
+block_2061 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:3 },
+    { op:'new_object' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'op' },
+    { op:'push', val:'if_true' },
+    { op:'set_field' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'then' },
+    { op:'get_local', idx:4 },
+    { op:'set_field' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'else' },
+    { op:'get_local', idx:6 },
+    { op:'set_field' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addInstr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2062, num_args:2 },
+  ]
+};
+
+block_2062 = {
+  instrs: [
+    { op:'call', ret_to:@block_2063, num_args:2 },
+  ]
+};
+
+block_2063 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'Block' },
+    { op:'get_field' },
+    { op:'push', val:'new' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2064, num_args:2 },
+  ]
+};
+
+block_2064 = {
+  instrs: [
+    { op:'call', ret_to:@block_2065, num_args:0 },
+  ]
+};
+
+block_2065 = {
+  instrs: [
+    { op:'set_local', idx:8 },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:8 },
+    { op:'dup', idx:1 },
+    { op:'push', val:'merge' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2066, num_args:2 },
+  ]
+};
+
+block_2066 = {
+  instrs: [
+    { op:'call', ret_to:@block_2067, num_args:2 },
+  ]
+};
+
+block_2067 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:5 },
+    { op:'push', val:'curBlock' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2068, num_args:2 },
+  ]
+};
+
+block_2068 = {
+  instrs: [
+    { op:'dup', idx:0 },
+    { op:'push', val:'hasBranch' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2069, num_args:2 },
+  ]
+};
+
+block_2069 = {
+  instrs: [
+    { op:'call', ret_to:@block_2070, num_args:1 },
+  ]
+};
+
+block_2070 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_not' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2071, num_args:1 },
+  ]
+};
+
+block_2072 = {
+  instrs: [
+    { op:'get_local', idx:5 },
+    { op:'push', val:2 },
+    { op:'new_object' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'op' },
+    { op:'push', val:'jump' },
+    { op:'set_field' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'to' },
+    { op:'get_local', idx:8 },
+    { op:'set_field' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addInstr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2073, num_args:2 },
+  ]
+};
+
+block_2073 = {
+  instrs: [
+    { op:'call', ret_to:@block_2074, num_args:2 },
+  ]
+};
+
+block_2071 = {
+  instrs: [
+    { op:'if_true', then:@block_2072, else:@block_2075 },
+  ]
+};
+
+block_2074 = {
+  instrs: [
+    { op:'pop' },
+    { op:'jump', to:@block_2076 },
+  ]
+};
+
+block_2075 = {
+  instrs: [
+    { op:'jump', to:@block_2076 },
+  ]
+};
+
+block_2076 = {
+  instrs: [
+    { op:'get_local', idx:7 },
+    { op:'push', val:'curBlock' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2077, num_args:2 },
+  ]
+};
+
+block_2077 = {
+  instrs: [
+    { op:'dup', idx:0 },
+    { op:'push', val:'hasBranch' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2078, num_args:2 },
+  ]
+};
+
+block_2078 = {
+  instrs: [
+    { op:'call', ret_to:@block_2079, num_args:1 },
+  ]
+};
+
+block_2079 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_not' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2080, num_args:1 },
+  ]
+};
+
+block_2081 = {
+  instrs: [
+    { op:'get_local', idx:7 },
+    { op:'push', val:2 },
+    { op:'new_object' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'op' },
+    { op:'push', val:'jump' },
+    { op:'set_field' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'to' },
+    { op:'get_local', idx:8 },
+    { op:'set_field' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addInstr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2082, num_args:2 },
+  ]
+};
+
+block_2082 = {
+  instrs: [
+    { op:'call', ret_to:@block_2083, num_args:2 },
+  ]
+};
+
+block_2080 = {
+  instrs: [
+    { op:'if_true', then:@block_2081, else:@block_2084 },
+  ]
+};
+
+block_2083 = {
+  instrs: [
+    { op:'pop' },
+    { op:'jump', to:@block_2085 },
+  ]
+};
+
+block_2084 = {
+  instrs: [
+    { op:'jump', to:@block_2085 },
+  ]
+};
+
+block_2085 = {
+  instrs: [
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_2046 = {
+  instrs: [
+    { op:'if_true', then:@block_2047, else:@block_2086 },
+  ]
+};
+
+block_2086 = {
+  instrs: [
+    { op:'jump', to:@block_2087 },
+  ]
+};
+
+block_2087 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'ForStmt' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_instOf' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2088, num_args:2 },
+  ]
+};
+
+block_2089 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'Block' },
+    { op:'get_field' },
+    { op:'push', val:'new' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2090, num_args:2 },
+  ]
+};
+
+block_2090 = {
+  instrs: [
+    { op:'call', ret_to:@block_2091, num_args:0 },
+  ]
+};
+
+block_2091 = {
+  instrs: [
+    { op:'set_local', idx:9 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'Block' },
+    { op:'get_field' },
+    { op:'push', val:'new' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2092, num_args:2 },
+  ]
+};
+
+block_2092 = {
+  instrs: [
+    { op:'call', ret_to:@block_2093, num_args:0 },
+  ]
+};
+
+block_2093 = {
+  instrs: [
+    { op:'set_local', idx:10 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'Block' },
+    { op:'get_field' },
+    { op:'push', val:'new' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2094, num_args:2 },
+  ]
+};
+
+block_2094 = {
+  instrs: [
+    { op:'call', ret_to:@block_2095, num_args:0 },
+  ]
+};
+
+block_2095 = {
+  instrs: [
+    { op:'set_local', idx:11 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'Block' },
+    { op:'get_field' },
+    { op:'push', val:'new' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2096, num_args:2 },
+  ]
+};
+
+block_2096 = {
+  instrs: [
+    { op:'call', ret_to:@block_2097, num_args:0 },
+  ]
+};
+
+block_2097 = {
+  instrs: [
+    { op:'set_local', idx:12 },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'initStmt' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2098, num_args:2 },
+  ]
+};
+
+block_2098 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genStmt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2099, num_args:2 },
+  ]
+};
+
+block_2099 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:2 },
+    { op:'new_object' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'op' },
+    { op:'push', val:'jump' },
+    { op:'set_field' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'to' },
+    { op:'get_local', idx:9 },
+    { op:'set_field' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addInstr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2100, num_args:2 },
+  ]
+};
+
+block_2100 = {
+  instrs: [
+    { op:'call', ret_to:@block_2101, num_args:2 },
+  ]
+};
+
+block_2101 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:9 },
+    { op:'dup', idx:1 },
+    { op:'push', val:'subCtx' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2102, num_args:2 },
+  ]
+};
+
+block_2102 = {
+  instrs: [
+    { op:'call', ret_to:@block_2103, num_args:2 },
+  ]
+};
+
+block_2103 = {
+  instrs: [
+    { op:'set_local', idx:13 },
+    { op:'get_local', idx:13 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'testExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2104, num_args:2 },
+  ]
+};
+
+block_2104 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2105, num_args:2 },
+  ]
+};
+
+block_2105 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:13 },
+    { op:'push', val:3 },
+    { op:'new_object' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'op' },
+    { op:'push', val:'if_true' },
+    { op:'set_field' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'then' },
+    { op:'get_local', idx:10 },
+    { op:'set_field' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'else' },
+    { op:'get_local', idx:12 },
+    { op:'set_field' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addInstr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2106, num_args:2 },
+  ]
+};
+
+block_2106 = {
+  instrs: [
+    { op:'call', ret_to:@block_2107, num_args:2 },
+  ]
+};
+
+block_2107 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:10 },
+    { op:'get_local', idx:11 },
+    { op:'get_local', idx:12 },
+    { op:'dup', idx:3 },
+    { op:'push', val:'subCtxLoop' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2108, num_args:2 },
+  ]
+};
+
+block_2108 = {
+  instrs: [
+    { op:'call', ret_to:@block_2109, num_args:4 },
+  ]
+};
+
+block_2109 = {
+  instrs: [
+    { op:'set_local', idx:14 },
+    { op:'get_local', idx:14 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'bodyStmt' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2110, num_args:2 },
+  ]
+};
+
+block_2110 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genStmt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2111, num_args:2 },
+  ]
+};
+
+block_2111 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:14 },
+    { op:'push', val:'curBlock' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2112, num_args:2 },
+  ]
+};
+
+block_2112 = {
+  instrs: [
+    { op:'dup', idx:0 },
+    { op:'push', val:'hasBranch' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2113, num_args:2 },
+  ]
+};
+
+block_2113 = {
+  instrs: [
+    { op:'call', ret_to:@block_2114, num_args:1 },
+  ]
+};
+
+block_2114 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_not' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2115, num_args:1 },
+  ]
+};
+
+block_2116 = {
+  instrs: [
+    { op:'get_local', idx:14 },
+    { op:'push', val:2 },
+    { op:'new_object' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'op' },
+    { op:'push', val:'jump' },
+    { op:'set_field' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'to' },
+    { op:'get_local', idx:11 },
+    { op:'set_field' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addInstr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2117, num_args:2 },
+  ]
+};
+
+block_2117 = {
+  instrs: [
+    { op:'call', ret_to:@block_2118, num_args:2 },
+  ]
+};
+
+block_2115 = {
+  instrs: [
+    { op:'if_true', then:@block_2116, else:@block_2119 },
+  ]
+};
+
+block_2118 = {
+  instrs: [
+    { op:'pop' },
+    { op:'jump', to:@block_2120 },
+  ]
+};
+
+block_2119 = {
+  instrs: [
+    { op:'jump', to:@block_2120 },
+  ]
+};
+
+block_2120 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:11 },
+    { op:'dup', idx:1 },
+    { op:'push', val:'subCtx' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2121, num_args:2 },
+  ]
+};
+
+block_2121 = {
+  instrs: [
+    { op:'call', ret_to:@block_2122, num_args:2 },
+  ]
+};
+
+block_2122 = {
+  instrs: [
+    { op:'set_local', idx:15 },
+    { op:'get_local', idx:15 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'incrExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2123, num_args:2 },
+  ]
+};
+
+block_2123 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2124, num_args:2 },
+  ]
+};
+
+block_2124 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:15 },
+    { op:'push', val:2 },
+    { op:'new_object' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'op' },
+    { op:'push', val:'jump' },
+    { op:'set_field' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'to' },
+    { op:'get_local', idx:9 },
+    { op:'set_field' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addInstr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2125, num_args:2 },
+  ]
+};
+
+block_2125 = {
+  instrs: [
+    { op:'call', ret_to:@block_2126, num_args:2 },
+  ]
+};
+
+block_2126 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:12 },
+    { op:'dup', idx:1 },
+    { op:'push', val:'merge' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2127, num_args:2 },
+  ]
+};
+
+block_2127 = {
+  instrs: [
+    { op:'call', ret_to:@block_2128, num_args:2 },
+  ]
+};
+
+block_2128 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_2088 = {
+  instrs: [
+    { op:'if_true', then:@block_2089, else:@block_2129 },
+  ]
+};
+
+block_2129 = {
+  instrs: [
+    { op:'jump', to:@block_2130 },
+  ]
+};
+
+block_2130 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'ContStmt' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_instOf' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2131, num_args:2 },
+  ]
+};
+
+block_2132 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:'curBlock' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2133, num_args:2 },
+  ]
+};
+
+block_2133 = {
+  instrs: [
+    { op:'dup', idx:0 },
+    { op:'push', val:'hasBranch' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2134, num_args:2 },
+  ]
+};
+
+block_2134 = {
+  instrs: [
+    { op:'call', ret_to:@block_2135, num_args:1 },
+  ]
+};
+
+block_2135 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_not' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2136, num_args:1 },
+  ]
+};
+
+block_2137 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:2 },
@@ -18390,11 +19853,11 @@ block_1945 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1946, num_args:2 },
+    { op:'call', ret_to:@block_2138, num_args:2 },
   ]
 };
 
-block_1946 = {
+block_2138 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:1 },
@@ -18402,55 +19865,55 @@ block_1946 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1947, num_args:2 },
+    { op:'call', ret_to:@block_2139, num_args:2 },
   ]
 };
 
-block_1947 = {
+block_2139 = {
   instrs: [
-    { op:'call', ret_to:@block_1948, num_args:2 },
+    { op:'call', ret_to:@block_2140, num_args:2 },
   ]
 };
 
-block_1944 = {
+block_2136 = {
   instrs: [
-    { op:'if_true', then:@block_1945, else:@block_1949 },
+    { op:'if_true', then:@block_2137, else:@block_2141 },
   ]
 };
 
-block_1948 = {
+block_2140 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_1950 },
+    { op:'jump', to:@block_2142 },
   ]
 };
 
-block_1949 = {
+block_2141 = {
   instrs: [
-    { op:'jump', to:@block_1950 },
+    { op:'jump', to:@block_2142 },
   ]
 };
 
-block_1950 = {
+block_2142 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-block_1939 = {
+block_2131 = {
   instrs: [
-    { op:'if_true', then:@block_1940, else:@block_1951 },
+    { op:'if_true', then:@block_2132, else:@block_2143 },
   ]
 };
 
-block_1951 = {
+block_2143 = {
   instrs: [
-    { op:'jump', to:@block_1952 },
+    { op:'jump', to:@block_2144 },
   ]
 };
 
-block_1952 = {
+block_2144 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -18459,48 +19922,48 @@ block_1952 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1953, num_args:2 },
+    { op:'call', ret_to:@block_2145, num_args:2 },
   ]
 };
 
-block_1954 = {
+block_2146 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'curBlock' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1955, num_args:2 },
+    { op:'call', ret_to:@block_2147, num_args:2 },
   ]
 };
 
-block_1955 = {
+block_2147 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'push', val:'hasBranch' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1956, num_args:2 },
+    { op:'call', ret_to:@block_2148, num_args:2 },
   ]
 };
 
-block_1956 = {
+block_2148 = {
   instrs: [
-    { op:'call', ret_to:@block_1957, num_args:1 },
+    { op:'call', ret_to:@block_2149, num_args:1 },
   ]
 };
 
-block_1957 = {
+block_2149 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_not' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1958, num_args:1 },
+    { op:'call', ret_to:@block_2150, num_args:1 },
   ]
 };
 
-block_1959 = {
+block_2151 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:2 },
@@ -18516,11 +19979,11 @@ block_1959 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1960, num_args:2 },
+    { op:'call', ret_to:@block_2152, num_args:2 },
   ]
 };
 
-block_1960 = {
+block_2152 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:1 },
@@ -18528,55 +19991,55 @@ block_1960 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1961, num_args:2 },
+    { op:'call', ret_to:@block_2153, num_args:2 },
   ]
 };
 
-block_1961 = {
+block_2153 = {
   instrs: [
-    { op:'call', ret_to:@block_1962, num_args:2 },
+    { op:'call', ret_to:@block_2154, num_args:2 },
   ]
 };
 
-block_1958 = {
+block_2150 = {
   instrs: [
-    { op:'if_true', then:@block_1959, else:@block_1963 },
+    { op:'if_true', then:@block_2151, else:@block_2155 },
   ]
 };
 
-block_1962 = {
+block_2154 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_1964 },
+    { op:'jump', to:@block_2156 },
   ]
 };
 
-block_1963 = {
+block_2155 = {
   instrs: [
-    { op:'jump', to:@block_1964 },
+    { op:'jump', to:@block_2156 },
   ]
 };
 
-block_1964 = {
+block_2156 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-block_1953 = {
+block_2145 = {
   instrs: [
-    { op:'if_true', then:@block_1954, else:@block_1965 },
+    { op:'if_true', then:@block_2146, else:@block_2157 },
   ]
 };
 
-block_1965 = {
+block_2157 = {
   instrs: [
-    { op:'jump', to:@block_1966 },
+    { op:'jump', to:@block_2158 },
   ]
 };
 
-block_1966 = {
+block_2158 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -18585,31 +20048,31 @@ block_1966 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1967, num_args:2 },
+    { op:'call', ret_to:@block_2159, num_args:2 },
   ]
 };
 
-block_1968 = {
+block_2160 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'argExprs' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1969, num_args:2 },
+    { op:'call', ret_to:@block_2161, num_args:2 },
   ]
 };
 
-block_1969 = {
+block_2161 = {
   instrs: [
     { op:'set_local', idx:16 },
     { op:'push', val:0 },
     { op:'set_local', idx:2 },
-    { op:'jump', to:@block_1970 },
+    { op:'jump', to:@block_2162 },
   ]
 };
 
-block_1970 = {
+block_2162 = {
   instrs: [
     { op:'get_local', idx:2 },
     { op:'get_local', idx:16 },
@@ -18617,18 +20080,26 @@ block_1970 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1974, num_args:2 },
+    { op:'call', ret_to:@block_2166, num_args:2 },
   ]
 };
 
-block_1974 = {
+block_2166 = {
   instrs: [
-    { op:'lt_i32' },
-    { op:'if_true', then:@block_1971, else:@block_1973 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_lt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2167, num_args:2 },
   ]
 };
 
-block_1971 = {
+block_2167 = {
+  instrs: [
+    { op:'if_true', then:@block_2163, else:@block_2165 },
+  ]
+};
+
+block_2163 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:16 },
@@ -18636,47 +20107,47 @@ block_1971 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getElem' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1975, num_args:2 },
+    { op:'call', ret_to:@block_2168, num_args:2 },
   ]
 };
 
-block_1975 = {
+block_2168 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'genExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1976, num_args:2 },
+    { op:'call', ret_to:@block_2169, num_args:2 },
   ]
 };
 
-block_1976 = {
+block_2169 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_1972 },
+    { op:'jump', to:@block_2164 },
   ]
 };
 
-block_1972 = {
+block_2164 = {
   instrs: [
     { op:'get_local', idx:2 },
     { op:'push', val:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_add' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1977, num_args:2 },
+    { op:'call', ret_to:@block_2170, num_args:2 },
   ]
 };
 
-block_1977 = {
+block_2170 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'set_local', idx:2 },
     { op:'pop' },
-    { op:'jump', to:@block_1970 },
+    { op:'jump', to:@block_2162 },
   ]
 };
 
-block_1973 = {
+block_2165 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
@@ -18684,28 +20155,28 @@ block_1973 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1978, num_args:2 },
+    { op:'call', ret_to:@block_2171, num_args:2 },
   ]
 };
 
-block_1978 = {
+block_2171 = {
   instrs: [
     { op:'dup', idx:1 },
     { op:'push', val:'addInstr' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1979, num_args:2 },
+    { op:'call', ret_to:@block_2172, num_args:2 },
   ]
 };
 
-block_1979 = {
+block_2172 = {
   instrs: [
-    { op:'call', ret_to:@block_1980, num_args:2 },
+    { op:'call', ret_to:@block_2173, num_args:2 },
   ]
 };
 
-block_1980 = {
+block_2173 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -18713,53 +20184,53 @@ block_1980 = {
   ]
 };
 
-block_1967 = {
+block_2159 = {
   instrs: [
-    { op:'if_true', then:@block_1968, else:@block_1981 },
+    { op:'if_true', then:@block_2160, else:@block_2174 },
   ]
 };
 
-block_1981 = {
+block_2174 = {
   instrs: [
-    { op:'jump', to:@block_1982 },
+    { op:'jump', to:@block_2175 },
   ]
 };
 
-block_1982 = {
+block_2175 = {
   instrs: [
     { op:'push', val:$false },
-    { op:'if_true', then:@block_1983, else:@block_1984 },
+    { op:'if_true', then:@block_2176, else:@block_2177 },
   ]
 };
 
-block_1983 = {
+block_2176 = {
   instrs: [
-    { op:'jump', to:@block_1985 },
+    { op:'jump', to:@block_2178 },
   ]
 };
 
-block_1984 = {
+block_2177 = {
   instrs: [
     { op:'push', val:'unknown statement in genStmt' },
     { op:'abort' },
-    { op:'jump', to:@block_1985 },
+    { op:'jump', to:@block_2178 },
   ]
 };
 
-block_1985 = {
+block_2178 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-fun_1788 = {
-  entry:@block_1787,
+fun_1979 = {
+  entry:@block_1978,
   num_params:2,
   num_locals:17,
 };
 
-block_1986 = {
+block_2179 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'Block' },
@@ -18768,17 +20239,17 @@ block_1986 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1988, num_args:2 },
+    { op:'call', ret_to:@block_2181, num_args:2 },
   ]
 };
 
-block_1988 = {
+block_2181 = {
   instrs: [
-    { op:'call', ret_to:@block_1989, num_args:0 },
+    { op:'call', ret_to:@block_2182, num_args:0 },
   ]
 };
 
-block_1989 = {
+block_2182 = {
   instrs: [
     { op:'set_local', idx:3 },
     { op:'push', val:@global_obj },
@@ -18788,17 +20259,17 @@ block_1989 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1990, num_args:2 },
+    { op:'call', ret_to:@block_2183, num_args:2 },
   ]
 };
 
-block_1990 = {
+block_2183 = {
   instrs: [
-    { op:'call', ret_to:@block_1991, num_args:0 },
+    { op:'call', ret_to:@block_2184, num_args:0 },
   ]
 };
 
-block_1991 = {
+block_2184 = {
   instrs: [
     { op:'set_local', idx:4 },
     { op:'get_local', idx:0 },
@@ -18806,11 +20277,11 @@ block_1991 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'genExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1992, num_args:2 },
+    { op:'call', ret_to:@block_2185, num_args:2 },
   ]
 };
 
-block_1992 = {
+block_2185 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -18829,17 +20300,17 @@ block_1992 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1993, num_args:2 },
+    { op:'call', ret_to:@block_2186, num_args:2 },
   ]
 };
 
-block_1993 = {
+block_2186 = {
   instrs: [
-    { op:'call', ret_to:@block_1994, num_args:2 },
+    { op:'call', ret_to:@block_2187, num_args:2 },
   ]
 };
 
-block_1994 = {
+block_2187 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -18862,17 +20333,17 @@ block_1994 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1995, num_args:2 },
+    { op:'call', ret_to:@block_2188, num_args:2 },
   ]
 };
 
-block_1995 = {
+block_2188 = {
   instrs: [
-    { op:'call', ret_to:@block_1996, num_args:2 },
+    { op:'call', ret_to:@block_2189, num_args:2 },
   ]
 };
 
-block_1996 = {
+block_2189 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -18882,17 +20353,17 @@ block_1996 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1997, num_args:2 },
+    { op:'call', ret_to:@block_2190, num_args:2 },
   ]
 };
 
-block_1997 = {
+block_2190 = {
   instrs: [
-    { op:'call', ret_to:@block_1998, num_args:2 },
+    { op:'call', ret_to:@block_2191, num_args:2 },
   ]
 };
 
-block_1998 = {
+block_2191 = {
   instrs: [
     { op:'set_local', idx:5 },
     { op:'get_local', idx:5 },
@@ -18902,17 +20373,17 @@ block_1998 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1999, num_args:2 },
+    { op:'call', ret_to:@block_2192, num_args:2 },
   ]
 };
 
-block_1999 = {
+block_2192 = {
   instrs: [
-    { op:'call', ret_to:@block_2000, num_args:2 },
+    { op:'call', ret_to:@block_2193, num_args:2 },
   ]
 };
 
-block_2000 = {
+block_2193 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:5 },
@@ -18920,11 +20391,11 @@ block_2000 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'genExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2001, num_args:2 },
+    { op:'call', ret_to:@block_2194, num_args:2 },
   ]
 };
 
-block_2001 = {
+block_2194 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:5 },
@@ -18943,17 +20414,17 @@ block_2001 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2002, num_args:2 },
+    { op:'call', ret_to:@block_2195, num_args:2 },
   ]
 };
 
-block_2002 = {
+block_2195 = {
   instrs: [
-    { op:'call', ret_to:@block_2003, num_args:2 },
+    { op:'call', ret_to:@block_2196, num_args:2 },
   ]
 };
 
-block_2003 = {
+block_2196 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -18963,17 +20434,17 @@ block_2003 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2004, num_args:2 },
+    { op:'call', ret_to:@block_2197, num_args:2 },
   ]
 };
 
-block_2004 = {
+block_2197 = {
   instrs: [
-    { op:'call', ret_to:@block_2005, num_args:2 },
+    { op:'call', ret_to:@block_2198, num_args:2 },
   ]
 };
 
-block_2005 = {
+block_2198 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -18981,13 +20452,13 @@ block_2005 = {
   ]
 };
 
-fun_1987 = {
-  entry:@block_1986,
+fun_2180 = {
+  entry:@block_2179,
   num_params:3,
   num_locals:6,
 };
 
-block_2006 = {
+block_2199 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'Block' },
@@ -18996,17 +20467,17 @@ block_2006 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2008, num_args:2 },
+    { op:'call', ret_to:@block_2201, num_args:2 },
   ]
 };
 
-block_2008 = {
+block_2201 = {
   instrs: [
-    { op:'call', ret_to:@block_2009, num_args:0 },
+    { op:'call', ret_to:@block_2202, num_args:0 },
   ]
 };
 
-block_2009 = {
+block_2202 = {
   instrs: [
     { op:'set_local', idx:3 },
     { op:'push', val:@global_obj },
@@ -19016,17 +20487,17 @@ block_2009 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2010, num_args:2 },
+    { op:'call', ret_to:@block_2203, num_args:2 },
   ]
 };
 
-block_2010 = {
+block_2203 = {
   instrs: [
-    { op:'call', ret_to:@block_2011, num_args:0 },
+    { op:'call', ret_to:@block_2204, num_args:0 },
   ]
 };
 
-block_2011 = {
+block_2204 = {
   instrs: [
     { op:'set_local', idx:4 },
     { op:'get_local', idx:0 },
@@ -19034,11 +20505,11 @@ block_2011 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'genExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2012, num_args:2 },
+    { op:'call', ret_to:@block_2205, num_args:2 },
   ]
 };
 
-block_2012 = {
+block_2205 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -19057,17 +20528,17 @@ block_2012 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2013, num_args:2 },
+    { op:'call', ret_to:@block_2206, num_args:2 },
   ]
 };
 
-block_2013 = {
+block_2206 = {
   instrs: [
-    { op:'call', ret_to:@block_2014, num_args:2 },
+    { op:'call', ret_to:@block_2207, num_args:2 },
   ]
 };
 
-block_2014 = {
+block_2207 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -19090,17 +20561,17 @@ block_2014 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2015, num_args:2 },
+    { op:'call', ret_to:@block_2208, num_args:2 },
   ]
 };
 
-block_2015 = {
+block_2208 = {
   instrs: [
-    { op:'call', ret_to:@block_2016, num_args:2 },
+    { op:'call', ret_to:@block_2209, num_args:2 },
   ]
 };
 
-block_2016 = {
+block_2209 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -19110,17 +20581,17 @@ block_2016 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2017, num_args:2 },
+    { op:'call', ret_to:@block_2210, num_args:2 },
   ]
 };
 
-block_2017 = {
+block_2210 = {
   instrs: [
-    { op:'call', ret_to:@block_2018, num_args:2 },
+    { op:'call', ret_to:@block_2211, num_args:2 },
   ]
 };
 
-block_2018 = {
+block_2211 = {
   instrs: [
     { op:'set_local', idx:5 },
     { op:'get_local', idx:5 },
@@ -19130,17 +20601,17 @@ block_2018 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2019, num_args:2 },
+    { op:'call', ret_to:@block_2212, num_args:2 },
   ]
 };
 
-block_2019 = {
+block_2212 = {
   instrs: [
-    { op:'call', ret_to:@block_2020, num_args:2 },
+    { op:'call', ret_to:@block_2213, num_args:2 },
   ]
 };
 
-block_2020 = {
+block_2213 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:5 },
@@ -19148,11 +20619,11 @@ block_2020 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'genExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2021, num_args:2 },
+    { op:'call', ret_to:@block_2214, num_args:2 },
   ]
 };
 
-block_2021 = {
+block_2214 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:5 },
@@ -19171,17 +20642,17 @@ block_2021 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2022, num_args:2 },
+    { op:'call', ret_to:@block_2215, num_args:2 },
   ]
 };
 
-block_2022 = {
+block_2215 = {
   instrs: [
-    { op:'call', ret_to:@block_2023, num_args:2 },
+    { op:'call', ret_to:@block_2216, num_args:2 },
   ]
 };
 
-block_2023 = {
+block_2216 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -19191,17 +20662,17 @@ block_2023 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2024, num_args:2 },
+    { op:'call', ret_to:@block_2217, num_args:2 },
   ]
 };
 
-block_2024 = {
+block_2217 = {
   instrs: [
-    { op:'call', ret_to:@block_2025, num_args:2 },
+    { op:'call', ret_to:@block_2218, num_args:2 },
   ]
 };
 
-block_2025 = {
+block_2218 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -19209,84 +20680,84 @@ block_2025 = {
   ]
 };
 
-fun_2007 = {
-  entry:@block_2006,
+fun_2200 = {
+  entry:@block_2199,
   num_params:3,
   num_locals:6,
 };
 
-block_2026 = {
+block_2219 = {
   instrs: [
     { op:'get_local', idx:2 },
     { op:'push', val:'names' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2028, num_args:2 },
+    { op:'call', ret_to:@block_2221, num_args:2 },
   ]
 };
 
-block_2028 = {
+block_2221 = {
   instrs: [
     { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2029, num_args:2 },
+    { op:'call', ret_to:@block_2222, num_args:2 },
   ]
 };
 
-block_2029 = {
+block_2222 = {
   instrs: [
     { op:'get_local', idx:2 },
     { op:'push', val:'exprs' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2030, num_args:2 },
+    { op:'call', ret_to:@block_2223, num_args:2 },
   ]
 };
 
-block_2030 = {
+block_2223 = {
   instrs: [
     { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2031, num_args:2 },
+    { op:'call', ret_to:@block_2224, num_args:2 },
   ]
 };
 
-block_2031 = {
+block_2224 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2032, num_args:2 },
+    { op:'call', ret_to:@block_2225, num_args:2 },
   ]
 };
 
-block_2032 = {
+block_2225 = {
   instrs: [
-    { op:'if_true', then:@block_2033, else:@block_2034 },
+    { op:'if_true', then:@block_2226, else:@block_2227 },
   ]
 };
 
-block_2033 = {
+block_2226 = {
   instrs: [
-    { op:'jump', to:@block_2035 },
+    { op:'jump', to:@block_2228 },
   ]
 };
 
-block_2034 = {
+block_2227 = {
   instrs: [
     { op:'push', val:'object property names and init exprs do not match' },
     { op:'abort' },
-    { op:'jump', to:@block_2035 },
+    { op:'jump', to:@block_2228 },
   ]
 };
 
-block_2035 = {
+block_2228 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:2 },
@@ -19302,21 +20773,21 @@ block_2035 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2036, num_args:2 },
+    { op:'call', ret_to:@block_2229, num_args:2 },
   ]
 };
 
-block_2036 = {
+block_2229 = {
   instrs: [
     { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2037, num_args:2 },
+    { op:'call', ret_to:@block_2230, num_args:2 },
   ]
 };
 
-block_2037 = {
+block_2230 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:1 },
@@ -19324,17 +20795,17 @@ block_2037 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2038, num_args:2 },
+    { op:'call', ret_to:@block_2231, num_args:2 },
   ]
 };
 
-block_2038 = {
+block_2231 = {
   instrs: [
-    { op:'call', ret_to:@block_2039, num_args:2 },
+    { op:'call', ret_to:@block_2232, num_args:2 },
   ]
 };
 
-block_2039 = {
+block_2232 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -19344,17 +20815,17 @@ block_2039 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2040, num_args:2 },
+    { op:'call', ret_to:@block_2233, num_args:2 },
   ]
 };
 
-block_2040 = {
+block_2233 = {
   instrs: [
-    { op:'call', ret_to:@block_2041, num_args:2 },
+    { op:'call', ret_to:@block_2234, num_args:2 },
   ]
 };
 
-block_2041 = {
+block_2234 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:1 },
@@ -19362,11 +20833,11 @@ block_2041 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_ne' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2042, num_args:2 },
+    { op:'call', ret_to:@block_2235, num_args:2 },
   ]
 };
 
-block_2043 = {
+block_2236 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:2 },
@@ -19384,17 +20855,17 @@ block_2043 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2044, num_args:2 },
+    { op:'call', ret_to:@block_2237, num_args:2 },
   ]
 };
 
-block_2044 = {
+block_2237 = {
   instrs: [
-    { op:'call', ret_to:@block_2045, num_args:2 },
+    { op:'call', ret_to:@block_2238, num_args:2 },
   ]
 };
 
-block_2045 = {
+block_2238 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -19404,17 +20875,17 @@ block_2045 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2046, num_args:2 },
+    { op:'call', ret_to:@block_2239, num_args:2 },
   ]
 };
 
-block_2046 = {
+block_2239 = {
   instrs: [
-    { op:'call', ret_to:@block_2047, num_args:2 },
+    { op:'call', ret_to:@block_2240, num_args:2 },
   ]
 };
 
-block_2047 = {
+block_2240 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -19422,11 +20893,11 @@ block_2047 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'genExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2048, num_args:2 },
+    { op:'call', ret_to:@block_2241, num_args:2 },
   ]
 };
 
-block_2048 = {
+block_2241 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -19436,44 +20907,44 @@ block_2048 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2049, num_args:2 },
+    { op:'call', ret_to:@block_2242, num_args:2 },
   ]
 };
 
-block_2049 = {
+block_2242 = {
   instrs: [
-    { op:'call', ret_to:@block_2050, num_args:2 },
+    { op:'call', ret_to:@block_2243, num_args:2 },
   ]
 };
 
-block_2042 = {
+block_2235 = {
   instrs: [
-    { op:'if_true', then:@block_2043, else:@block_2051 },
+    { op:'if_true', then:@block_2236, else:@block_2244 },
   ]
 };
 
-block_2050 = {
+block_2243 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_2052 },
+    { op:'jump', to:@block_2245 },
   ]
 };
 
-block_2051 = {
+block_2244 = {
   instrs: [
-    { op:'jump', to:@block_2052 },
+    { op:'jump', to:@block_2245 },
   ]
 };
 
-block_2052 = {
+block_2245 = {
   instrs: [
     { op:'push', val:0 },
     { op:'set_local', idx:3 },
-    { op:'jump', to:@block_2053 },
+    { op:'jump', to:@block_2246 },
   ]
 };
 
-block_2053 = {
+block_2246 = {
   instrs: [
     { op:'get_local', idx:3 },
     { op:'get_local', idx:2 },
@@ -19481,28 +20952,36 @@ block_2053 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2057, num_args:2 },
+    { op:'call', ret_to:@block_2250, num_args:2 },
   ]
 };
 
-block_2057 = {
+block_2250 = {
   instrs: [
     { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2058, num_args:2 },
+    { op:'call', ret_to:@block_2251, num_args:2 },
   ]
 };
 
-block_2058 = {
+block_2251 = {
   instrs: [
-    { op:'lt_i32' },
-    { op:'if_true', then:@block_2054, else:@block_2056 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_lt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2252, num_args:2 },
   ]
 };
 
-block_2054 = {
+block_2252 = {
+  instrs: [
+    { op:'if_true', then:@block_2247, else:@block_2249 },
+  ]
+};
+
+block_2247 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:2 },
@@ -19520,17 +20999,17 @@ block_2054 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2059, num_args:2 },
+    { op:'call', ret_to:@block_2253, num_args:2 },
   ]
 };
 
-block_2059 = {
+block_2253 = {
   instrs: [
-    { op:'call', ret_to:@block_2060, num_args:2 },
+    { op:'call', ret_to:@block_2254, num_args:2 },
   ]
 };
 
-block_2060 = {
+block_2254 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -19547,21 +21026,21 @@ block_2060 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2061, num_args:2 },
+    { op:'call', ret_to:@block_2255, num_args:2 },
   ]
 };
 
-block_2061 = {
+block_2255 = {
   instrs: [
     { op:'get_local', idx:3 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getElem' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2062, num_args:2 },
+    { op:'call', ret_to:@block_2256, num_args:2 },
   ]
 };
 
-block_2062 = {
+block_2256 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:1 },
@@ -19569,17 +21048,17 @@ block_2062 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2063, num_args:2 },
+    { op:'call', ret_to:@block_2257, num_args:2 },
   ]
 };
 
-block_2063 = {
+block_2257 = {
   instrs: [
-    { op:'call', ret_to:@block_2064, num_args:2 },
+    { op:'call', ret_to:@block_2258, num_args:2 },
   ]
 };
 
-block_2064 = {
+block_2258 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -19588,30 +21067,30 @@ block_2064 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2065, num_args:2 },
+    { op:'call', ret_to:@block_2259, num_args:2 },
   ]
 };
 
-block_2065 = {
+block_2259 = {
   instrs: [
     { op:'get_local', idx:3 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getElem' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2066, num_args:2 },
+    { op:'call', ret_to:@block_2260, num_args:2 },
   ]
 };
 
-block_2066 = {
+block_2260 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'genExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2067, num_args:2 },
+    { op:'call', ret_to:@block_2261, num_args:2 },
   ]
 };
 
-block_2067 = {
+block_2261 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -19621,57 +21100,57 @@ block_2067 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2068, num_args:2 },
+    { op:'call', ret_to:@block_2262, num_args:2 },
   ]
 };
 
-block_2068 = {
+block_2262 = {
   instrs: [
-    { op:'call', ret_to:@block_2069, num_args:2 },
+    { op:'call', ret_to:@block_2263, num_args:2 },
   ]
 };
 
-block_2069 = {
+block_2263 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_2055 },
+    { op:'jump', to:@block_2248 },
   ]
 };
 
-block_2055 = {
+block_2248 = {
   instrs: [
     { op:'get_local', idx:3 },
     { op:'push', val:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_add' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2070, num_args:2 },
+    { op:'call', ret_to:@block_2264, num_args:2 },
   ]
 };
 
-block_2070 = {
+block_2264 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'set_local', idx:3 },
     { op:'pop' },
-    { op:'jump', to:@block_2053 },
+    { op:'jump', to:@block_2246 },
   ]
 };
 
-block_2056 = {
+block_2249 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-fun_2027 = {
-  entry:@block_2026,
+fun_2220 = {
+  entry:@block_2219,
   num_params:3,
   num_locals:4,
 };
 
-block_2071 = {
+block_2265 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -19680,140 +21159,140 @@ block_2071 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2073, num_args:2 },
+    { op:'call', ret_to:@block_2267, num_args:2 },
   ]
 };
 
-block_2074 = {
+block_2268 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'name' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2075, num_args:2 },
+    { op:'call', ret_to:@block_2269, num_args:2 },
   ]
 };
 
-block_2075 = {
+block_2269 = {
   instrs: [
     { op:'push', val:'exports' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2076, num_args:2 },
+    { op:'call', ret_to:@block_2270, num_args:2 },
   ]
 };
 
-block_2077 = {
+block_2271 = {
   instrs: [
     { op:'push', val:$false },
     { op:'push', val:'cannot assign to exports variable' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseError' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2078, num_args:2 },
+    { op:'call', ret_to:@block_2272, num_args:2 },
   ]
 };
 
-block_2076 = {
+block_2270 = {
   instrs: [
-    { op:'if_true', then:@block_2077, else:@block_2079 },
+    { op:'if_true', then:@block_2271, else:@block_2273 },
   ]
 };
 
-block_2078 = {
+block_2272 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_2080 },
+    { op:'jump', to:@block_2274 },
   ]
 };
 
-block_2079 = {
+block_2273 = {
   instrs: [
-    { op:'jump', to:@block_2080 },
+    { op:'jump', to:@block_2274 },
   ]
 };
 
-block_2080 = {
+block_2274 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'fun' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2081, num_args:2 },
+    { op:'call', ret_to:@block_2275, num_args:2 },
   ]
 };
 
-block_2081 = {
+block_2275 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'name' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2082, num_args:2 },
+    { op:'call', ret_to:@block_2276, num_args:2 },
   ]
 };
 
-block_2082 = {
+block_2276 = {
   instrs: [
     { op:'dup', idx:1 },
     { op:'push', val:'hasLocal' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2083, num_args:2 },
+    { op:'call', ret_to:@block_2277, num_args:2 },
   ]
 };
 
-block_2083 = {
+block_2277 = {
   instrs: [
-    { op:'call', ret_to:@block_2084, num_args:2 },
+    { op:'call', ret_to:@block_2278, num_args:2 },
   ]
 };
 
-block_2085 = {
+block_2279 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'fun' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2086, num_args:2 },
+    { op:'call', ret_to:@block_2280, num_args:2 },
   ]
 };
 
-block_2086 = {
+block_2280 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'name' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2087, num_args:2 },
+    { op:'call', ret_to:@block_2281, num_args:2 },
   ]
 };
 
-block_2087 = {
+block_2281 = {
   instrs: [
     { op:'dup', idx:1 },
     { op:'push', val:'getLocalIdx' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2088, num_args:2 },
+    { op:'call', ret_to:@block_2282, num_args:2 },
   ]
 };
 
-block_2088 = {
+block_2282 = {
   instrs: [
-    { op:'call', ret_to:@block_2089, num_args:2 },
+    { op:'call', ret_to:@block_2283, num_args:2 },
   ]
 };
 
-block_2089 = {
+block_2283 = {
   instrs: [
     { op:'set_local', idx:3 },
     { op:'get_local', idx:0 },
@@ -19821,11 +21300,11 @@ block_2089 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'genExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2090, num_args:2 },
+    { op:'call', ret_to:@block_2284, num_args:2 },
   ]
 };
 
-block_2090 = {
+block_2284 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -19844,17 +21323,17 @@ block_2090 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2091, num_args:2 },
+    { op:'call', ret_to:@block_2285, num_args:2 },
   ]
 };
 
-block_2091 = {
+block_2285 = {
   instrs: [
-    { op:'call', ret_to:@block_2092, num_args:2 },
+    { op:'call', ret_to:@block_2286, num_args:2 },
   ]
 };
 
-block_2092 = {
+block_2286 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -19873,28 +21352,28 @@ block_2092 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2093, num_args:2 },
+    { op:'call', ret_to:@block_2287, num_args:2 },
   ]
 };
 
-block_2093 = {
+block_2287 = {
   instrs: [
-    { op:'call', ret_to:@block_2094, num_args:2 },
+    { op:'call', ret_to:@block_2288, num_args:2 },
   ]
 };
 
-block_2095 = {
+block_2289 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:2 },
     { op:'push', val:@global_obj },
     { op:'push', val:'genExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2096, num_args:2 },
+    { op:'call', ret_to:@block_2290, num_args:2 },
   ]
 };
 
-block_2096 = {
+block_2290 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -19903,28 +21382,28 @@ block_2096 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2097, num_args:2 },
+    { op:'call', ret_to:@block_2291, num_args:2 },
   ]
 };
 
-block_2097 = {
+block_2291 = {
   instrs: [
     { op:'dup', idx:1 },
     { op:'push', val:'addPush' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2098, num_args:2 },
+    { op:'call', ret_to:@block_2292, num_args:2 },
   ]
 };
 
-block_2098 = {
+block_2292 = {
   instrs: [
-    { op:'call', ret_to:@block_2099, num_args:2 },
+    { op:'call', ret_to:@block_2293, num_args:2 },
   ]
 };
 
-block_2099 = {
+block_2293 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -19933,28 +21412,28 @@ block_2099 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2100, num_args:2 },
+    { op:'call', ret_to:@block_2294, num_args:2 },
   ]
 };
 
-block_2100 = {
+block_2294 = {
   instrs: [
     { op:'dup', idx:1 },
     { op:'push', val:'addPush' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2101, num_args:2 },
+    { op:'call', ret_to:@block_2295, num_args:2 },
   ]
 };
 
-block_2101 = {
+block_2295 = {
   instrs: [
-    { op:'call', ret_to:@block_2102, num_args:2 },
+    { op:'call', ret_to:@block_2296, num_args:2 },
   ]
 };
 
-block_2102 = {
+block_2296 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -19973,17 +21452,17 @@ block_2102 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2103, num_args:2 },
+    { op:'call', ret_to:@block_2297, num_args:2 },
   ]
 };
 
-block_2103 = {
+block_2297 = {
   instrs: [
-    { op:'call', ret_to:@block_2104, num_args:2 },
+    { op:'call', ret_to:@block_2298, num_args:2 },
   ]
 };
 
-block_2104 = {
+block_2298 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -19993,56 +21472,56 @@ block_2104 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2105, num_args:2 },
+    { op:'call', ret_to:@block_2299, num_args:2 },
   ]
 };
 
-block_2105 = {
+block_2299 = {
   instrs: [
-    { op:'call', ret_to:@block_2106, num_args:2 },
+    { op:'call', ret_to:@block_2300, num_args:2 },
   ]
 };
 
-block_2084 = {
+block_2278 = {
   instrs: [
-    { op:'if_true', then:@block_2085, else:@block_2095 },
+    { op:'if_true', then:@block_2279, else:@block_2289 },
   ]
 };
 
-block_2094 = {
-  instrs: [
-    { op:'pop' },
-    { op:'jump', to:@block_2107 },
-  ]
-};
-
-block_2106 = {
+block_2288 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_2107 },
+    { op:'jump', to:@block_2301 },
   ]
 };
 
-block_2107 = {
+block_2300 = {
+  instrs: [
+    { op:'pop' },
+    { op:'jump', to:@block_2301 },
+  ]
+};
+
+block_2301 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-block_2073 = {
+block_2267 = {
   instrs: [
-    { op:'if_true', then:@block_2074, else:@block_2108 },
+    { op:'if_true', then:@block_2268, else:@block_2302 },
   ]
 };
 
-block_2108 = {
+block_2302 = {
   instrs: [
-    { op:'jump', to:@block_2109 },
+    { op:'jump', to:@block_2303 },
   ]
 };
 
-block_2109 = {
+block_2303 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -20051,22 +21530,22 @@ block_2109 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2110, num_args:2 },
+    { op:'call', ret_to:@block_2304, num_args:2 },
   ]
 };
 
-block_2111 = {
+block_2305 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'op' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2112, num_args:2 },
+    { op:'call', ret_to:@block_2306, num_args:2 },
   ]
 };
 
-block_2112 = {
+block_2306 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'OP_MEMBER' },
@@ -20074,11 +21553,11 @@ block_2112 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2113, num_args:2 },
+    { op:'call', ret_to:@block_2307, num_args:2 },
   ]
 };
 
-block_2114 = {
+block_2308 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'set_local', idx:4 },
@@ -20087,11 +21566,11 @@ block_2114 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2115, num_args:2 },
+    { op:'call', ret_to:@block_2309, num_args:2 },
   ]
 };
 
-block_2115 = {
+block_2309 = {
   instrs: [
     { op:'set_local', idx:5 },
     { op:'get_local', idx:0 },
@@ -20099,11 +21578,11 @@ block_2115 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'genExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2116, num_args:2 },
+    { op:'call', ret_to:@block_2310, num_args:2 },
   ]
 };
 
-block_2116 = {
+block_2310 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -20112,20 +21591,20 @@ block_2116 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2117, num_args:2 },
+    { op:'call', ret_to:@block_2311, num_args:2 },
   ]
 };
 
-block_2117 = {
+block_2311 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'genExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2118, num_args:2 },
+    { op:'call', ret_to:@block_2312, num_args:2 },
   ]
 };
 
-block_2118 = {
+block_2312 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -20142,11 +21621,11 @@ block_2118 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2119, num_args:2 },
+    { op:'call', ret_to:@block_2313, num_args:2 },
   ]
 };
 
-block_2119 = {
+block_2313 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:1 },
@@ -20154,17 +21633,17 @@ block_2119 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2120, num_args:2 },
+    { op:'call', ret_to:@block_2314, num_args:2 },
   ]
 };
 
-block_2120 = {
+block_2314 = {
   instrs: [
-    { op:'call', ret_to:@block_2121, num_args:2 },
+    { op:'call', ret_to:@block_2315, num_args:2 },
   ]
 };
 
-block_2121 = {
+block_2315 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -20183,17 +21662,17 @@ block_2121 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2122, num_args:2 },
+    { op:'call', ret_to:@block_2316, num_args:2 },
   ]
 };
 
-block_2122 = {
+block_2316 = {
   instrs: [
-    { op:'call', ret_to:@block_2123, num_args:2 },
+    { op:'call', ret_to:@block_2317, num_args:2 },
   ]
 };
 
-block_2123 = {
+block_2317 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -20203,17 +21682,17 @@ block_2123 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2124, num_args:2 },
+    { op:'call', ret_to:@block_2318, num_args:2 },
   ]
 };
 
-block_2124 = {
+block_2318 = {
   instrs: [
-    { op:'call', ret_to:@block_2125, num_args:2 },
+    { op:'call', ret_to:@block_2319, num_args:2 },
   ]
 };
 
-block_2125 = {
+block_2319 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -20221,102 +21700,102 @@ block_2125 = {
   ]
 };
 
-block_2113 = {
+block_2307 = {
   instrs: [
-    { op:'if_true', then:@block_2114, else:@block_2126 },
+    { op:'if_true', then:@block_2308, else:@block_2320 },
   ]
 };
 
-block_2126 = {
+block_2320 = {
   instrs: [
-    { op:'jump', to:@block_2127 },
+    { op:'jump', to:@block_2321 },
   ]
 };
 
-block_2127 = {
+block_2321 = {
   instrs: [
     { op:'push', val:$false },
-    { op:'if_true', then:@block_2128, else:@block_2129 },
+    { op:'if_true', then:@block_2322, else:@block_2323 },
   ]
 };
 
-block_2128 = {
+block_2322 = {
   instrs: [
-    { op:'jump', to:@block_2130 },
+    { op:'jump', to:@block_2324 },
   ]
 };
 
-block_2129 = {
+block_2323 = {
   instrs: [
     { op:'push', val:'assertion failed' },
     { op:'abort' },
-    { op:'jump', to:@block_2130 },
+    { op:'jump', to:@block_2324 },
   ]
 };
 
-block_2110 = {
+block_2304 = {
   instrs: [
-    { op:'if_true', then:@block_2111, else:@block_2131 },
+    { op:'if_true', then:@block_2305, else:@block_2325 },
   ]
 };
 
-block_2130 = {
+block_2324 = {
   instrs: [
-    { op:'jump', to:@block_2132 },
+    { op:'jump', to:@block_2326 },
   ]
 };
 
-block_2131 = {
+block_2325 = {
   instrs: [
-    { op:'jump', to:@block_2132 },
+    { op:'jump', to:@block_2326 },
   ]
 };
 
-block_2132 = {
+block_2326 = {
   instrs: [
     { op:'push', val:$false },
-    { op:'if_true', then:@block_2133, else:@block_2134 },
+    { op:'if_true', then:@block_2327, else:@block_2328 },
   ]
 };
 
-block_2133 = {
+block_2327 = {
   instrs: [
-    { op:'jump', to:@block_2135 },
+    { op:'jump', to:@block_2329 },
   ]
 };
 
-block_2134 = {
+block_2328 = {
   instrs: [
     { op:'push', val:'unhandled expression type in genAssign' },
     { op:'abort' },
-    { op:'jump', to:@block_2135 },
+    { op:'jump', to:@block_2329 },
   ]
 };
 
-block_2135 = {
+block_2329 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-fun_2072 = {
-  entry:@block_2071,
+fun_2266 = {
+  entry:@block_2265,
   num_params:3,
   num_locals:6,
 };
 
-block_2136 = {
+block_2330 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'print' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2138, num_args:1 },
+    { op:'call', ret_to:@block_2332, num_args:1 },
   ]
 };
 
-block_2138 = {
+block_2332 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -20324,1023 +21803,1023 @@ block_2138 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'parseString' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2139, num_args:2 },
+    { op:'call', ret_to:@block_2333, num_args:2 },
   ]
 };
 
-block_2139 = {
+block_2333 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-fun_2137 = {
-  entry:@block_2136,
+fun_2331 = {
+  entry:@block_2330,
   num_params:1,
   num_locals:1,
 };
 
-block_2140 = {
+block_2334 = {
   instrs: [
     { op:'push', val:'parser tests' },
     { op:'push', val:@global_obj },
     { op:'push', val:'print' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2142, num_args:1 },
+    { op:'call', ret_to:@block_2336, num_args:1 },
   ]
 };
 
-block_2142 = {
+block_2336 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'foobar;' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2143, num_args:1 },
+    { op:'call', ret_to:@block_2337, num_args:1 },
   ]
 };
 
-block_2143 = {
+block_2337 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'  foo_bar;  ' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2144, num_args:1 },
+    { op:'call', ret_to:@block_2338, num_args:1 },
   ]
 };
 
-block_2144 = {
+block_2338 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'  foo_bar ; ' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2145, num_args:1 },
+    { op:'call', ret_to:@block_2339, num_args:1 },
   ]
 };
 
-block_2145 = {
+block_2339 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'123;' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2146, num_args:1 },
+    { op:'call', ret_to:@block_2340, num_args:1 },
   ]
 };
 
-block_2146 = {
+block_2340 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'\'abc\';' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2147, num_args:1 },
+    { op:'call', ret_to:@block_2341, num_args:1 },
   ]
 };
 
-block_2147 = {
+block_2341 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'\"double-quoted string!\";' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2148, num_args:1 },
+    { op:'call', ret_to:@block_2342, num_args:1 },
   ]
 };
 
-block_2148 = {
+block_2342 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'\"double-quoted string, \'hi\'!\";' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2149, num_args:1 },
+    { op:'call', ret_to:@block_2343, num_args:1 },
   ]
 };
 
-block_2149 = {
+block_2343 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'\'hi\'; // comment' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2150, num_args:1 },
+    { op:'call', ret_to:@block_2344, num_args:1 },
   ]
 };
 
-block_2150 = {
+block_2344 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'\'hi\';' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2151, num_args:1 },
+    { op:'call', ret_to:@block_2345, num_args:1 },
   ]
 };
 
-block_2151 = {
+block_2345 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'\'new\\nline\';' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2152, num_args:1 },
+    { op:'call', ret_to:@block_2346, num_args:1 },
   ]
 };
 
-block_2152 = {
+block_2346 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'true;' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2153, num_args:1 },
+    { op:'call', ret_to:@block_2347, num_args:1 },
   ]
 };
 
-block_2153 = {
+block_2347 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'false;' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2154, num_args:1 },
+    { op:'call', ret_to:@block_2348, num_args:1 },
   ]
 };
 
-block_2154 = {
+block_2348 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'[];' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2155, num_args:1 },
+    { op:'call', ret_to:@block_2349, num_args:1 },
   ]
 };
 
-block_2155 = {
+block_2349 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'[1];' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2156, num_args:1 },
+    { op:'call', ret_to:@block_2350, num_args:1 },
   ]
 };
 
-block_2156 = {
+block_2350 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'[1,a];' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2157, num_args:1 },
+    { op:'call', ret_to:@block_2351, num_args:1 },
   ]
 };
 
-block_2157 = {
+block_2351 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'[1 , a];' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2158, num_args:1 },
+    { op:'call', ret_to:@block_2352, num_args:1 },
   ]
 };
 
-block_2158 = {
+block_2352 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'[1,a, ];' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2159, num_args:1 },
+    { op:'call', ret_to:@block_2353, num_args:1 },
   ]
 };
 
-block_2159 = {
+block_2353 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'[ 1,\x0Aa ];' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2160, num_args:1 },
+    { op:'call', ret_to:@block_2354, num_args:1 },
   ]
 };
 
-block_2160 = {
+block_2354 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'var x = {x:3};' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2161, num_args:1 },
+    { op:'call', ret_to:@block_2355, num_args:1 },
   ]
 };
 
-block_2161 = {
+block_2355 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'var x = {x:3,y:2};' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2162, num_args:1 },
+    { op:'call', ret_to:@block_2356, num_args:1 },
   ]
 };
 
-block_2162 = {
+block_2356 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'var x = {x:3,y:2+z};' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2163, num_args:1 },
+    { op:'call', ret_to:@block_2357, num_args:1 },
   ]
 };
 
-block_2163 = {
+block_2357 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'var x = {x:3,y:2+z,};' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2164, num_args:1 },
+    { op:'call', ret_to:@block_2358, num_args:1 },
   ]
 };
 
-block_2164 = {
+block_2358 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'1; // comment' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2165, num_args:1 },
+    { op:'call', ret_to:@block_2359, num_args:1 },
   ]
 };
 
-block_2165 = {
+block_2359 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'[ 1//comment\x0A,a ];' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2166, num_args:1 },
+    { op:'call', ret_to:@block_2360, num_args:1 },
   ]
 };
 
-block_2166 = {
+block_2360 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'1 /* comment */ + x;' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2167, num_args:1 },
+    { op:'call', ret_to:@block_2361, num_args:1 },
   ]
 };
 
-block_2167 = {
+block_2361 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'1 /* // comment */ + x;' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2168, num_args:1 },
+    { op:'call', ret_to:@block_2362, num_args:1 },
   ]
 };
 
-block_2168 = {
+block_2362 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'-1;' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2169, num_args:1 },
+    { op:'call', ret_to:@block_2363, num_args:1 },
   ]
 };
 
-block_2169 = {
+block_2363 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'-x + 2;' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2170, num_args:1 },
+    { op:'call', ret_to:@block_2364, num_args:1 },
   ]
 };
 
-block_2170 = {
+block_2364 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'x + -1;' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2171, num_args:1 },
+    { op:'call', ret_to:@block_2365, num_args:1 },
   ]
 };
 
-block_2171 = {
+block_2365 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'a + b;' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2172, num_args:1 },
+    { op:'call', ret_to:@block_2366, num_args:1 },
   ]
 };
 
-block_2172 = {
+block_2366 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'a + b + c;' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2173, num_args:1 },
+    { op:'call', ret_to:@block_2367, num_args:1 },
   ]
 };
 
-block_2173 = {
+block_2367 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'a + b - c;' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2174, num_args:1 },
+    { op:'call', ret_to:@block_2368, num_args:1 },
   ]
 };
 
-block_2174 = {
+block_2368 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'a + b * c + d;' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2175, num_args:1 },
+    { op:'call', ret_to:@block_2369, num_args:1 },
   ]
 };
 
-block_2175 = {
+block_2369 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'a || b || c;' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2176, num_args:1 },
+    { op:'call', ret_to:@block_2370, num_args:1 },
   ]
 };
 
-block_2176 = {
+block_2370 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'a && b;' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2177, num_args:1 },
+    { op:'call', ret_to:@block_2371, num_args:1 },
   ]
 };
 
-block_2177 = {
+block_2371 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'(a);' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2178, num_args:1 },
+    { op:'call', ret_to:@block_2372, num_args:1 },
   ]
 };
 
-block_2178 = {
+block_2372 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'(b ) ;' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2179, num_args:1 },
+    { op:'call', ret_to:@block_2373, num_args:1 },
   ]
 };
 
-block_2179 = {
+block_2373 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'(a + b);' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2180, num_args:1 },
+    { op:'call', ret_to:@block_2374, num_args:1 },
   ]
 };
 
-block_2180 = {
+block_2374 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'(a + (b + c));' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2181, num_args:1 },
+    { op:'call', ret_to:@block_2375, num_args:1 },
   ]
 };
 
-block_2181 = {
+block_2375 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'((a + b) + c);' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2182, num_args:1 },
+    { op:'call', ret_to:@block_2376, num_args:1 },
   ]
 };
 
-block_2182 = {
+block_2376 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'(a + b) * (c + d);' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2183, num_args:1 },
+    { op:'call', ret_to:@block_2377, num_args:1 },
   ]
 };
 
-block_2183 = {
+block_2377 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'a.b;' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2184, num_args:1 },
+    { op:'call', ret_to:@block_2378, num_args:1 },
   ]
 };
 
-block_2184 = {
+block_2378 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'a.b + c;' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2185, num_args:1 },
+    { op:'call', ret_to:@block_2379, num_args:1 },
   ]
 };
 
-block_2185 = {
+block_2379 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'a[0];' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2186, num_args:1 },
+    { op:'call', ret_to:@block_2380, num_args:1 },
   ]
 };
 
-block_2186 = {
+block_2380 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'a[b];' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2187, num_args:1 },
+    { op:'call', ret_to:@block_2381, num_args:1 },
   ]
 };
 
-block_2187 = {
+block_2381 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'a[b+2];' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2188, num_args:1 },
+    { op:'call', ret_to:@block_2382, num_args:1 },
   ]
 };
 
-block_2188 = {
+block_2382 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'a[2*b+1];' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2189, num_args:1 },
+    { op:'call', ret_to:@block_2383, num_args:1 },
   ]
 };
 
-block_2189 = {
+block_2383 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'if (1) 2; ' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2190, num_args:1 },
+    { op:'call', ret_to:@block_2384, num_args:1 },
   ]
 };
 
-block_2190 = {
+block_2384 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'if (1) return 2;' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2191, num_args:1 },
+    { op:'call', ret_to:@block_2385, num_args:1 },
   ]
 };
 
-block_2191 = {
+block_2385 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'if (!x) return 1; else return 2;' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2192, num_args:1 },
+    { op:'call', ret_to:@block_2386, num_args:1 },
   ]
 };
 
-block_2192 = {
+block_2386 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'if (x <= 2) return 0; ' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2193, num_args:1 },
+    { op:'call', ret_to:@block_2387, num_args:1 },
   ]
 };
 
-block_2193 = {
+block_2387 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'if (x == 1) return 2; ' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2194, num_args:1 },
+    { op:'call', ret_to:@block_2388, num_args:1 },
   ]
 };
 
-block_2194 = {
+block_2388 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'if (typeof x == \'string\') return 2; ' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2195, num_args:1 },
+    { op:'call', ret_to:@block_2389, num_args:1 },
   ]
 };
 
-block_2195 = {
+block_2389 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'if (\'foo\' in obj) return 1;' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2196, num_args:1 },
+    { op:'call', ret_to:@block_2390, num_args:1 },
   ]
 };
 
-block_2196 = {
+block_2390 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'for (a; b; c) d;' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2197, num_args:1 },
+    { op:'call', ret_to:@block_2391, num_args:1 },
   ]
 };
 
-block_2197 = {
+block_2391 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'for (a; b; c) continue;' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2198, num_args:1 },
+    { op:'call', ret_to:@block_2392, num_args:1 },
   ]
 };
 
-block_2198 = {
+block_2392 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'for (a; b; c) break;' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2199, num_args:1 },
+    { op:'call', ret_to:@block_2393, num_args:1 },
   ]
 };
 
-block_2199 = {
+block_2393 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'for (;;) d;' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2200, num_args:1 },
+    { op:'call', ret_to:@block_2394, num_args:1 },
   ]
 };
 
-block_2200 = {
+block_2394 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'for (i = 0; i < 10; i = i + 1) x;' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2201, num_args:1 },
+    { op:'call', ret_to:@block_2395, num_args:1 },
   ]
 };
 
-block_2201 = {
+block_2395 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'x = 1;' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2202, num_args:1 },
+    { op:'call', ret_to:@block_2396, num_args:1 },
   ]
 };
 
-block_2202 = {
+block_2396 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'x = -1;' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2203, num_args:1 },
+    { op:'call', ret_to:@block_2397, num_args:1 },
   ]
 };
 
-block_2203 = {
+block_2397 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'a.b = x + y;' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2204, num_args:1 },
+    { op:'call', ret_to:@block_2398, num_args:1 },
   ]
 };
 
-block_2204 = {
+block_2398 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'x = y = 1;' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2205, num_args:1 },
+    { op:'call', ret_to:@block_2399, num_args:1 },
   ]
 };
 
-block_2205 = {
+block_2399 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'var x = 3;' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2206, num_args:1 },
+    { op:'call', ret_to:@block_2400, num_args:1 },
   ]
 };
 
-block_2206 = {
+block_2400 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'x += 3;' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2207, num_args:1 },
+    { op:'call', ret_to:@block_2401, num_args:1 },
   ]
 };
 
-block_2207 = {
+block_2401 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'a();' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2208, num_args:1 },
+    { op:'call', ret_to:@block_2402, num_args:1 },
   ]
 };
 
-block_2208 = {
+block_2402 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'a(b);' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2209, num_args:1 },
+    { op:'call', ret_to:@block_2403, num_args:1 },
   ]
 };
 
-block_2209 = {
+block_2403 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'a(b,c);' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2210, num_args:1 },
+    { op:'call', ret_to:@block_2404, num_args:1 },
   ]
 };
 
-block_2210 = {
+block_2404 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'a(b,c+1);' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2211, num_args:1 },
+    { op:'call', ret_to:@block_2405, num_args:1 },
   ]
 };
 
-block_2211 = {
+block_2405 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'a(b,c+1,);' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2212, num_args:1 },
+    { op:'call', ret_to:@block_2406, num_args:1 },
   ]
 };
 
-block_2212 = {
+block_2406 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'x + a(b,c+1);' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2213, num_args:1 },
+    { op:'call', ret_to:@block_2407, num_args:1 },
   ]
 };
 
-block_2213 = {
+block_2407 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'x + a(b,c+1) + y;' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2214, num_args:1 },
+    { op:'call', ret_to:@block_2408, num_args:1 },
   ]
 };
 
-block_2214 = {
+block_2408 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'a(); b();' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2215, num_args:1 },
+    { op:'call', ret_to:@block_2409, num_args:1 },
   ]
 };
 
-block_2215 = {
+block_2409 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'var io = import \'core/io\';' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2216, num_args:1 },
+    { op:'call', ret_to:@block_2410, num_args:1 },
   ]
 };
 
-block_2216 = {
+block_2410 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'$add_i32(1, 2);' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2217, num_args:1 },
+    { op:'call', ret_to:@block_2411, num_args:1 },
   ]
 };
 
-block_2217 = {
+block_2411 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'assert(x);' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2218, num_args:1 },
+    { op:'call', ret_to:@block_2412, num_args:1 },
   ]
 };
 
-block_2218 = {
+block_2412 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'assert(x, \'foo\');' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2219, num_args:1 },
+    { op:'call', ret_to:@block_2413, num_args:1 },
   ]
 };
 
-block_2219 = {
+block_2413 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'function () { return 0; }; ' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2220, num_args:1 },
+    { op:'call', ret_to:@block_2414, num_args:1 },
   ]
 };
 
-block_2220 = {
+block_2414 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'function (x) {return x;};' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2221, num_args:1 },
+    { op:'call', ret_to:@block_2415, num_args:1 },
   ]
 };
 
-block_2221 = {
+block_2415 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'function foo(x) { return x; };' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2222, num_args:1 },
+    { op:'call', ret_to:@block_2416, num_args:1 },
   ]
 };
 
-block_2222 = {
+block_2416 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'function (x,y) { return x; };' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2223, num_args:1 },
+    { op:'call', ret_to:@block_2417, num_args:1 },
   ]
 };
 
-block_2223 = {
+block_2417 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'function (x,y,) { return x; };' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2224, num_args:1 },
+    { op:'call', ret_to:@block_2418, num_args:1 },
   ]
 };
 
-block_2224 = {
+block_2418 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'function (x,y) { return x+y; };' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2225, num_args:1 },
+    { op:'call', ret_to:@block_2419, num_args:1 },
   ]
 };
 
-block_2225 = {
+block_2419 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'obj.method = function (this, x) { this.x = x; }; ' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2226, num_args:1 },
+    { op:'call', ret_to:@block_2420, num_args:1 },
   ]
 };
 
-block_2226 = {
+block_2420 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'{ 1; 2; }' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2227, num_args:1 },
+    { op:'call', ret_to:@block_2421, num_args:1 },
   ]
 };
 
-block_2227 = {
+block_2421 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'function (x) { print(x); print(y); };' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2228, num_args:1 },
+    { op:'call', ret_to:@block_2422, num_args:1 },
   ]
 };
 
-block_2228 = {
+block_2422 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'function (x) { var y = x + 1; print(y); };' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2229, num_args:1 },
+    { op:'call', ret_to:@block_2423, num_args:1 },
   ]
 };
 
-block_2229 = {
+block_2423 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'o:foo();' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2230, num_args:1 },
+    { op:'call', ret_to:@block_2424, num_args:1 },
   ]
 };
 
-block_2230 = {
+block_2424 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'o:foo(1,2);' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2231, num_args:1 },
+    { op:'call', ret_to:@block_2425, num_args:1 },
   ]
 };
 
-block_2231 = {
+block_2425 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'x + o:foo(1,2);' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2232, num_args:1 },
+    { op:'call', ret_to:@block_2426, num_args:1 },
   ]
 };
 
-block_2232 = {
+block_2426 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -21348,13 +22827,13 @@ block_2232 = {
   ]
 };
 
-fun_2141 = {
-  entry:@block_2140,
+fun_2335 = {
+  entry:@block_2334,
   num_params:0,
   num_locals:0,
 };
 
-block_261 = {
+block_434 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -21464,23 +22943,23 @@ block_261 = {
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseError' },
-    { op:'push', val:@fun_263 },
+    { op:'push', val:@fun_436 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'isSpace' },
-    { op:'push', val:@fun_282 },
+    { op:'push', val:@fun_455 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'isDigit' },
-    { op:'push', val:@fun_291 },
+    { op:'push', val:@fun_464 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'isAlpha' },
-    { op:'push', val:@fun_297 },
+    { op:'push', val:@fun_470 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'isAlnum' },
-    { op:'push', val:@fun_309 },
+    { op:'push', val:@fun_482 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'Input' },
@@ -21507,7 +22986,7 @@ block_261 = {
     { op:'push', val:1 },
     { op:'set_field' },
     { op:'set_field' },
-    { op:'push', val:@fun_327 },
+    { op:'push', val:@fun_500 },
     { op:'push', val:@global_obj },
     { op:'push', val:'Input' },
     { op:'get_field' },
@@ -21515,7 +22994,7 @@ block_261 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_332 },
+    { op:'push', val:@fun_505 },
     { op:'push', val:@global_obj },
     { op:'push', val:'Input' },
     { op:'get_field' },
@@ -21523,7 +23002,7 @@ block_261 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_344 },
+    { op:'push', val:@fun_517 },
     { op:'push', val:@global_obj },
     { op:'push', val:'Input' },
     { op:'get_field' },
@@ -21531,7 +23010,7 @@ block_261 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_381 },
+    { op:'push', val:@fun_554 },
     { op:'push', val:@global_obj },
     { op:'push', val:'Input' },
     { op:'get_field' },
@@ -21539,7 +23018,7 @@ block_261 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_386 },
+    { op:'push', val:@fun_559 },
     { op:'push', val:@global_obj },
     { op:'push', val:'Input' },
     { op:'get_field' },
@@ -21547,7 +23026,7 @@ block_261 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_411 },
+    { op:'push', val:@fun_585 },
     { op:'push', val:@global_obj },
     { op:'push', val:'Input' },
     { op:'get_field' },
@@ -21555,7 +23034,7 @@ block_261 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_430 },
+    { op:'push', val:@fun_606 },
     { op:'push', val:@global_obj },
     { op:'push', val:'Input' },
     { op:'get_field' },
@@ -21563,7 +23042,7 @@ block_261 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_441 },
+    { op:'push', val:@fun_617 },
     { op:'push', val:@global_obj },
     { op:'push', val:'Input' },
     { op:'get_field' },
@@ -21571,7 +23050,7 @@ block_261 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_505 },
+    { op:'push', val:@fun_681 },
     { op:'push', val:@global_obj },
     { op:'push', val:'Input' },
     { op:'get_field' },
@@ -21579,7 +23058,7 @@ block_261 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_511 },
+    { op:'push', val:@fun_687 },
     { op:'push', val:@global_obj },
     { op:'push', val:'Input' },
     { op:'get_field' },
@@ -21587,7 +23066,7 @@ block_261 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_517 },
+    { op:'push', val:@fun_693 },
     { op:'push', val:@global_obj },
     { op:'push', val:'Input' },
     { op:'get_field' },
@@ -21597,82 +23076,82 @@ block_261 = {
     { op:'pop' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseInt' },
-    { op:'push', val:@fun_523 },
+    { op:'push', val:@fun_699 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseEscSeq' },
-    { op:'push', val:@fun_566 },
+    { op:'push', val:@fun_745 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseStringLit' },
-    { op:'push', val:@fun_602 },
+    { op:'push', val:@fun_781 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseIdentStr' },
-    { op:'push', val:@fun_634 },
+    { op:'push', val:@fun_813 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseIfStmt' },
-    { op:'push', val:@fun_670 },
+    { op:'push', val:@fun_849 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseForStmt' },
-    { op:'push', val:@fun_684 },
+    { op:'push', val:@fun_863 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExprList' },
-    { op:'push', val:@fun_711 },
+    { op:'push', val:@fun_890 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseObjExpr' },
-    { op:'push', val:@fun_732 },
+    { op:'push', val:@fun_911 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseFunExpr' },
-    { op:'push', val:@fun_758 },
+    { op:'push', val:@fun_937 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'matchOp' },
-    { op:'push', val:@fun_791 },
+    { op:'push', val:@fun_970 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseAtom' },
-    { op:'push', val:@fun_842 },
+    { op:'push', val:@fun_1024 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExprPrec' },
-    { op:'push', val:@fun_928 },
+    { op:'push', val:@fun_1110 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExpr' },
-    { op:'push', val:@fun_1007 },
+    { op:'push', val:@fun_1191 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseBlockStmt' },
-    { op:'push', val:@fun_1010 },
+    { op:'push', val:@fun_1194 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseStmt' },
-    { op:'push', val:@fun_1036 },
+    { op:'push', val:@fun_1220 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseUnit' },
-    { op:'push', val:@fun_1123 },
+    { op:'push', val:@fun_1307 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseString' },
-    { op:'push', val:@fun_1126 },
+    { op:'push', val:@fun_1310 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseFile' },
-    { op:'push', val:@fun_1129 },
+    { op:'push', val:@fun_1313 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'Block' },
     { op:'push', val:0 },
     { op:'new_object' },
     { op:'set_field' },
-    { op:'push', val:@fun_1133 },
+    { op:'push', val:@fun_1317 },
     { op:'push', val:@global_obj },
     { op:'push', val:'Block' },
     { op:'get_field' },
@@ -21680,7 +23159,7 @@ block_261 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_1135 },
+    { op:'push', val:@fun_1319 },
     { op:'push', val:@global_obj },
     { op:'push', val:'Block' },
     { op:'get_field' },
@@ -21688,7 +23167,7 @@ block_261 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_1156 },
+    { op:'push', val:@fun_1340 },
     { op:'push', val:@global_obj },
     { op:'push', val:'Block' },
     { op:'get_field' },
@@ -21701,7 +23180,7 @@ block_261 = {
     { op:'push', val:0 },
     { op:'new_object' },
     { op:'set_field' },
-    { op:'push', val:@fun_1161 },
+    { op:'push', val:@fun_1345 },
     { op:'push', val:@global_obj },
     { op:'push', val:'Function' },
     { op:'get_field' },
@@ -21709,7 +23188,7 @@ block_261 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_1163 },
+    { op:'push', val:@fun_1347 },
     { op:'push', val:@global_obj },
     { op:'push', val:'Function' },
     { op:'get_field' },
@@ -21717,7 +23196,7 @@ block_261 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_1176 },
+    { op:'push', val:@fun_1360 },
     { op:'push', val:@global_obj },
     { op:'push', val:'Function' },
     { op:'get_field' },
@@ -21725,7 +23204,7 @@ block_261 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_1182 },
+    { op:'push', val:@fun_1366 },
     { op:'push', val:@global_obj },
     { op:'push', val:'Function' },
     { op:'get_field' },
@@ -21738,7 +23217,7 @@ block_261 = {
     { op:'push', val:0 },
     { op:'new_object' },
     { op:'set_field' },
-    { op:'push', val:@fun_1198 },
+    { op:'push', val:@fun_1383 },
     { op:'push', val:@global_obj },
     { op:'push', val:'CodeGenCtx' },
     { op:'get_field' },
@@ -21746,7 +23225,7 @@ block_261 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_1200 },
+    { op:'push', val:@fun_1385 },
     { op:'push', val:@global_obj },
     { op:'push', val:'CodeGenCtx' },
     { op:'get_field' },
@@ -21754,7 +23233,7 @@ block_261 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_1208 },
+    { op:'push', val:@fun_1393 },
     { op:'push', val:@global_obj },
     { op:'push', val:'CodeGenCtx' },
     { op:'get_field' },
@@ -21762,7 +23241,7 @@ block_261 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_1214 },
+    { op:'push', val:@fun_1399 },
     { op:'push', val:@global_obj },
     { op:'push', val:'CodeGenCtx' },
     { op:'get_field' },
@@ -21770,7 +23249,7 @@ block_261 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_1216 },
+    { op:'push', val:@fun_1401 },
     { op:'push', val:@global_obj },
     { op:'push', val:'CodeGenCtx' },
     { op:'get_field' },
@@ -21778,7 +23257,7 @@ block_261 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_1226 },
+    { op:'push', val:@fun_1411 },
     { op:'push', val:@global_obj },
     { op:'push', val:'CodeGenCtx' },
     { op:'get_field' },
@@ -21786,7 +23265,7 @@ block_261 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_1231 },
+    { op:'push', val:@fun_1416 },
     { op:'push', val:@global_obj },
     { op:'push', val:'CodeGenCtx' },
     { op:'get_field' },
@@ -21796,56 +23275,56 @@ block_261 = {
     { op:'pop' },
     { op:'push', val:@global_obj },
     { op:'push', val:'registerDecls' },
-    { op:'push', val:@fun_1236 },
+    { op:'push', val:@fun_1421 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'genUnit' },
-    { op:'push', val:@fun_1302 },
+    { op:'push', val:@fun_1488 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'runtimeCall' },
-    { op:'push', val:@fun_1325 },
+    { op:'push', val:@fun_1511 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'genExpr' },
-    { op:'push', val:@fun_1336 },
+    { op:'push', val:@fun_1522 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'genStmt' },
-    { op:'push', val:@fun_1788 },
+    { op:'push', val:@fun_1979 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'genLogicalAnd' },
-    { op:'push', val:@fun_1987 },
+    { op:'push', val:@fun_2180 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'genLogicalOr' },
-    { op:'push', val:@fun_2007 },
+    { op:'push', val:@fun_2200 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'genObjExpr' },
-    { op:'push', val:@fun_2027 },
+    { op:'push', val:@fun_2220 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'genAssign' },
-    { op:'push', val:@fun_2072 },
+    { op:'push', val:@fun_2266 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParse' },
-    { op:'push', val:@fun_2137 },
+    { op:'push', val:@fun_2331 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParser' },
-    { op:'push', val:@fun_2141 },
+    { op:'push', val:@fun_2335 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'testParser' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2233, num_args:0 },
+    { op:'call', ret_to:@block_2427, num_args:0 },
   ]
 };
 
-block_2233 = {
+block_2427 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$true },

--- a/makefile.in
+++ b/makefile.in
@@ -76,7 +76,7 @@ vm/core.cpp     \
 vm/main.cpp     \
 
 zeta: vm/*.cpp vm/*.h
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $(ZETA_BIN) $(ZETA_SRCS)
+	$(CXX) $(CXXFLAGS) -o $(ZETA_BIN) $(ZETA_SRCS) $(LDFLAGS)
 
 ##############################################################################
 # Plush compiler

--- a/makefile.in
+++ b/makefile.in
@@ -19,6 +19,7 @@ test: zeta cplush plush-pkg cscheme
 	# cplush tests
 	./$(CPLUSH_BIN) --test
 	./plush.sh tests/plush/trivial.pls
+	./plush.sh tests/plush/floats.pls
 	./plush.sh tests/plush/simple_exprs.pls
 	./plush.sh tests/plush/identfn.pls
 	./plush.sh tests/plush/fib.pls

--- a/packages/lang/plush/0/package
+++ b/packages/lang/plush/0/package
@@ -757,8 +757,9 @@ fun_101 = {
 block_108 = {
   instrs: [
     { op:'get_local', idx:0 },
+    { op:'i32_to_f32' },
     { op:'get_local', idx:1 },
-    { op:'eq_i32' },
+    { op:'eq_f32' },
     { op:'ret' },
   ]
 };
@@ -766,7 +767,7 @@ block_108 = {
 block_107 = {
   instrs: [
     { op:'get_local', idx:1 },
-    { op:'has_tag', tag:'int32' },
+    { op:'has_tag', tag:'float32' },
     { op:'if_true', then:@block_108, else:@block_109 },
   ]
 };
@@ -777,67 +778,69 @@ block_109 = {
   ]
 };
 
-block_105 = {
+block_111 = {
   instrs: [
     { op:'get_local', idx:0 },
-    { op:'has_tag', tag:'int32' },
-    { op:'if_true', then:@block_107, else:@block_111 },
+    { op:'get_local', idx:1 },
+    { op:'eq_i32' },
+    { op:'ret' },
   ]
 };
 
 block_110 = {
   instrs: [
-    { op:'jump', to:@block_112 },
-  ]
-};
-
-block_111 = {
-  instrs: [
-    { op:'jump', to:@block_112 },
-  ]
-};
-
-block_114 = {
-  instrs: [
-    { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
-    { op:'eq_str' },
-    { op:'ret' },
-  ]
-};
-
-block_113 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'has_tag', tag:'string' },
-    { op:'if_true', then:@block_114, else:@block_115 },
-  ]
-};
-
-block_115 = {
-  instrs: [
-    { op:'jump', to:@block_116 },
-  ]
-};
-
-block_116 = {
-  instrs: [
-    { op:'push', val:$false },
-    { op:'ret' },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_111, else:@block_112 },
   ]
 };
 
 block_112 = {
   instrs: [
+    { op:'jump', to:@block_113 },
+  ]
+};
+
+block_105 = {
+  instrs: [
     { op:'get_local', idx:0 },
-    { op:'has_tag', tag:'string' },
-    { op:'if_true', then:@block_113, else:@block_117 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_107, else:@block_114 },
+  ]
+};
+
+block_113 = {
+  instrs: [
+    { op:'jump', to:@block_115 },
+  ]
+};
+
+block_114 = {
+  instrs: [
+    { op:'jump', to:@block_115 },
   ]
 };
 
 block_117 = {
   instrs: [
-    { op:'jump', to:@block_118 },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'eq_f32' },
+    { op:'ret' },
+  ]
+};
+
+block_116 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_117, else:@block_118 },
+  ]
+};
+
+block_118 = {
+  instrs: [
+    { op:'jump', to:@block_119 },
   ]
 };
 
@@ -845,7 +848,8 @@ block_120 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
-    { op:'eq_obj' },
+    { op:'i32_to_f32' },
+    { op:'eq_f32' },
     { op:'ret' },
   ]
 };
@@ -853,7 +857,7 @@ block_120 = {
 block_119 = {
   instrs: [
     { op:'get_local', idx:1 },
-    { op:'has_tag', tag:'object' },
+    { op:'has_tag', tag:'int32' },
     { op:'if_true', then:@block_120, else:@block_121 },
   ]
 };
@@ -864,18 +868,17 @@ block_121 = {
   ]
 };
 
-block_122 = {
+block_115 = {
   instrs: [
-    { op:'push', val:$false },
-    { op:'ret' },
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_116, else:@block_123 },
   ]
 };
 
-block_118 = {
+block_122 = {
   instrs: [
-    { op:'get_local', idx:0 },
-    { op:'has_tag', tag:'object' },
-    { op:'if_true', then:@block_119, else:@block_123 },
+    { op:'jump', to:@block_124 },
   ]
 };
 
@@ -889,7 +892,7 @@ block_126 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
-    { op:'eq_bool' },
+    { op:'eq_str' },
     { op:'ret' },
   ]
 };
@@ -897,7 +900,7 @@ block_126 = {
 block_125 = {
   instrs: [
     { op:'get_local', idx:1 },
-    { op:'has_tag', tag:'bool' },
+    { op:'has_tag', tag:'string' },
     { op:'if_true', then:@block_126, else:@block_127 },
   ]
 };
@@ -918,7 +921,7 @@ block_128 = {
 block_124 = {
   instrs: [
     { op:'get_local', idx:0 },
-    { op:'has_tag', tag:'bool' },
+    { op:'has_tag', tag:'string' },
     { op:'if_true', then:@block_125, else:@block_129 },
   ]
 };
@@ -931,7 +934,9 @@ block_129 = {
 
 block_132 = {
   instrs: [
-    { op:'push', val:$true },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'eq_obj' },
     { op:'ret' },
   ]
 };
@@ -939,7 +944,7 @@ block_132 = {
 block_131 = {
   instrs: [
     { op:'get_local', idx:1 },
-    { op:'has_tag', tag:'undef' },
+    { op:'has_tag', tag:'object' },
     { op:'if_true', then:@block_132, else:@block_133 },
   ]
 };
@@ -960,7 +965,7 @@ block_134 = {
 block_130 = {
   instrs: [
     { op:'get_local', idx:0 },
-    { op:'has_tag', tag:'undef' },
+    { op:'has_tag', tag:'object' },
     { op:'if_true', then:@block_131, else:@block_135 },
   ]
 };
@@ -971,28 +976,114 @@ block_135 = {
   ]
 };
 
-block_136 = {
+block_138 = {
   instrs: [
-    { op:'push', val:$false },
-    { op:'if_true', then:@block_137, else:@block_138 },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'eq_bool' },
+    { op:'ret' },
   ]
 };
 
 block_137 = {
   instrs: [
-    { op:'jump', to:@block_139 },
-  ]
-};
-
-block_138 = {
-  instrs: [
-    { op:'push', val:'unhandled type in equality comparison' },
-    { op:'abort' },
-    { op:'jump', to:@block_139 },
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'bool' },
+    { op:'if_true', then:@block_138, else:@block_139 },
   ]
 };
 
 block_139 = {
+  instrs: [
+    { op:'jump', to:@block_140 },
+  ]
+};
+
+block_140 = {
+  instrs: [
+    { op:'push', val:$false },
+    { op:'ret' },
+  ]
+};
+
+block_136 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'bool' },
+    { op:'if_true', then:@block_137, else:@block_141 },
+  ]
+};
+
+block_141 = {
+  instrs: [
+    { op:'jump', to:@block_142 },
+  ]
+};
+
+block_144 = {
+  instrs: [
+    { op:'push', val:$true },
+    { op:'ret' },
+  ]
+};
+
+block_143 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'undef' },
+    { op:'if_true', then:@block_144, else:@block_145 },
+  ]
+};
+
+block_145 = {
+  instrs: [
+    { op:'jump', to:@block_146 },
+  ]
+};
+
+block_146 = {
+  instrs: [
+    { op:'push', val:$false },
+    { op:'ret' },
+  ]
+};
+
+block_142 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'undef' },
+    { op:'if_true', then:@block_143, else:@block_147 },
+  ]
+};
+
+block_147 = {
+  instrs: [
+    { op:'jump', to:@block_148 },
+  ]
+};
+
+block_148 = {
+  instrs: [
+    { op:'push', val:$false },
+    { op:'if_true', then:@block_149, else:@block_150 },
+  ]
+};
+
+block_149 = {
+  instrs: [
+    { op:'jump', to:@block_151 },
+  ]
+};
+
+block_150 = {
+  instrs: [
+    { op:'push', val:'unhandled type in equality comparison' },
+    { op:'abort' },
+    { op:'jump', to:@block_151 },
+  ]
+};
+
+block_151 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
@@ -1005,187 +1096,88 @@ fun_106 = {
   num_locals:2,
 };
 
-block_140 = {
+block_152 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_142, num_args:2 },
+    { op:'call', ret_to:@block_154, num_args:2 },
   ]
 };
 
-block_143 = {
+block_155 = {
   instrs: [
     { op:'push', val:$false },
     { op:'ret' },
   ]
 };
 
-block_144 = {
+block_156 = {
   instrs: [
     { op:'push', val:$true },
     { op:'ret' },
   ]
 };
 
-block_142 = {
+block_154 = {
   instrs: [
-    { op:'if_true', then:@block_143, else:@block_144 },
+    { op:'if_true', then:@block_155, else:@block_156 },
   ]
 };
 
-block_145 = {
+block_157 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-fun_141 = {
-  entry:@block_140,
+fun_153 = {
+  entry:@block_152,
   num_params:2,
   num_locals:2,
-};
-
-block_149 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'le_i32' },
-    { op:'ret' },
-  ]
-};
-
-block_148 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'has_tag', tag:'int32' },
-    { op:'if_true', then:@block_149, else:@block_150 },
-  ]
-};
-
-block_150 = {
-  instrs: [
-    { op:'jump', to:@block_151 },
-  ]
-};
-
-block_146 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'has_tag', tag:'int32' },
-    { op:'if_true', then:@block_148, else:@block_152 },
-  ]
-};
-
-block_151 = {
-  instrs: [
-    { op:'jump', to:@block_153 },
-  ]
-};
-
-block_152 = {
-  instrs: [
-    { op:'jump', to:@block_153 },
-  ]
-};
-
-block_155 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'str_len' },
-    { op:'push', val:1 },
-    { op:'eq_i32' },
-    { op:'if_true', then:@block_156, else:@block_157 },
-  ]
-};
-
-block_156 = {
-  instrs: [
-    { op:'jump', to:@block_158 },
-  ]
-};
-
-block_157 = {
-  instrs: [
-    { op:'push', val:'rt_le' },
-    { op:'abort' },
-    { op:'jump', to:@block_158 },
-  ]
-};
-
-block_158 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'str_len' },
-    { op:'push', val:1 },
-    { op:'eq_i32' },
-    { op:'if_true', then:@block_159, else:@block_160 },
-  ]
-};
-
-block_159 = {
-  instrs: [
-    { op:'jump', to:@block_161 },
-  ]
-};
-
-block_160 = {
-  instrs: [
-    { op:'push', val:'rt_le' },
-    { op:'abort' },
-    { op:'jump', to:@block_161 },
-  ]
 };
 
 block_161 = {
   instrs: [
     { op:'get_local', idx:0 },
-    { op:'push', val:0 },
-    { op:'get_char_code' },
+    { op:'i32_to_f32' },
     { op:'get_local', idx:1 },
-    { op:'push', val:0 },
-    { op:'get_char_code' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_le' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_162, num_args:2 },
+    { op:'lt_f32' },
+    { op:'ret' },
+  ]
+};
+
+block_160 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_161, else:@block_162 },
   ]
 };
 
 block_162 = {
   instrs: [
-    { op:'ret' },
-  ]
-};
-
-block_154 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'has_tag', tag:'string' },
-    { op:'if_true', then:@block_155, else:@block_163 },
-  ]
-};
-
-block_163 = {
-  instrs: [
-    { op:'jump', to:@block_164 },
-  ]
-};
-
-block_153 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'has_tag', tag:'string' },
-    { op:'if_true', then:@block_154, else:@block_165 },
+    { op:'jump', to:@block_163 },
   ]
 };
 
 block_164 = {
   instrs: [
-    { op:'jump', to:@block_166 },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'lt_i32' },
+    { op:'ret' },
+  ]
+};
+
+block_163 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_164, else:@block_165 },
   ]
 };
 
@@ -1195,45 +1187,55 @@ block_165 = {
   ]
 };
 
+block_158 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_160, else:@block_167 },
+  ]
+};
+
 block_166 = {
   instrs: [
-    { op:'push', val:$false },
-    { op:'if_true', then:@block_167, else:@block_168 },
+    { op:'jump', to:@block_168 },
   ]
 };
 
 block_167 = {
   instrs: [
-    { op:'jump', to:@block_169 },
+    { op:'jump', to:@block_168 },
   ]
 };
 
-block_168 = {
+block_170 = {
   instrs: [
-    { op:'push', val:'unhandled type in less-than or equal comparison' },
-    { op:'abort' },
-    { op:'jump', to:@block_169 },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'lt_f32' },
+    { op:'ret' },
   ]
 };
 
 block_169 = {
   instrs: [
-    { op:'push', val:$undef },
-    { op:'ret' },
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_170, else:@block_171 },
   ]
 };
 
-fun_147 = {
-  entry:@block_146,
-  num_params:2,
-  num_locals:2,
+block_171 = {
+  instrs: [
+    { op:'jump', to:@block_172 },
+  ]
 };
 
 block_173 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
-    { op:'ge_i32' },
+    { op:'i32_to_f32' },
+    { op:'lt_f32' },
     { op:'ret' },
   ]
 };
@@ -1252,11 +1254,11 @@ block_174 = {
   ]
 };
 
-block_170 = {
+block_168 = {
   instrs: [
     { op:'get_local', idx:0 },
-    { op:'has_tag', tag:'int32' },
-    { op:'if_true', then:@block_172, else:@block_176 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_169, else:@block_176 },
   ]
 };
 
@@ -1272,80 +1274,77 @@ block_176 = {
   ]
 };
 
-block_179 = {
+block_177 = {
+  instrs: [
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+fun_159 = {
+  entry:@block_158,
+  num_params:2,
+  num_locals:2,
+};
+
+block_181 = {
   instrs: [
     { op:'get_local', idx:0 },
-    { op:'str_len' },
-    { op:'push', val:1 },
-    { op:'eq_i32' },
-    { op:'if_true', then:@block_180, else:@block_181 },
+    { op:'i32_to_f32' },
+    { op:'get_local', idx:1 },
+    { op:'le_f32' },
+    { op:'ret' },
   ]
 };
 
 block_180 = {
   instrs: [
-    { op:'jump', to:@block_182 },
-  ]
-};
-
-block_181 = {
-  instrs: [
-    { op:'push', val:'rt_ge' },
-    { op:'abort' },
-    { op:'jump', to:@block_182 },
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_181, else:@block_182 },
   ]
 };
 
 block_182 = {
   instrs: [
-    { op:'get_local', idx:1 },
-    { op:'str_len' },
-    { op:'push', val:1 },
-    { op:'eq_i32' },
-    { op:'if_true', then:@block_183, else:@block_184 },
-  ]
-};
-
-block_183 = {
-  instrs: [
-    { op:'jump', to:@block_185 },
+    { op:'jump', to:@block_183 },
   ]
 };
 
 block_184 = {
   instrs: [
-    { op:'push', val:'rt_ge' },
-    { op:'abort' },
-    { op:'jump', to:@block_185 },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'le_i32' },
+    { op:'ret' },
+  ]
+};
+
+block_183 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_184, else:@block_185 },
   ]
 };
 
 block_185 = {
   instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:0 },
-    { op:'get_char_code' },
-    { op:'get_local', idx:1 },
-    { op:'push', val:0 },
-    { op:'get_char_code' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_ge' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_186, num_args:2 },
-  ]
-};
-
-block_186 = {
-  instrs: [
-    { op:'ret' },
+    { op:'jump', to:@block_186 },
   ]
 };
 
 block_178 = {
   instrs: [
-    { op:'get_local', idx:1 },
-    { op:'has_tag', tag:'string' },
-    { op:'if_true', then:@block_179, else:@block_187 },
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_180, else:@block_187 },
+  ]
+};
+
+block_186 = {
+  instrs: [
+    { op:'jump', to:@block_188 },
   ]
 };
 
@@ -1355,230 +1354,225 @@ block_187 = {
   ]
 };
 
-block_177 = {
+block_190 = {
   instrs: [
     { op:'get_local', idx:0 },
-    { op:'has_tag', tag:'string' },
-    { op:'if_true', then:@block_178, else:@block_189 },
-  ]
-};
-
-block_188 = {
-  instrs: [
-    { op:'jump', to:@block_190 },
+    { op:'get_local', idx:1 },
+    { op:'le_f32' },
+    { op:'ret' },
   ]
 };
 
 block_189 = {
   instrs: [
-    { op:'jump', to:@block_190 },
-  ]
-};
-
-block_190 = {
-  instrs: [
-    { op:'push', val:$false },
-    { op:'if_true', then:@block_191, else:@block_192 },
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_190, else:@block_191 },
   ]
 };
 
 block_191 = {
   instrs: [
-    { op:'jump', to:@block_193 },
-  ]
-};
-
-block_192 = {
-  instrs: [
-    { op:'push', val:'unhandled type in less-than or equal comparison' },
-    { op:'abort' },
-    { op:'jump', to:@block_193 },
+    { op:'jump', to:@block_192 },
   ]
 };
 
 block_193 = {
   instrs: [
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-fun_171 = {
-  entry:@block_170,
-  num_params:2,
-  num_locals:2,
-};
-
-block_197 = {
-  instrs: [
-    { op:'get_local', idx:1 },
     { op:'get_local', idx:0 },
-    { op:'has_field' },
+    { op:'get_local', idx:1 },
+    { op:'i32_to_f32' },
+    { op:'le_f32' },
     { op:'ret' },
   ]
 };
 
-block_196 = {
+block_192 = {
   instrs: [
     { op:'get_local', idx:1 },
-    { op:'has_tag', tag:'object' },
-    { op:'if_true', then:@block_197, else:@block_198 },
-  ]
-};
-
-block_198 = {
-  instrs: [
-    { op:'jump', to:@block_199 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_193, else:@block_194 },
   ]
 };
 
 block_194 = {
   instrs: [
+    { op:'jump', to:@block_195 },
+  ]
+};
+
+block_188 = {
+  instrs: [
     { op:'get_local', idx:0 },
-    { op:'has_tag', tag:'string' },
-    { op:'if_true', then:@block_196, else:@block_200 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_189, else:@block_196 },
+  ]
+};
+
+block_195 = {
+  instrs: [
+    { op:'jump', to:@block_197 },
+  ]
+};
+
+block_196 = {
+  instrs: [
+    { op:'jump', to:@block_197 },
   ]
 };
 
 block_199 = {
   instrs: [
-    { op:'jump', to:@block_201 },
+    { op:'get_local', idx:0 },
+    { op:'str_len' },
+    { op:'push', val:1 },
+    { op:'eq_i32' },
+    { op:'if_true', then:@block_200, else:@block_201 },
   ]
 };
 
 block_200 = {
   instrs: [
-    { op:'jump', to:@block_201 },
+    { op:'jump', to:@block_202 },
   ]
 };
 
 block_201 = {
   instrs: [
-    { op:'push', val:$false },
-    { op:'if_true', then:@block_202, else:@block_203 },
+    { op:'push', val:'rt_le' },
+    { op:'abort' },
+    { op:'jump', to:@block_202 },
   ]
 };
 
 block_202 = {
   instrs: [
-    { op:'jump', to:@block_204 },
+    { op:'get_local', idx:1 },
+    { op:'str_len' },
+    { op:'push', val:1 },
+    { op:'eq_i32' },
+    { op:'if_true', then:@block_203, else:@block_204 },
   ]
 };
 
 block_203 = {
   instrs: [
-    { op:'push', val:'unhandled type in the \'in\' operator' },
-    { op:'abort' },
-    { op:'jump', to:@block_204 },
+    { op:'jump', to:@block_205 },
   ]
 };
 
 block_204 = {
+  instrs: [
+    { op:'push', val:'rt_le' },
+    { op:'abort' },
+    { op:'jump', to:@block_205 },
+  ]
+};
+
+block_205 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:0 },
+    { op:'get_char_code' },
+    { op:'get_local', idx:1 },
+    { op:'push', val:0 },
+    { op:'get_char_code' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_le' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_206, num_args:2 },
+  ]
+};
+
+block_206 = {
+  instrs: [
+    { op:'ret' },
+  ]
+};
+
+block_198 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'string' },
+    { op:'if_true', then:@block_199, else:@block_207 },
+  ]
+};
+
+block_207 = {
+  instrs: [
+    { op:'jump', to:@block_208 },
+  ]
+};
+
+block_197 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'string' },
+    { op:'if_true', then:@block_198, else:@block_209 },
+  ]
+};
+
+block_208 = {
+  instrs: [
+    { op:'jump', to:@block_210 },
+  ]
+};
+
+block_209 = {
+  instrs: [
+    { op:'jump', to:@block_210 },
+  ]
+};
+
+block_210 = {
+  instrs: [
+    { op:'push', val:$false },
+    { op:'if_true', then:@block_211, else:@block_212 },
+  ]
+};
+
+block_211 = {
+  instrs: [
+    { op:'jump', to:@block_213 },
+  ]
+};
+
+block_212 = {
+  instrs: [
+    { op:'push', val:'unhandled type in less-than or equal comparison' },
+    { op:'abort' },
+    { op:'jump', to:@block_213 },
+  ]
+};
+
+block_213 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-fun_195 = {
-  entry:@block_194,
+fun_179 = {
+  entry:@block_178,
   num_params:2,
   num_locals:2,
 };
 
-block_205 = {
+block_217 = {
   instrs: [
     { op:'get_local', idx:0 },
-    { op:'has_tag', tag:'object' },
-    { op:'if_true', then:@block_207, else:@block_208 },
-  ]
-};
-
-block_207 = {
-  instrs: [
-    { op:'jump', to:@block_209 },
-  ]
-};
-
-block_208 = {
-  instrs: [
-    { op:'push', val:'instanceof only applies to objects' },
-    { op:'abort' },
-    { op:'jump', to:@block_209 },
-  ]
-};
-
-block_209 = {
-  instrs: [
+    { op:'i32_to_f32' },
     { op:'get_local', idx:1 },
-    { op:'has_tag', tag:'object' },
-    { op:'if_true', then:@block_210, else:@block_211 },
-  ]
-};
-
-block_210 = {
-  instrs: [
-    { op:'jump', to:@block_212 },
-  ]
-};
-
-block_211 = {
-  instrs: [
-    { op:'push', val:'prototype in instanceof must be an object' },
-    { op:'abort' },
-    { op:'jump', to:@block_212 },
-  ]
-};
-
-block_214 = {
-  instrs: [
-    { op:'push', val:$true },
+    { op:'gt_f32' },
     { op:'ret' },
-  ]
-};
-
-block_213 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'proto' },
-    { op:'get_field' },
-    { op:'set_local', idx:2 },
-    { op:'get_local', idx:2 },
-    { op:'get_local', idx:1 },
-    { op:'eq_obj' },
-    { op:'if_true', then:@block_214, else:@block_215 },
-  ]
-};
-
-block_215 = {
-  instrs: [
-    { op:'jump', to:@block_216 },
   ]
 };
 
 block_216 = {
   instrs: [
-    { op:'get_local', idx:2 },
     { op:'get_local', idx:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_instOf' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_217, num_args:2 },
-  ]
-};
-
-block_217 = {
-  instrs: [
-    { op:'ret' },
-  ]
-};
-
-block_212 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'proto' },
-    { op:'has_field' },
-    { op:'if_true', then:@block_213, else:@block_218 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_217, else:@block_218 },
   ]
 };
 
@@ -1588,20 +1582,593 @@ block_218 = {
   ]
 };
 
+block_220 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'gt_i32' },
+    { op:'ret' },
+  ]
+};
+
 block_219 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_220, else:@block_221 },
+  ]
+};
+
+block_221 = {
+  instrs: [
+    { op:'jump', to:@block_222 },
+  ]
+};
+
+block_214 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_216, else:@block_223 },
+  ]
+};
+
+block_222 = {
+  instrs: [
+    { op:'jump', to:@block_224 },
+  ]
+};
+
+block_223 = {
+  instrs: [
+    { op:'jump', to:@block_224 },
+  ]
+};
+
+block_226 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'gt_f32' },
+    { op:'ret' },
+  ]
+};
+
+block_225 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_226, else:@block_227 },
+  ]
+};
+
+block_227 = {
+  instrs: [
+    { op:'jump', to:@block_228 },
+  ]
+};
+
+block_229 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'i32_to_f32' },
+    { op:'gt_f32' },
+    { op:'ret' },
+  ]
+};
+
+block_228 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_229, else:@block_230 },
+  ]
+};
+
+block_230 = {
+  instrs: [
+    { op:'jump', to:@block_231 },
+  ]
+};
+
+block_224 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_225, else:@block_232 },
+  ]
+};
+
+block_231 = {
+  instrs: [
+    { op:'jump', to:@block_233 },
+  ]
+};
+
+block_232 = {
+  instrs: [
+    { op:'jump', to:@block_233 },
+  ]
+};
+
+block_233 = {
+  instrs: [
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+fun_215 = {
+  entry:@block_214,
+  num_params:2,
+  num_locals:2,
+};
+
+block_237 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'i32_to_f32' },
+    { op:'get_local', idx:1 },
+    { op:'ge_f32' },
+    { op:'ret' },
+  ]
+};
+
+block_236 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_237, else:@block_238 },
+  ]
+};
+
+block_238 = {
+  instrs: [
+    { op:'jump', to:@block_239 },
+  ]
+};
+
+block_240 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'ge_i32' },
+    { op:'ret' },
+  ]
+};
+
+block_239 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_240, else:@block_241 },
+  ]
+};
+
+block_241 = {
+  instrs: [
+    { op:'jump', to:@block_242 },
+  ]
+};
+
+block_234 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_236, else:@block_243 },
+  ]
+};
+
+block_242 = {
+  instrs: [
+    { op:'jump', to:@block_244 },
+  ]
+};
+
+block_243 = {
+  instrs: [
+    { op:'jump', to:@block_244 },
+  ]
+};
+
+block_246 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'ge_f32' },
+    { op:'ret' },
+  ]
+};
+
+block_245 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_246, else:@block_247 },
+  ]
+};
+
+block_247 = {
+  instrs: [
+    { op:'jump', to:@block_248 },
+  ]
+};
+
+block_249 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'i32_to_f32' },
+    { op:'ge_f32' },
+    { op:'ret' },
+  ]
+};
+
+block_248 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_249, else:@block_250 },
+  ]
+};
+
+block_250 = {
+  instrs: [
+    { op:'jump', to:@block_251 },
+  ]
+};
+
+block_244 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_245, else:@block_252 },
+  ]
+};
+
+block_251 = {
+  instrs: [
+    { op:'jump', to:@block_253 },
+  ]
+};
+
+block_252 = {
+  instrs: [
+    { op:'jump', to:@block_253 },
+  ]
+};
+
+block_255 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'str_len' },
+    { op:'push', val:1 },
+    { op:'eq_i32' },
+    { op:'if_true', then:@block_256, else:@block_257 },
+  ]
+};
+
+block_256 = {
+  instrs: [
+    { op:'jump', to:@block_258 },
+  ]
+};
+
+block_257 = {
+  instrs: [
+    { op:'push', val:'rt_ge' },
+    { op:'abort' },
+    { op:'jump', to:@block_258 },
+  ]
+};
+
+block_258 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'str_len' },
+    { op:'push', val:1 },
+    { op:'eq_i32' },
+    { op:'if_true', then:@block_259, else:@block_260 },
+  ]
+};
+
+block_259 = {
+  instrs: [
+    { op:'jump', to:@block_261 },
+  ]
+};
+
+block_260 = {
+  instrs: [
+    { op:'push', val:'rt_ge' },
+    { op:'abort' },
+    { op:'jump', to:@block_261 },
+  ]
+};
+
+block_261 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:0 },
+    { op:'get_char_code' },
+    { op:'get_local', idx:1 },
+    { op:'push', val:0 },
+    { op:'get_char_code' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_ge' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_262, num_args:2 },
+  ]
+};
+
+block_262 = {
+  instrs: [
+    { op:'ret' },
+  ]
+};
+
+block_254 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'string' },
+    { op:'if_true', then:@block_255, else:@block_263 },
+  ]
+};
+
+block_263 = {
+  instrs: [
+    { op:'jump', to:@block_264 },
+  ]
+};
+
+block_253 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'string' },
+    { op:'if_true', then:@block_254, else:@block_265 },
+  ]
+};
+
+block_264 = {
+  instrs: [
+    { op:'jump', to:@block_266 },
+  ]
+};
+
+block_265 = {
+  instrs: [
+    { op:'jump', to:@block_266 },
+  ]
+};
+
+block_266 = {
+  instrs: [
+    { op:'push', val:$false },
+    { op:'if_true', then:@block_267, else:@block_268 },
+  ]
+};
+
+block_267 = {
+  instrs: [
+    { op:'jump', to:@block_269 },
+  ]
+};
+
+block_268 = {
+  instrs: [
+    { op:'push', val:'unhandled type in less-than or equal comparison' },
+    { op:'abort' },
+    { op:'jump', to:@block_269 },
+  ]
+};
+
+block_269 = {
+  instrs: [
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+fun_235 = {
+  entry:@block_234,
+  num_params:2,
+  num_locals:2,
+};
+
+block_273 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'get_local', idx:0 },
+    { op:'has_field' },
+    { op:'ret' },
+  ]
+};
+
+block_272 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'object' },
+    { op:'if_true', then:@block_273, else:@block_274 },
+  ]
+};
+
+block_274 = {
+  instrs: [
+    { op:'jump', to:@block_275 },
+  ]
+};
+
+block_270 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'string' },
+    { op:'if_true', then:@block_272, else:@block_276 },
+  ]
+};
+
+block_275 = {
+  instrs: [
+    { op:'jump', to:@block_277 },
+  ]
+};
+
+block_276 = {
+  instrs: [
+    { op:'jump', to:@block_277 },
+  ]
+};
+
+block_277 = {
+  instrs: [
+    { op:'push', val:$false },
+    { op:'if_true', then:@block_278, else:@block_279 },
+  ]
+};
+
+block_278 = {
+  instrs: [
+    { op:'jump', to:@block_280 },
+  ]
+};
+
+block_279 = {
+  instrs: [
+    { op:'push', val:'unhandled type in the \'in\' operator' },
+    { op:'abort' },
+    { op:'jump', to:@block_280 },
+  ]
+};
+
+block_280 = {
+  instrs: [
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+fun_271 = {
+  entry:@block_270,
+  num_params:2,
+  num_locals:2,
+};
+
+block_281 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'object' },
+    { op:'if_true', then:@block_283, else:@block_284 },
+  ]
+};
+
+block_283 = {
+  instrs: [
+    { op:'jump', to:@block_285 },
+  ]
+};
+
+block_284 = {
+  instrs: [
+    { op:'push', val:'instanceof only applies to objects' },
+    { op:'abort' },
+    { op:'jump', to:@block_285 },
+  ]
+};
+
+block_285 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'has_tag', tag:'object' },
+    { op:'if_true', then:@block_286, else:@block_287 },
+  ]
+};
+
+block_286 = {
+  instrs: [
+    { op:'jump', to:@block_288 },
+  ]
+};
+
+block_287 = {
+  instrs: [
+    { op:'push', val:'prototype in instanceof must be an object' },
+    { op:'abort' },
+    { op:'jump', to:@block_288 },
+  ]
+};
+
+block_290 = {
+  instrs: [
+    { op:'push', val:$true },
+    { op:'ret' },
+  ]
+};
+
+block_289 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:'proto' },
+    { op:'get_field' },
+    { op:'set_local', idx:2 },
+    { op:'get_local', idx:2 },
+    { op:'get_local', idx:1 },
+    { op:'eq_obj' },
+    { op:'if_true', then:@block_290, else:@block_291 },
+  ]
+};
+
+block_291 = {
+  instrs: [
+    { op:'jump', to:@block_292 },
+  ]
+};
+
+block_292 = {
+  instrs: [
+    { op:'get_local', idx:2 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_instOf' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_293, num_args:2 },
+  ]
+};
+
+block_293 = {
+  instrs: [
+    { op:'ret' },
+  ]
+};
+
+block_288 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:'proto' },
+    { op:'has_field' },
+    { op:'if_true', then:@block_289, else:@block_294 },
+  ]
+};
+
+block_294 = {
+  instrs: [
+    { op:'jump', to:@block_295 },
+  ]
+};
+
+block_295 = {
   instrs: [
     { op:'push', val:$false },
     { op:'ret' },
   ]
 };
 
-fun_206 = {
-  entry:@block_205,
+fun_282 = {
+  entry:@block_281,
   num_params:2,
   num_locals:3,
 };
 
-block_223 = {
+block_299 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
@@ -1610,22 +2177,22 @@ block_223 = {
   ]
 };
 
-block_222 = {
+block_298 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
     { op:'has_field' },
-    { op:'if_true', then:@block_223, else:@block_224 },
+    { op:'if_true', then:@block_299, else:@block_300 },
   ]
 };
 
-block_224 = {
+block_300 = {
   instrs: [
-    { op:'jump', to:@block_225 },
+    { op:'jump', to:@block_301 },
   ]
 };
 
-block_226 = {
+block_302 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'proto' },
@@ -1636,104 +2203,104 @@ block_226 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_227, num_args:2 },
+    { op:'call', ret_to:@block_303, num_args:2 },
   ]
 };
 
-block_227 = {
+block_303 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-block_225 = {
+block_301 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'proto' },
     { op:'has_field' },
-    { op:'if_true', then:@block_226, else:@block_228 },
+    { op:'if_true', then:@block_302, else:@block_304 },
   ]
 };
 
-block_228 = {
+block_304 = {
   instrs: [
-    { op:'jump', to:@block_229 },
+    { op:'jump', to:@block_305 },
   ]
 };
 
-block_231 = {
+block_307 = {
   instrs: [
     { op:'push', val:'undefined property \"' },
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_add' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_232, num_args:2 },
+    { op:'call', ret_to:@block_308, num_args:2 },
   ]
 };
 
-block_232 = {
+block_308 = {
   instrs: [
     { op:'push', val:'\"' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_add' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_233, num_args:2 },
+    { op:'call', ret_to:@block_309, num_args:2 },
   ]
 };
 
-block_229 = {
+block_305 = {
   instrs: [
     { op:'push', val:$false },
-    { op:'if_true', then:@block_230, else:@block_231 },
+    { op:'if_true', then:@block_306, else:@block_307 },
   ]
 };
 
-block_230 = {
+block_306 = {
   instrs: [
-    { op:'jump', to:@block_234 },
+    { op:'jump', to:@block_310 },
   ]
 };
 
-block_233 = {
+block_309 = {
   instrs: [
     { op:'abort' },
-    { op:'jump', to:@block_234 },
+    { op:'jump', to:@block_310 },
   ]
 };
 
-block_220 = {
+block_296 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'has_tag', tag:'object' },
-    { op:'if_true', then:@block_222, else:@block_235 },
+    { op:'if_true', then:@block_298, else:@block_311 },
   ]
 };
 
-block_234 = {
+block_310 = {
   instrs: [
-    { op:'jump', to:@block_236 },
+    { op:'jump', to:@block_312 },
   ]
 };
 
-block_235 = {
+block_311 = {
   instrs: [
-    { op:'jump', to:@block_236 },
+    { op:'jump', to:@block_312 },
   ]
 };
 
-block_237 = {
+block_313 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_238, num_args:2 },
+    { op:'call', ret_to:@block_314, num_args:2 },
   ]
 };
 
-block_239 = {
+block_315 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'array_len' },
@@ -1741,30 +2308,30 @@ block_239 = {
   ]
 };
 
-block_238 = {
+block_314 = {
   instrs: [
-    { op:'if_true', then:@block_239, else:@block_240 },
+    { op:'if_true', then:@block_315, else:@block_316 },
   ]
 };
 
-block_240 = {
+block_316 = {
   instrs: [
-    { op:'jump', to:@block_241 },
+    { op:'jump', to:@block_317 },
   ]
 };
 
-block_241 = {
+block_317 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'push' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_242, num_args:2 },
+    { op:'call', ret_to:@block_318, num_args:2 },
   ]
 };
 
-block_243 = {
+block_319 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_push' },
@@ -1773,50 +2340,50 @@ block_243 = {
   ]
 };
 
-block_242 = {
+block_318 = {
   instrs: [
-    { op:'if_true', then:@block_243, else:@block_244 },
+    { op:'if_true', then:@block_319, else:@block_320 },
   ]
 };
 
-block_244 = {
+block_320 = {
   instrs: [
-    { op:'jump', to:@block_245 },
+    { op:'jump', to:@block_321 },
   ]
 };
 
-block_236 = {
+block_312 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'has_tag', tag:'array' },
-    { op:'if_true', then:@block_237, else:@block_246 },
+    { op:'if_true', then:@block_313, else:@block_322 },
   ]
 };
 
-block_245 = {
+block_321 = {
   instrs: [
-    { op:'jump', to:@block_247 },
+    { op:'jump', to:@block_323 },
   ]
 };
 
-block_246 = {
+block_322 = {
   instrs: [
-    { op:'jump', to:@block_247 },
+    { op:'jump', to:@block_323 },
   ]
 };
 
-block_248 = {
+block_324 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_249, num_args:2 },
+    { op:'call', ret_to:@block_325, num_args:2 },
   ]
 };
 
-block_250 = {
+block_326 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'str_len' },
@@ -1824,93 +2391,93 @@ block_250 = {
   ]
 };
 
-block_249 = {
+block_325 = {
   instrs: [
-    { op:'if_true', then:@block_250, else:@block_251 },
+    { op:'if_true', then:@block_326, else:@block_327 },
   ]
 };
 
-block_251 = {
+block_327 = {
   instrs: [
-    { op:'jump', to:@block_252 },
+    { op:'jump', to:@block_328 },
   ]
 };
 
-block_247 = {
+block_323 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'has_tag', tag:'string' },
-    { op:'if_true', then:@block_248, else:@block_253 },
+    { op:'if_true', then:@block_324, else:@block_329 },
   ]
 };
 
-block_252 = {
+block_328 = {
   instrs: [
-    { op:'jump', to:@block_254 },
+    { op:'jump', to:@block_330 },
   ]
 };
 
-block_253 = {
+block_329 = {
   instrs: [
-    { op:'jump', to:@block_254 },
+    { op:'jump', to:@block_330 },
   ]
 };
 
-block_256 = {
+block_332 = {
   instrs: [
     { op:'push', val:'unhandled base type in read of property \"' },
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_add' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_257, num_args:2 },
+    { op:'call', ret_to:@block_333, num_args:2 },
   ]
 };
 
-block_257 = {
+block_333 = {
   instrs: [
     { op:'push', val:'\"' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_add' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_258, num_args:2 },
+    { op:'call', ret_to:@block_334, num_args:2 },
   ]
 };
 
-block_254 = {
+block_330 = {
   instrs: [
     { op:'push', val:$false },
-    { op:'if_true', then:@block_255, else:@block_256 },
+    { op:'if_true', then:@block_331, else:@block_332 },
   ]
 };
 
-block_255 = {
+block_331 = {
   instrs: [
-    { op:'jump', to:@block_259 },
+    { op:'jump', to:@block_335 },
   ]
 };
 
-block_258 = {
+block_334 = {
   instrs: [
     { op:'abort' },
-    { op:'jump', to:@block_259 },
+    { op:'jump', to:@block_335 },
   ]
 };
 
-block_259 = {
+block_335 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-fun_221 = {
-  entry:@block_220,
+fun_297 = {
+  entry:@block_296,
   num_params:2,
   num_locals:3,
 };
 
-block_262 = {
+block_338 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
@@ -1919,21 +2486,21 @@ block_262 = {
   ]
 };
 
-block_260 = {
+block_336 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'has_tag', tag:'array' },
-    { op:'if_true', then:@block_262, else:@block_263 },
+    { op:'if_true', then:@block_338, else:@block_339 },
   ]
 };
 
-block_263 = {
+block_339 = {
   instrs: [
-    { op:'jump', to:@block_264 },
+    { op:'jump', to:@block_340 },
   ]
 };
 
-block_265 = {
+block_341 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
@@ -1942,55 +2509,55 @@ block_265 = {
   ]
 };
 
-block_264 = {
+block_340 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'has_tag', tag:'string' },
-    { op:'if_true', then:@block_265, else:@block_266 },
+    { op:'if_true', then:@block_341, else:@block_342 },
   ]
 };
 
-block_266 = {
+block_342 = {
   instrs: [
-    { op:'jump', to:@block_267 },
+    { op:'jump', to:@block_343 },
   ]
 };
 
-block_267 = {
+block_343 = {
   instrs: [
     { op:'push', val:$false },
-    { op:'if_true', then:@block_268, else:@block_269 },
+    { op:'if_true', then:@block_344, else:@block_345 },
   ]
 };
 
-block_268 = {
+block_344 = {
   instrs: [
-    { op:'jump', to:@block_270 },
+    { op:'jump', to:@block_346 },
   ]
 };
 
-block_269 = {
+block_345 = {
   instrs: [
     { op:'push', val:'unhandled type in getElem' },
     { op:'abort' },
-    { op:'jump', to:@block_270 },
+    { op:'jump', to:@block_346 },
   ]
 };
 
-block_270 = {
+block_346 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-fun_261 = {
-  entry:@block_260,
+fun_337 = {
+  entry:@block_336,
   num_params:2,
   num_locals:2,
 };
 
-block_271 = {
+block_347 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
@@ -2000,13 +2567,13 @@ block_271 = {
   ]
 };
 
-fun_272 = {
-  entry:@block_271,
+fun_348 = {
+  entry:@block_347,
   num_params:2,
   num_locals:2,
 };
 
-block_275 = {
+block_351 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
@@ -2016,17 +2583,17 @@ block_275 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_276, num_args:2 },
+    { op:'call', ret_to:@block_352, num_args:2 },
   ]
 };
 
-block_276 = {
+block_352 = {
   instrs: [
-    { op:'call', ret_to:@block_277, num_args:1 },
+    { op:'call', ret_to:@block_353, num_args:1 },
   ]
 };
 
-block_277 = {
+block_353 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -2034,21 +2601,21 @@ block_277 = {
   ]
 };
 
-block_273 = {
+block_349 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'has_tag', tag:'string' },
-    { op:'if_true', then:@block_275, else:@block_278 },
+    { op:'if_true', then:@block_351, else:@block_354 },
   ]
 };
 
-block_278 = {
+block_354 = {
   instrs: [
-    { op:'jump', to:@block_279 },
+    { op:'jump', to:@block_355 },
   ]
 };
 
-block_280 = {
+block_356 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
@@ -2058,17 +2625,17 @@ block_280 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_281, num_args:2 },
+    { op:'call', ret_to:@block_357, num_args:2 },
   ]
 };
 
-block_281 = {
+block_357 = {
   instrs: [
-    { op:'call', ret_to:@block_282, num_args:1 },
+    { op:'call', ret_to:@block_358, num_args:1 },
   ]
 };
 
-block_282 = {
+block_358 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -2076,21 +2643,21 @@ block_282 = {
   ]
 };
 
-block_279 = {
+block_355 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'has_tag', tag:'int32' },
-    { op:'if_true', then:@block_280, else:@block_283 },
+    { op:'if_true', then:@block_356, else:@block_359 },
   ]
 };
 
-block_283 = {
+block_359 = {
   instrs: [
-    { op:'jump', to:@block_284 },
+    { op:'jump', to:@block_360 },
   ]
 };
 
-block_285 = {
+block_361 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
@@ -2100,17 +2667,17 @@ block_285 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_286, num_args:2 },
+    { op:'call', ret_to:@block_362, num_args:2 },
   ]
 };
 
-block_286 = {
+block_362 = {
   instrs: [
-    { op:'call', ret_to:@block_287, num_args:1 },
+    { op:'call', ret_to:@block_363, num_args:1 },
   ]
 };
 
-block_287 = {
+block_363 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -2118,42 +2685,42 @@ block_287 = {
   ]
 };
 
-block_284 = {
+block_360 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'has_tag', tag:'float32' },
-    { op:'if_true', then:@block_285, else:@block_288 },
+    { op:'if_true', then:@block_361, else:@block_364 },
   ]
 };
 
-block_288 = {
+block_364 = {
   instrs: [
-    { op:'jump', to:@block_289 },
+    { op:'jump', to:@block_365 },
   ]
 };
 
-block_289 = {
+block_365 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:$true },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_290, num_args:2 },
+    { op:'call', ret_to:@block_366, num_args:2 },
   ]
 };
 
-block_291 = {
+block_367 = {
   instrs: [
     { op:'push', val:'true' },
     { op:'push', val:@global_obj },
     { op:'push', val:'output' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_292, num_args:1 },
+    { op:'call', ret_to:@block_368, num_args:1 },
   ]
 };
 
-block_292 = {
+block_368 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -2161,40 +2728,40 @@ block_292 = {
   ]
 };
 
-block_290 = {
+block_366 = {
   instrs: [
-    { op:'if_true', then:@block_291, else:@block_293 },
+    { op:'if_true', then:@block_367, else:@block_369 },
   ]
 };
 
-block_293 = {
+block_369 = {
   instrs: [
-    { op:'jump', to:@block_294 },
+    { op:'jump', to:@block_370 },
   ]
 };
 
-block_294 = {
+block_370 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:$false },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_295, num_args:2 },
+    { op:'call', ret_to:@block_371, num_args:2 },
   ]
 };
 
-block_296 = {
+block_372 = {
   instrs: [
     { op:'push', val:'false' },
     { op:'push', val:@global_obj },
     { op:'push', val:'output' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_297, num_args:1 },
+    { op:'call', ret_to:@block_373, num_args:1 },
   ]
 };
 
-block_297 = {
+block_373 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -2202,74 +2769,232 @@ block_297 = {
   ]
 };
 
-block_295 = {
+block_371 = {
   instrs: [
-    { op:'if_true', then:@block_296, else:@block_298 },
+    { op:'if_true', then:@block_372, else:@block_374 },
   ]
 };
 
-block_298 = {
+block_374 = {
   instrs: [
-    { op:'jump', to:@block_299 },
+    { op:'jump', to:@block_375 },
   ]
 };
 
-block_299 = {
+block_375 = {
   instrs: [
     { op:'push', val:$false },
-    { op:'if_true', then:@block_300, else:@block_301 },
+    { op:'if_true', then:@block_376, else:@block_377 },
   ]
 };
 
-block_300 = {
+block_376 = {
   instrs: [
-    { op:'jump', to:@block_302 },
+    { op:'jump', to:@block_378 },
   ]
 };
 
-block_301 = {
+block_377 = {
   instrs: [
     { op:'push', val:'unhandled type in output function' },
     { op:'abort' },
-    { op:'jump', to:@block_302 },
+    { op:'jump', to:@block_378 },
   ]
 };
 
-block_302 = {
+block_378 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-fun_274 = {
-  entry:@block_273,
+fun_350 = {
+  entry:@block_349,
   num_params:1,
   num_locals:1,
 };
 
-block_303 = {
+block_381 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'i32_to_f32' },
+    { op:'sin_f32' },
+    { op:'ret' },
+  ]
+};
+
+block_379 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_381, else:@block_382 },
+  ]
+};
+
+block_382 = {
+  instrs: [
+    { op:'jump', to:@block_383 },
+  ]
+};
+
+block_384 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'sin_f32' },
+    { op:'ret' },
+  ]
+};
+
+block_383 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_384, else:@block_385 },
+  ]
+};
+
+block_385 = {
+  instrs: [
+    { op:'jump', to:@block_386 },
+  ]
+};
+
+block_386 = {
+  instrs: [
+    { op:'push', val:$false },
+    { op:'if_true', then:@block_387, else:@block_388 },
+  ]
+};
+
+block_387 = {
+  instrs: [
+    { op:'jump', to:@block_389 },
+  ]
+};
+
+block_388 = {
+  instrs: [
+    { op:'push', val:'unhandled type in sin function' },
+    { op:'abort' },
+    { op:'jump', to:@block_389 },
+  ]
+};
+
+block_389 = {
+  instrs: [
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+fun_380 = {
+  entry:@block_379,
+  num_params:1,
+  num_locals:1,
+};
+
+block_392 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'i32_to_f32' },
+    { op:'sqrt_f32' },
+    { op:'ret' },
+  ]
+};
+
+block_390 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'int32' },
+    { op:'if_true', then:@block_392, else:@block_393 },
+  ]
+};
+
+block_393 = {
+  instrs: [
+    { op:'jump', to:@block_394 },
+  ]
+};
+
+block_395 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'sqrt_f32' },
+    { op:'ret' },
+  ]
+};
+
+block_394 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'has_tag', tag:'float32' },
+    { op:'if_true', then:@block_395, else:@block_396 },
+  ]
+};
+
+block_396 = {
+  instrs: [
+    { op:'jump', to:@block_397 },
+  ]
+};
+
+block_397 = {
+  instrs: [
+    { op:'push', val:$false },
+    { op:'if_true', then:@block_398, else:@block_399 },
+  ]
+};
+
+block_398 = {
+  instrs: [
+    { op:'jump', to:@block_400 },
+  ]
+};
+
+block_399 = {
+  instrs: [
+    { op:'push', val:'unhandled type in sin function' },
+    { op:'abort' },
+    { op:'jump', to:@block_400 },
+  ]
+};
+
+block_400 = {
+  instrs: [
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+fun_391 = {
+  entry:@block_390,
+  num_params:1,
+  num_locals:1,
+};
+
+block_401 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'output' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_305, num_args:1 },
+    { op:'call', ret_to:@block_403, num_args:1 },
   ]
 };
 
-block_305 = {
+block_403 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'\x0A' },
     { op:'push', val:@global_obj },
     { op:'push', val:'output' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_306, num_args:1 },
+    { op:'call', ret_to:@block_404, num_args:1 },
   ]
 };
 
-block_306 = {
+block_404 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -2277,13 +3002,13 @@ block_306 = {
   ]
 };
 
-fun_304 = {
-  entry:@block_303,
+fun_402 = {
+  entry:@block_401,
   num_params:1,
   num_locals:1,
 };
 
-block_307 = {
+block_405 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
@@ -2293,24 +3018,24 @@ block_307 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_309, num_args:2 },
+    { op:'call', ret_to:@block_407, num_args:2 },
   ]
 };
 
-block_309 = {
+block_407 = {
   instrs: [
-    { op:'call', ret_to:@block_310, num_args:1 },
+    { op:'call', ret_to:@block_408, num_args:1 },
   ]
 };
 
-block_310 = {
+block_408 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-fun_308 = {
-  entry:@block_307,
+fun_406 = {
+  entry:@block_405,
   num_params:1,
   num_locals:1,
 };
@@ -2343,35 +3068,43 @@ block_0 = {
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_ne' },
-    { op:'push', val:@fun_141 },
+    { op:'push', val:@fun_153 },
+    { op:'set_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_lt' },
+    { op:'push', val:@fun_159 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_le' },
-    { op:'push', val:@fun_147 },
+    { op:'push', val:@fun_179 },
+    { op:'set_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_gt' },
+    { op:'push', val:@fun_215 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_ge' },
-    { op:'push', val:@fun_171 },
+    { op:'push', val:@fun_235 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_in' },
-    { op:'push', val:@fun_195 },
+    { op:'push', val:@fun_271 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
-    { op:'push', val:@fun_206 },
+    { op:'push', val:@fun_282 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
-    { op:'push', val:@fun_221 },
+    { op:'push', val:@fun_297 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getElem' },
-    { op:'push', val:@fun_261 },
+    { op:'push', val:@fun_337 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_push' },
-    { op:'push', val:@fun_272 },
+    { op:'push', val:@fun_348 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'io' },
@@ -2380,15 +3113,23 @@ block_0 = {
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'output' },
-    { op:'push', val:@fun_274 },
+    { op:'push', val:@fun_350 },
+    { op:'set_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'sin' },
+    { op:'push', val:@fun_380 },
+    { op:'set_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'sqrt' },
+    { op:'push', val:@fun_391 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'print' },
-    { op:'push', val:@fun_304 },
+    { op:'push', val:@fun_402 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'readFile' },
-    { op:'push', val:@fun_308 },
+    { op:'push', val:@fun_406 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'OpInfo' },
@@ -2413,11 +3154,11 @@ block_0 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_sub' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_311, num_args:2 },
+    { op:'call', ret_to:@block_409, num_args:2 },
   ]
 };
 
-block_312 = {
+block_410 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'opList' },
@@ -2428,17 +3169,17 @@ block_312 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_314, num_args:2 },
+    { op:'call', ret_to:@block_412, num_args:2 },
   ]
 };
 
-block_314 = {
+block_412 = {
   instrs: [
-    { op:'call', ret_to:@block_315, num_args:2 },
+    { op:'call', ret_to:@block_413, num_args:2 },
   ]
 };
 
-block_315 = {
+block_413 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -2446,13 +3187,13 @@ block_315 = {
   ]
 };
 
-fun_313 = {
-  entry:@block_312,
+fun_411 = {
+  entry:@block_410,
   num_params:1,
   num_locals:1,
 };
 
-block_311 = {
+block_409 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:0 },
@@ -2475,7 +3216,7 @@ block_311 = {
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
-    { op:'push', val:@fun_313 },
+    { op:'push', val:@fun_411 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'OP_MEMBER' },
@@ -2502,11 +3243,11 @@ block_311 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_316, num_args:1 },
+    { op:'call', ret_to:@block_414, num_args:1 },
   ]
 };
 
-block_316 = {
+block_414 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -2538,11 +3279,11 @@ block_316 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_317, num_args:1 },
+    { op:'call', ret_to:@block_415, num_args:1 },
   ]
 };
 
-block_317 = {
+block_415 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -2570,11 +3311,11 @@ block_317 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_318, num_args:1 },
+    { op:'call', ret_to:@block_416, num_args:1 },
   ]
 };
 
-block_318 = {
+block_416 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -2606,11 +3347,11 @@ block_318 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_319, num_args:1 },
+    { op:'call', ret_to:@block_417, num_args:1 },
   ]
 };
 
-block_319 = {
+block_417 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -2638,11 +3379,11 @@ block_319 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_320, num_args:1 },
+    { op:'call', ret_to:@block_418, num_args:1 },
   ]
 };
 
-block_320 = {
+block_418 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -2674,11 +3415,11 @@ block_320 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_321, num_args:1 },
+    { op:'call', ret_to:@block_419, num_args:1 },
   ]
 };
 
-block_321 = {
+block_419 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -2710,11 +3451,11 @@ block_321 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_322, num_args:1 },
+    { op:'call', ret_to:@block_420, num_args:1 },
   ]
 };
 
-block_322 = {
+block_420 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -2746,11 +3487,11 @@ block_322 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_323, num_args:1 },
+    { op:'call', ret_to:@block_421, num_args:1 },
   ]
 };
 
-block_323 = {
+block_421 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -2778,11 +3519,11 @@ block_323 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_324, num_args:1 },
+    { op:'call', ret_to:@block_422, num_args:1 },
   ]
 };
 
-block_324 = {
+block_422 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -2810,11 +3551,11 @@ block_324 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_325, num_args:1 },
+    { op:'call', ret_to:@block_423, num_args:1 },
   ]
 };
 
-block_325 = {
+block_423 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -2842,11 +3583,11 @@ block_325 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_326, num_args:1 },
+    { op:'call', ret_to:@block_424, num_args:1 },
   ]
 };
 
-block_326 = {
+block_424 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -2870,11 +3611,11 @@ block_326 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_327, num_args:1 },
+    { op:'call', ret_to:@block_425, num_args:1 },
   ]
 };
 
-block_327 = {
+block_425 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -2898,11 +3639,11 @@ block_327 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_328, num_args:1 },
+    { op:'call', ret_to:@block_426, num_args:1 },
   ]
 };
 
-block_328 = {
+block_426 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -2926,11 +3667,11 @@ block_328 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_329, num_args:1 },
+    { op:'call', ret_to:@block_427, num_args:1 },
   ]
 };
 
-block_329 = {
+block_427 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -2954,11 +3695,11 @@ block_329 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_330, num_args:1 },
+    { op:'call', ret_to:@block_428, num_args:1 },
   ]
 };
 
-block_330 = {
+block_428 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -2982,11 +3723,11 @@ block_330 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_331, num_args:1 },
+    { op:'call', ret_to:@block_429, num_args:1 },
   ]
 };
 
-block_331 = {
+block_429 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -3010,11 +3751,11 @@ block_331 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_332, num_args:1 },
+    { op:'call', ret_to:@block_430, num_args:1 },
   ]
 };
 
-block_332 = {
+block_430 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -3038,11 +3779,11 @@ block_332 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_333, num_args:1 },
+    { op:'call', ret_to:@block_431, num_args:1 },
   ]
 };
 
-block_333 = {
+block_431 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -3070,11 +3811,11 @@ block_333 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_334, num_args:1 },
+    { op:'call', ret_to:@block_432, num_args:1 },
   ]
 };
 
-block_334 = {
+block_432 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -3102,11 +3843,11 @@ block_334 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_335, num_args:1 },
+    { op:'call', ret_to:@block_433, num_args:1 },
   ]
 };
 
-block_335 = {
+block_433 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -3138,53 +3879,53 @@ block_335 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'addOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_336, num_args:1 },
+    { op:'call', ret_to:@block_434, num_args:1 },
   ]
 };
 
-block_337 = {
+block_435 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:$false },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_ne' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_339, num_args:2 },
+    { op:'call', ret_to:@block_437, num_args:2 },
   ]
 };
 
-block_340 = {
+block_438 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'srcName' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_341, num_args:2 },
+    { op:'call', ret_to:@block_439, num_args:2 },
   ]
 };
 
-block_341 = {
+block_439 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'output' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_342, num_args:1 },
+    { op:'call', ret_to:@block_440, num_args:1 },
   ]
 };
 
-block_342 = {
+block_440 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:'@' },
     { op:'push', val:@global_obj },
     { op:'push', val:'output' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_343, num_args:1 },
+    { op:'call', ret_to:@block_441, num_args:1 },
   ]
 };
 
-block_343 = {
+block_441 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -3192,31 +3933,31 @@ block_343 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_344, num_args:2 },
+    { op:'call', ret_to:@block_442, num_args:2 },
   ]
 };
 
-block_344 = {
+block_442 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'output' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_345, num_args:1 },
+    { op:'call', ret_to:@block_443, num_args:1 },
   ]
 };
 
-block_345 = {
+block_443 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:':' },
     { op:'push', val:@global_obj },
     { op:'push', val:'output' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_346, num_args:1 },
+    { op:'call', ret_to:@block_444, num_args:1 },
   ]
 };
 
-block_346 = {
+block_444 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -3224,113 +3965,113 @@ block_346 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_347, num_args:2 },
+    { op:'call', ret_to:@block_445, num_args:2 },
   ]
 };
 
-block_347 = {
+block_445 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'output' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_348, num_args:1 },
+    { op:'call', ret_to:@block_446, num_args:1 },
   ]
 };
 
-block_348 = {
+block_446 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:' - ' },
     { op:'push', val:@global_obj },
     { op:'push', val:'output' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_349, num_args:1 },
+    { op:'call', ret_to:@block_447, num_args:1 },
   ]
 };
 
-block_339 = {
+block_437 = {
   instrs: [
-    { op:'if_true', then:@block_340, else:@block_350 },
+    { op:'if_true', then:@block_438, else:@block_448 },
   ]
 };
 
-block_349 = {
+block_447 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_351 },
+    { op:'jump', to:@block_449 },
   ]
 };
 
-block_350 = {
+block_448 = {
   instrs: [
-    { op:'jump', to:@block_351 },
+    { op:'jump', to:@block_449 },
   ]
 };
 
-block_351 = {
+block_449 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'print' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_352, num_args:1 },
+    { op:'call', ret_to:@block_450, num_args:1 },
   ]
 };
 
-block_352 = {
+block_450 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$false },
-    { op:'if_true', then:@block_353, else:@block_354 },
+    { op:'if_true', then:@block_451, else:@block_452 },
   ]
 };
 
-block_353 = {
+block_451 = {
   instrs: [
-    { op:'jump', to:@block_355 },
+    { op:'jump', to:@block_453 },
   ]
 };
 
-block_354 = {
+block_452 = {
   instrs: [
     { op:'push', val:'assertion failed' },
     { op:'abort' },
-    { op:'jump', to:@block_355 },
+    { op:'jump', to:@block_453 },
   ]
 };
 
-block_355 = {
+block_453 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-fun_338 = {
-  entry:@block_337,
+fun_436 = {
+  entry:@block_435,
   num_params:2,
   num_locals:2,
 };
 
-block_356 = {
+block_454 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:' ' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_362, num_args:2 },
+    { op:'call', ret_to:@block_460, num_args:2 },
   ]
 };
 
-block_362 = {
+block_460 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_361, else:@block_360 },
+    { op:'if_true', then:@block_459, else:@block_458 },
   ]
 };
 
-block_360 = {
+block_458 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -3338,24 +4079,24 @@ block_360 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_363, num_args:2 },
+    { op:'call', ret_to:@block_461, num_args:2 },
   ]
 };
 
-block_363 = {
+block_461 = {
   instrs: [
-    { op:'jump', to:@block_361 },
+    { op:'jump', to:@block_459 },
   ]
 };
 
-block_361 = {
+block_459 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_359, else:@block_358 },
+    { op:'if_true', then:@block_457, else:@block_456 },
   ]
 };
 
-block_358 = {
+block_456 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -3363,47 +4104,47 @@ block_358 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_364, num_args:2 },
+    { op:'call', ret_to:@block_462, num_args:2 },
   ]
 };
 
-block_364 = {
+block_462 = {
   instrs: [
-    { op:'jump', to:@block_359 },
+    { op:'jump', to:@block_457 },
   ]
 };
 
-block_359 = {
+block_457 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-fun_357 = {
-  entry:@block_356,
+fun_455 = {
+  entry:@block_454,
   num_params:1,
   num_locals:1,
 };
 
-block_365 = {
+block_463 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'0' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_ge' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_369, num_args:2 },
+    { op:'call', ret_to:@block_467, num_args:2 },
   ]
 };
 
-block_369 = {
+block_467 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_367, else:@block_368 },
+    { op:'if_true', then:@block_465, else:@block_466 },
   ]
 };
 
-block_367 = {
+block_465 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -3411,47 +4152,47 @@ block_367 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_le' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_370, num_args:2 },
+    { op:'call', ret_to:@block_468, num_args:2 },
   ]
 };
 
-block_370 = {
+block_468 = {
   instrs: [
-    { op:'jump', to:@block_368 },
+    { op:'jump', to:@block_466 },
   ]
 };
 
-block_368 = {
+block_466 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-fun_366 = {
-  entry:@block_365,
+fun_464 = {
+  entry:@block_463,
   num_params:1,
   num_locals:1,
 };
 
-block_371 = {
+block_469 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'a' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_ge' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_377, num_args:2 },
+    { op:'call', ret_to:@block_475, num_args:2 },
   ]
 };
 
-block_377 = {
+block_475 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_375, else:@block_376 },
+    { op:'if_true', then:@block_473, else:@block_474 },
   ]
 };
 
-block_375 = {
+block_473 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -3459,24 +4200,24 @@ block_375 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_le' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_378, num_args:2 },
+    { op:'call', ret_to:@block_476, num_args:2 },
   ]
 };
 
-block_378 = {
+block_476 = {
   instrs: [
-    { op:'jump', to:@block_376 },
+    { op:'jump', to:@block_474 },
   ]
 };
 
-block_376 = {
+block_474 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_374, else:@block_373 },
+    { op:'if_true', then:@block_472, else:@block_471 },
   ]
 };
 
-block_373 = {
+block_471 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -3484,18 +4225,18 @@ block_373 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_ge' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_381, num_args:2 },
+    { op:'call', ret_to:@block_479, num_args:2 },
   ]
 };
 
-block_381 = {
+block_479 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_379, else:@block_380 },
+    { op:'if_true', then:@block_477, else:@block_478 },
   ]
 };
 
-block_379 = {
+block_477 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -3503,53 +4244,53 @@ block_379 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_le' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_382, num_args:2 },
+    { op:'call', ret_to:@block_480, num_args:2 },
   ]
 };
 
-block_382 = {
+block_480 = {
   instrs: [
-    { op:'jump', to:@block_380 },
+    { op:'jump', to:@block_478 },
   ]
 };
 
-block_380 = {
+block_478 = {
   instrs: [
-    { op:'jump', to:@block_374 },
+    { op:'jump', to:@block_472 },
   ]
 };
 
-block_374 = {
+block_472 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-fun_372 = {
-  entry:@block_371,
+fun_470 = {
+  entry:@block_469,
   num_params:1,
   num_locals:1,
 };
 
-block_383 = {
+block_481 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'a' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_ge' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_391, num_args:2 },
+    { op:'call', ret_to:@block_489, num_args:2 },
   ]
 };
 
-block_391 = {
+block_489 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_389, else:@block_390 },
+    { op:'if_true', then:@block_487, else:@block_488 },
   ]
 };
 
-block_389 = {
+block_487 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -3557,24 +4298,24 @@ block_389 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_le' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_392, num_args:2 },
+    { op:'call', ret_to:@block_490, num_args:2 },
   ]
 };
 
-block_392 = {
+block_490 = {
   instrs: [
-    { op:'jump', to:@block_390 },
+    { op:'jump', to:@block_488 },
   ]
 };
 
-block_390 = {
+block_488 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_388, else:@block_387 },
+    { op:'if_true', then:@block_486, else:@block_485 },
   ]
 };
 
-block_387 = {
+block_485 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -3582,18 +4323,18 @@ block_387 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_ge' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_395, num_args:2 },
+    { op:'call', ret_to:@block_493, num_args:2 },
   ]
 };
 
-block_395 = {
+block_493 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_393, else:@block_394 },
+    { op:'if_true', then:@block_491, else:@block_492 },
   ]
 };
 
-block_393 = {
+block_491 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -3601,30 +4342,30 @@ block_393 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_le' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_396, num_args:2 },
+    { op:'call', ret_to:@block_494, num_args:2 },
   ]
 };
 
-block_396 = {
+block_494 = {
   instrs: [
-    { op:'jump', to:@block_394 },
+    { op:'jump', to:@block_492 },
   ]
 };
 
-block_394 = {
+block_492 = {
   instrs: [
-    { op:'jump', to:@block_388 },
+    { op:'jump', to:@block_486 },
   ]
 };
 
-block_388 = {
+block_486 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_386, else:@block_385 },
+    { op:'if_true', then:@block_484, else:@block_483 },
   ]
 };
 
-block_385 = {
+block_483 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -3632,18 +4373,18 @@ block_385 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_ge' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_399, num_args:2 },
+    { op:'call', ret_to:@block_497, num_args:2 },
   ]
 };
 
-block_399 = {
+block_497 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_397, else:@block_398 },
+    { op:'if_true', then:@block_495, else:@block_496 },
   ]
 };
 
-block_397 = {
+block_495 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -3651,35 +4392,35 @@ block_397 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_le' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_400, num_args:2 },
+    { op:'call', ret_to:@block_498, num_args:2 },
   ]
 };
 
-block_400 = {
+block_498 = {
   instrs: [
-    { op:'jump', to:@block_398 },
+    { op:'jump', to:@block_496 },
   ]
 };
 
-block_398 = {
+block_496 = {
   instrs: [
-    { op:'jump', to:@block_386 },
+    { op:'jump', to:@block_484 },
   ]
 };
 
-block_386 = {
+block_484 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-fun_384 = {
-  entry:@block_383,
+fun_482 = {
+  entry:@block_481,
   num_params:1,
   num_locals:1,
 };
 
-block_401 = {
+block_499 = {
   instrs: [
     { op:'push', val:3 },
     { op:'new_object' },
@@ -3690,11 +4431,11 @@ block_401 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_403, num_args:2 },
+    { op:'call', ret_to:@block_501, num_args:2 },
   ]
 };
 
-block_403 = {
+block_501 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:0 },
@@ -3704,11 +4445,11 @@ block_403 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_404, num_args:2 },
+    { op:'call', ret_to:@block_502, num_args:2 },
   ]
 };
 
-block_404 = {
+block_502 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:0 },
@@ -3718,879 +4459,27 @@ block_404 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_405, num_args:2 },
-  ]
-};
-
-block_405 = {
-  instrs: [
-    { op:'set_field' },
-    { op:'ret' },
-  ]
-};
-
-fun_402 = {
-  entry:@block_401,
-  num_params:1,
-  num_locals:1,
-};
-
-block_406 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'strIdx' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_408, num_args:2 },
-  ]
-};
-
-block_408 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'srcString' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_409, num_args:2 },
-  ]
-};
-
-block_409 = {
-  instrs: [
-    { op:'push', val:'length' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_410, num_args:2 },
-  ]
-};
-
-block_410 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_ge' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_411, num_args:2 },
-  ]
-};
-
-block_412 = {
-  instrs: [
-    { op:'push', val:'\x00' },
-    { op:'ret' },
-  ]
-};
-
-block_411 = {
-  instrs: [
-    { op:'if_true', then:@block_412, else:@block_413 },
-  ]
-};
-
-block_413 = {
-  instrs: [
-    { op:'jump', to:@block_414 },
-  ]
-};
-
-block_414 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'srcString' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_415, num_args:2 },
-  ]
-};
-
-block_415 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'strIdx' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_416, num_args:2 },
-  ]
-};
-
-block_416 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getElem' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_417, num_args:2 },
-  ]
-};
-
-block_417 = {
-  instrs: [
-    { op:'ret' },
-  ]
-};
-
-fun_407 = {
-  entry:@block_406,
-  num_params:1,
-  num_locals:1,
-};
-
-block_418 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'dup', idx:0 },
-    { op:'push', val:'peekCh' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_420, num_args:2 },
-  ]
-};
-
-block_420 = {
-  instrs: [
-    { op:'call', ret_to:@block_421, num_args:1 },
-  ]
-};
-
-block_421 = {
-  instrs: [
-    { op:'set_local', idx:1 },
-    { op:'get_local', idx:0 },
-    { op:'dup', idx:0 },
-    { op:'push', val:'eof' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_422, num_args:2 },
-  ]
-};
-
-block_422 = {
-  instrs: [
-    { op:'call', ret_to:@block_423, num_args:1 },
-  ]
-};
-
-block_423 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_not' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_424, num_args:1 },
-  ]
-};
-
-block_424 = {
-  instrs: [
-    { op:'if_true', then:@block_425, else:@block_426 },
-  ]
-};
-
-block_425 = {
-  instrs: [
-    { op:'jump', to:@block_427 },
-  ]
-};
-
-block_426 = {
-  instrs: [
-    { op:'push', val:'tried to read past end of input' },
-    { op:'abort' },
-    { op:'jump', to:@block_427 },
-  ]
-};
-
-block_427 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'\x1F' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_le' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_432, num_args:2 },
-  ]
-};
-
-block_432 = {
-  instrs: [
-    { op:'dup', idx:0 },
-    { op:'if_true', then:@block_431, else:@block_430 },
-  ]
-};
-
-block_430 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'\x7F' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_ge' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_433, num_args:2 },
-  ]
-};
-
-block_433 = {
-  instrs: [
-    { op:'jump', to:@block_431 },
-  ]
-};
-
-block_431 = {
-  instrs: [
-    { op:'dup', idx:0 },
-    { op:'if_true', then:@block_428, else:@block_429 },
-  ]
-};
-
-block_428 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'\x0A' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_ne' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_438, num_args:2 },
-  ]
-};
-
-block_438 = {
-  instrs: [
-    { op:'dup', idx:0 },
-    { op:'if_true', then:@block_436, else:@block_437 },
-  ]
-};
-
-block_436 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'\x09' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_ne' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_439, num_args:2 },
-  ]
-};
-
-block_439 = {
-  instrs: [
-    { op:'jump', to:@block_437 },
-  ]
-};
-
-block_437 = {
-  instrs: [
-    { op:'dup', idx:0 },
-    { op:'if_true', then:@block_434, else:@block_435 },
-  ]
-};
-
-block_434 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'\x0D' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_ne' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_440, num_args:2 },
-  ]
-};
-
-block_440 = {
-  instrs: [
-    { op:'jump', to:@block_435 },
-  ]
-};
-
-block_435 = {
-  instrs: [
-    { op:'jump', to:@block_429 },
-  ]
-};
-
-block_441 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'invalid character in input' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'parseError' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_442, num_args:2 },
-  ]
-};
-
-block_429 = {
-  instrs: [
-    { op:'if_true', then:@block_441, else:@block_443 },
-  ]
-};
-
-block_442 = {
-  instrs: [
-    { op:'pop' },
-    { op:'jump', to:@block_444 },
-  ]
-};
-
-block_443 = {
-  instrs: [
-    { op:'jump', to:@block_444 },
-  ]
-};
-
-block_444 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'strIdx' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_445, num_args:2 },
-  ]
-};
-
-block_445 = {
-  instrs: [
-    { op:'push', val:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_add' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_446, num_args:2 },
-  ]
-};
-
-block_446 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'strIdx' },
-    { op:'dup', idx:2 },
-    { op:'set_field' },
-    { op:'pop' },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'\x0A' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_447, num_args:2 },
-  ]
-};
-
-block_448 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'lineNo' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_449, num_args:2 },
-  ]
-};
-
-block_449 = {
-  instrs: [
-    { op:'push', val:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_add' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_450, num_args:2 },
-  ]
-};
-
-block_451 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'colNo' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_452, num_args:2 },
-  ]
-};
-
-block_452 = {
-  instrs: [
-    { op:'push', val:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_add' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_453, num_args:2 },
-  ]
-};
-
-block_447 = {
-  instrs: [
-    { op:'if_true', then:@block_448, else:@block_451 },
-  ]
-};
-
-block_450 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'lineNo' },
-    { op:'dup', idx:2 },
-    { op:'set_field' },
-    { op:'pop' },
-    { op:'push', val:1 },
-    { op:'get_local', idx:0 },
-    { op:'push', val:'colNo' },
-    { op:'dup', idx:2 },
-    { op:'set_field' },
-    { op:'pop' },
-    { op:'jump', to:@block_454 },
-  ]
-};
-
-block_453 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'colNo' },
-    { op:'dup', idx:2 },
-    { op:'set_field' },
-    { op:'pop' },
-    { op:'jump', to:@block_454 },
-  ]
-};
-
-block_454 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'ret' },
-  ]
-};
-
-fun_419 = {
-  entry:@block_418,
-  num_params:1,
-  num_locals:2,
-};
-
-block_455 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'dup', idx:0 },
-    { op:'push', val:'peekCh' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_457, num_args:2 },
-  ]
-};
-
-block_457 = {
-  instrs: [
-    { op:'call', ret_to:@block_458, num_args:1 },
-  ]
-};
-
-block_458 = {
-  instrs: [
-    { op:'push', val:'\x00' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_459, num_args:2 },
-  ]
-};
-
-block_459 = {
-  instrs: [
-    { op:'ret' },
-  ]
-};
-
-fun_456 = {
-  entry:@block_455,
-  num_params:1,
-  num_locals:1,
-};
-
-block_460 = {
-  instrs: [
-    { op:'push', val:0 },
-    { op:'set_local', idx:2 },
-    { op:'push', val:$true },
-    { op:'pop' },
-    { op:'jump', to:@block_462 },
-  ]
-};
-
-block_462 = {
-  instrs: [
-    { op:'get_local', idx:2 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'length' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_466, num_args:2 },
-  ]
-};
-
-block_466 = {
-  instrs: [
-    { op:'lt_i32' },
-    { op:'if_true', then:@block_463, else:@block_465 },
-  ]
-};
-
-block_463 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'strIdx' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_467, num_args:2 },
-  ]
-};
-
-block_467 = {
-  instrs: [
-    { op:'get_local', idx:2 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_add' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_468, num_args:2 },
-  ]
-};
-
-block_468 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'srcString' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_469, num_args:2 },
-  ]
-};
-
-block_469 = {
-  instrs: [
-    { op:'push', val:'length' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_470, num_args:2 },
-  ]
-};
-
-block_470 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_ge' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_471, num_args:2 },
-  ]
-};
-
-block_472 = {
-  instrs: [
-    { op:'push', val:$false },
-    { op:'ret' },
-  ]
-};
-
-block_471 = {
-  instrs: [
-    { op:'if_true', then:@block_472, else:@block_473 },
-  ]
-};
-
-block_473 = {
-  instrs: [
-    { op:'jump', to:@block_474 },
-  ]
-};
-
-block_474 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'get_local', idx:2 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getElem' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_475, num_args:2 },
-  ]
-};
-
-block_475 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'srcString' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_476, num_args:2 },
-  ]
-};
-
-block_476 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'strIdx' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_477, num_args:2 },
-  ]
-};
-
-block_477 = {
-  instrs: [
-    { op:'get_local', idx:2 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_add' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_478, num_args:2 },
-  ]
-};
-
-block_478 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getElem' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_479, num_args:2 },
-  ]
-};
-
-block_479 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_ne' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_480, num_args:2 },
-  ]
-};
-
-block_481 = {
-  instrs: [
-    { op:'push', val:$false },
-    { op:'ret' },
-  ]
-};
-
-block_480 = {
-  instrs: [
-    { op:'if_true', then:@block_481, else:@block_482 },
-  ]
-};
-
-block_482 = {
-  instrs: [
-    { op:'jump', to:@block_483 },
-  ]
-};
-
-block_483 = {
-  instrs: [
-    { op:'jump', to:@block_464 },
-  ]
-};
-
-block_464 = {
-  instrs: [
-    { op:'get_local', idx:2 },
-    { op:'push', val:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_add' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_484, num_args:2 },
-  ]
-};
-
-block_484 = {
-  instrs: [
-    { op:'dup', idx:0 },
-    { op:'set_local', idx:2 },
-    { op:'pop' },
-    { op:'jump', to:@block_462 },
-  ]
-};
-
-block_465 = {
-  instrs: [
-    { op:'push', val:$true },
-    { op:'ret' },
-  ]
-};
-
-fun_461 = {
-  entry:@block_460,
-  num_params:2,
-  num_locals:3,
-};
-
-block_485 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'length' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_487, num_args:2 },
-  ]
-};
-
-block_487 = {
-  instrs: [
-    { op:'push', val:0 },
-    { op:'gt_i32' },
-    { op:'if_true', then:@block_488, else:@block_489 },
-  ]
-};
-
-block_488 = {
-  instrs: [
-    { op:'jump', to:@block_490 },
-  ]
-};
-
-block_489 = {
-  instrs: [
-    { op:'push', val:'assertion failed' },
-    { op:'abort' },
-    { op:'jump', to:@block_490 },
-  ]
-};
-
-block_490 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'dup', idx:1 },
-    { op:'push', val:'next' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_491, num_args:2 },
-  ]
-};
-
-block_491 = {
-  instrs: [
-    { op:'call', ret_to:@block_492, num_args:2 },
-  ]
-};
-
-block_493 = {
-  instrs: [
-    { op:'push', val:0 },
-    { op:'set_local', idx:2 },
-    { op:'jump', to:@block_494 },
-  ]
-};
-
-block_494 = {
-  instrs: [
-    { op:'get_local', idx:2 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'length' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_498, num_args:2 },
-  ]
-};
-
-block_498 = {
-  instrs: [
-    { op:'lt_i32' },
-    { op:'if_true', then:@block_495, else:@block_497 },
-  ]
-};
-
-block_495 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'dup', idx:0 },
-    { op:'push', val:'readCh' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_499, num_args:2 },
-  ]
-};
-
-block_499 = {
-  instrs: [
-    { op:'call', ret_to:@block_500, num_args:1 },
-  ]
-};
-
-block_500 = {
-  instrs: [
-    { op:'pop' },
-    { op:'jump', to:@block_496 },
-  ]
-};
-
-block_496 = {
-  instrs: [
-    { op:'get_local', idx:2 },
-    { op:'push', val:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_add' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_501, num_args:2 },
-  ]
-};
-
-block_501 = {
-  instrs: [
-    { op:'dup', idx:0 },
-    { op:'set_local', idx:2 },
-    { op:'pop' },
-    { op:'jump', to:@block_494 },
-  ]
-};
-
-block_497 = {
-  instrs: [
-    { op:'push', val:$true },
-    { op:'ret' },
-  ]
-};
-
-block_492 = {
-  instrs: [
-    { op:'if_true', then:@block_493, else:@block_502 },
-  ]
-};
-
-block_502 = {
-  instrs: [
-    { op:'jump', to:@block_503 },
+    { op:'call', ret_to:@block_503, num_args:2 },
   ]
 };
 
 block_503 = {
   instrs: [
-    { op:'push', val:$false },
+    { op:'set_field' },
     { op:'ret' },
   ]
 };
 
-fun_486 = {
-  entry:@block_485,
-  num_params:2,
-  num_locals:3,
+fun_500 = {
+  entry:@block_499,
+  num_params:1,
+  num_locals:1,
 };
 
 block_504 = {
   instrs: [
     { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'dup', idx:1 },
-    { op:'push', val:'match' },
+    { op:'push', val:'strIdx' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -4600,119 +4489,139 @@ block_504 = {
 
 block_506 = {
   instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:'srcString' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
     { op:'call', ret_to:@block_507, num_args:2 },
   ]
 };
 
 block_507 = {
   instrs: [
+    { op:'push', val:'length' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_not' },
+    { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_508, num_args:1 },
-  ]
-};
-
-block_509 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'expected to find \'' },
-    { op:'get_local', idx:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_add' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_510, num_args:2 },
-  ]
-};
-
-block_510 = {
-  instrs: [
-    { op:'push', val:'\'' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_add' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_511, num_args:2 },
-  ]
-};
-
-block_511 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'parseError' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_512, num_args:2 },
+    { op:'call', ret_to:@block_508, num_args:2 },
   ]
 };
 
 block_508 = {
   instrs: [
-    { op:'if_true', then:@block_509, else:@block_513 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_ge' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_509, num_args:2 },
+  ]
+};
+
+block_510 = {
+  instrs: [
+    { op:'push', val:'\x00' },
+    { op:'ret' },
+  ]
+};
+
+block_509 = {
+  instrs: [
+    { op:'if_true', then:@block_510, else:@block_511 },
+  ]
+};
+
+block_511 = {
+  instrs: [
+    { op:'jump', to:@block_512 },
   ]
 };
 
 block_512 = {
   instrs: [
-    { op:'pop' },
-    { op:'jump', to:@block_514 },
+    { op:'get_local', idx:0 },
+    { op:'push', val:'srcString' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_513, num_args:2 },
   ]
 };
 
 block_513 = {
   instrs: [
-    { op:'jump', to:@block_514 },
+    { op:'get_local', idx:0 },
+    { op:'push', val:'strIdx' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_514, num_args:2 },
   ]
 };
 
 block_514 = {
   instrs: [
-    { op:'push', val:$undef },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getElem' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_515, num_args:2 },
+  ]
+};
+
+block_515 = {
+  instrs: [
     { op:'ret' },
   ]
 };
 
 fun_505 = {
   entry:@block_504,
-  num_params:2,
-  num_locals:2,
+  num_params:1,
+  num_locals:1,
 };
 
-block_515 = {
+block_516 = {
   instrs: [
-    { op:'push', val:$true },
-    { op:'pop' },
-    { op:'jump', to:@block_517 },
-  ]
-};
-
-block_517 = {
-  instrs: [
-    { op:'push', val:$true },
-    { op:'if_true', then:@block_518, else:@block_520 },
+    { op:'get_local', idx:0 },
+    { op:'dup', idx:0 },
+    { op:'push', val:'peekCh' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_518, num_args:2 },
   ]
 };
 
 block_518 = {
   instrs: [
+    { op:'call', ret_to:@block_519, num_args:1 },
+  ]
+};
+
+block_519 = {
+  instrs: [
+    { op:'set_local', idx:1 },
     { op:'get_local', idx:0 },
     { op:'dup', idx:0 },
     { op:'push', val:'eof' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_521, num_args:2 },
+    { op:'call', ret_to:@block_520, num_args:2 },
+  ]
+};
+
+block_520 = {
+  instrs: [
+    { op:'call', ret_to:@block_521, num_args:1 },
   ]
 };
 
 block_521 = {
   instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_not' },
+    { op:'get_field' },
     { op:'call', ret_to:@block_522, num_args:1 },
-  ]
-};
-
-block_523 = {
-  instrs: [
-    { op:'push', val:$undef },
-    { op:'ret' },
   ]
 };
 
@@ -4722,46 +4631,26 @@ block_522 = {
   ]
 };
 
+block_523 = {
+  instrs: [
+    { op:'jump', to:@block_525 },
+  ]
+};
+
 block_524 = {
   instrs: [
+    { op:'push', val:'tried to read past end of input' },
+    { op:'abort' },
     { op:'jump', to:@block_525 },
   ]
 };
 
 block_525 = {
   instrs: [
-    { op:'get_local', idx:0 },
-    { op:'dup', idx:0 },
-    { op:'push', val:'peekCh' },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'\x1F' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_526, num_args:2 },
-  ]
-};
-
-block_526 = {
-  instrs: [
-    { op:'call', ret_to:@block_527, num_args:1 },
-  ]
-};
-
-block_527 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'isSpace' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_528, num_args:1 },
-  ]
-};
-
-block_529 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'dup', idx:0 },
-    { op:'push', val:'readCh' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'rt_le' },
     { op:'get_field' },
     { op:'call', ret_to:@block_530, num_args:2 },
   ]
@@ -4769,24 +4658,93 @@ block_529 = {
 
 block_530 = {
   instrs: [
-    { op:'call', ret_to:@block_531, num_args:1 },
-  ]
-};
-
-block_531 = {
-  instrs: [
-    { op:'pop' },
-    { op:'jump', to:@block_519 },
+    { op:'dup', idx:0 },
+    { op:'if_true', then:@block_529, else:@block_528 },
   ]
 };
 
 block_528 = {
   instrs: [
-    { op:'if_true', then:@block_529, else:@block_532 },
+    { op:'pop' },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'\x7F' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_ge' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_531, num_args:2 },
+  ]
+};
+
+block_531 = {
+  instrs: [
+    { op:'jump', to:@block_529 },
+  ]
+};
+
+block_529 = {
+  instrs: [
+    { op:'dup', idx:0 },
+    { op:'if_true', then:@block_526, else:@block_527 },
+  ]
+};
+
+block_526 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'\x0A' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_ne' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_536, num_args:2 },
+  ]
+};
+
+block_536 = {
+  instrs: [
+    { op:'dup', idx:0 },
+    { op:'if_true', then:@block_534, else:@block_535 },
+  ]
+};
+
+block_534 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'\x09' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_ne' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_537, num_args:2 },
+  ]
+};
+
+block_537 = {
+  instrs: [
+    { op:'jump', to:@block_535 },
+  ]
+};
+
+block_535 = {
+  instrs: [
+    { op:'dup', idx:0 },
+    { op:'if_true', then:@block_532, else:@block_533 },
   ]
 };
 
 block_532 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'\x0D' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_ne' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_538, num_args:2 },
+  ]
+};
+
+block_538 = {
   instrs: [
     { op:'jump', to:@block_533 },
   ]
@@ -4794,98 +4752,93 @@ block_532 = {
 
 block_533 = {
   instrs: [
+    { op:'jump', to:@block_527 },
+  ]
+};
+
+block_539 = {
+  instrs: [
     { op:'get_local', idx:0 },
-    { op:'push', val:'//' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'match' },
+    { op:'push', val:'invalid character in input' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'parseError' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_534, num_args:2 },
+    { op:'call', ret_to:@block_540, num_args:2 },
   ]
 };
 
-block_534 = {
+block_527 = {
   instrs: [
-    { op:'call', ret_to:@block_535, num_args:2 },
+    { op:'if_true', then:@block_539, else:@block_541 },
   ]
 };
 
-block_536 = {
+block_540 = {
   instrs: [
-    { op:'push', val:$true },
     { op:'pop' },
-    { op:'jump', to:@block_537 },
-  ]
-};
-
-block_537 = {
-  instrs: [
-    { op:'push', val:$true },
-    { op:'if_true', then:@block_538, else:@block_540 },
-  ]
-};
-
-block_538 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'dup', idx:0 },
-    { op:'push', val:'eof' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_541, num_args:2 },
+    { op:'jump', to:@block_542 },
   ]
 };
 
 block_541 = {
   instrs: [
-    { op:'call', ret_to:@block_542, num_args:1 },
-  ]
-};
-
-block_543 = {
-  instrs: [
-    { op:'push', val:$undef },
-    { op:'ret' },
+    { op:'jump', to:@block_542 },
   ]
 };
 
 block_542 = {
   instrs: [
-    { op:'if_true', then:@block_543, else:@block_544 },
+    { op:'get_local', idx:0 },
+    { op:'push', val:'strIdx' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_543, num_args:2 },
+  ]
+};
+
+block_543 = {
+  instrs: [
+    { op:'push', val:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_add' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_544, num_args:2 },
   ]
 };
 
 block_544 = {
   instrs: [
-    { op:'jump', to:@block_545 },
-  ]
-};
-
-block_545 = {
-  instrs: [
     { op:'get_local', idx:0 },
-    { op:'dup', idx:0 },
-    { op:'push', val:'readCh' },
+    { op:'push', val:'strIdx' },
+    { op:'dup', idx:2 },
+    { op:'set_field' },
+    { op:'pop' },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'\x0A' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_546, num_args:2 },
+    { op:'call', ret_to:@block_545, num_args:2 },
   ]
 };
 
 block_546 = {
   instrs: [
-    { op:'call', ret_to:@block_547, num_args:1 },
+    { op:'get_local', idx:0 },
+    { op:'push', val:'lineNo' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_547, num_args:2 },
   ]
 };
 
 block_547 = {
   instrs: [
-    { op:'push', val:'\x0A' },
+    { op:'push', val:1 },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
+    { op:'push', val:'rt_add' },
     { op:'get_field' },
     { op:'call', ret_to:@block_548, num_args:2 },
   ]
@@ -4893,141 +4846,184 @@ block_547 = {
 
 block_549 = {
   instrs: [
-    { op:'jump', to:@block_540 },
-  ]
-};
-
-block_548 = {
-  instrs: [
-    { op:'if_true', then:@block_549, else:@block_550 },
+    { op:'get_local', idx:0 },
+    { op:'push', val:'colNo' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_550, num_args:2 },
   ]
 };
 
 block_550 = {
   instrs: [
-    { op:'jump', to:@block_551 },
+    { op:'push', val:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_add' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_551, num_args:2 },
+  ]
+};
+
+block_545 = {
+  instrs: [
+    { op:'if_true', then:@block_546, else:@block_549 },
+  ]
+};
+
+block_548 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:'lineNo' },
+    { op:'dup', idx:2 },
+    { op:'set_field' },
+    { op:'pop' },
+    { op:'push', val:1 },
+    { op:'get_local', idx:0 },
+    { op:'push', val:'colNo' },
+    { op:'dup', idx:2 },
+    { op:'set_field' },
+    { op:'pop' },
+    { op:'jump', to:@block_552 },
   ]
 };
 
 block_551 = {
   instrs: [
-    { op:'jump', to:@block_539 },
-  ]
-};
-
-block_539 = {
-  instrs: [
-    { op:'push', val:$true },
+    { op:'get_local', idx:0 },
+    { op:'push', val:'colNo' },
+    { op:'dup', idx:2 },
+    { op:'set_field' },
     { op:'pop' },
-    { op:'jump', to:@block_537 },
-  ]
-};
-
-block_540 = {
-  instrs: [
-    { op:'jump', to:@block_519 },
-  ]
-};
-
-block_535 = {
-  instrs: [
-    { op:'if_true', then:@block_536, else:@block_552 },
+    { op:'jump', to:@block_552 },
   ]
 };
 
 block_552 = {
   instrs: [
-    { op:'jump', to:@block_553 },
+    { op:'get_local', idx:1 },
+    { op:'ret' },
   ]
+};
+
+fun_517 = {
+  entry:@block_516,
+  num_params:1,
+  num_locals:2,
 };
 
 block_553 = {
   instrs: [
     { op:'get_local', idx:0 },
-    { op:'push', val:'/*' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'match' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'peekCh' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_554, num_args:2 },
+    { op:'call', ret_to:@block_555, num_args:2 },
   ]
 };
 
-block_554 = {
+block_555 = {
   instrs: [
-    { op:'call', ret_to:@block_555, num_args:2 },
+    { op:'call', ret_to:@block_556, num_args:1 },
   ]
 };
 
 block_556 = {
   instrs: [
-    { op:'push', val:$true },
-    { op:'pop' },
-    { op:'jump', to:@block_557 },
+    { op:'push', val:'\x00' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_557, num_args:2 },
   ]
 };
 
 block_557 = {
   instrs: [
-    { op:'push', val:$true },
-    { op:'if_true', then:@block_558, else:@block_560 },
+    { op:'ret' },
   ]
+};
+
+fun_554 = {
+  entry:@block_553,
+  num_params:1,
+  num_locals:1,
 };
 
 block_558 = {
   instrs: [
-    { op:'get_local', idx:0 },
-    { op:'dup', idx:0 },
-    { op:'push', val:'eof' },
+    { op:'push', val:0 },
+    { op:'set_local', idx:2 },
+    { op:'push', val:$true },
+    { op:'pop' },
+    { op:'jump', to:@block_560 },
+  ]
+};
+
+block_560 = {
+  instrs: [
+    { op:'get_local', idx:2 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_561, num_args:2 },
-  ]
-};
-
-block_561 = {
-  instrs: [
-    { op:'call', ret_to:@block_562, num_args:1 },
-  ]
-};
-
-block_563 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'end of input in multiline comment' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'parseError' },
     { op:'get_field' },
     { op:'call', ret_to:@block_564, num_args:2 },
   ]
 };
 
-block_562 = {
-  instrs: [
-    { op:'if_true', then:@block_563, else:@block_565 },
-  ]
-};
-
 block_564 = {
   instrs: [
-    { op:'pop' },
-    { op:'jump', to:@block_566 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_lt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_565, num_args:2 },
   ]
 };
 
 block_565 = {
   instrs: [
-    { op:'jump', to:@block_566 },
+    { op:'if_true', then:@block_561, else:@block_563 },
+  ]
+};
+
+block_561 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:'strIdx' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_566, num_args:2 },
   ]
 };
 
 block_566 = {
   instrs: [
+    { op:'get_local', idx:2 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_add' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_567, num_args:2 },
+  ]
+};
+
+block_567 = {
+  instrs: [
     { op:'get_local', idx:0 },
-    { op:'dup', idx:0 },
-    { op:'push', val:'readCh' },
+    { op:'push', val:'srcString' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_568, num_args:2 },
+  ]
+};
+
+block_568 = {
+  instrs: [
+    { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -5037,28 +5033,797 @@ block_566 = {
 
 block_569 = {
   instrs: [
-    { op:'call', ret_to:@block_570, num_args:1 },
-  ]
-};
-
-block_570 = {
-  instrs: [
-    { op:'push', val:'*' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
+    { op:'push', val:'rt_ge' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_571, num_args:2 },
+    { op:'call', ret_to:@block_570, num_args:2 },
   ]
 };
 
 block_571 = {
   instrs: [
-    { op:'dup', idx:0 },
-    { op:'if_true', then:@block_567, else:@block_568 },
+    { op:'push', val:$false },
+    { op:'ret' },
   ]
 };
 
-block_567 = {
+block_570 = {
+  instrs: [
+    { op:'if_true', then:@block_571, else:@block_572 },
+  ]
+};
+
+block_572 = {
+  instrs: [
+    { op:'jump', to:@block_573 },
+  ]
+};
+
+block_573 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'get_local', idx:2 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getElem' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_574, num_args:2 },
+  ]
+};
+
+block_574 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:'srcString' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_575, num_args:2 },
+  ]
+};
+
+block_575 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:'strIdx' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_576, num_args:2 },
+  ]
+};
+
+block_576 = {
+  instrs: [
+    { op:'get_local', idx:2 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_add' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_577, num_args:2 },
+  ]
+};
+
+block_577 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getElem' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_578, num_args:2 },
+  ]
+};
+
+block_578 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_ne' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_579, num_args:2 },
+  ]
+};
+
+block_580 = {
+  instrs: [
+    { op:'push', val:$false },
+    { op:'ret' },
+  ]
+};
+
+block_579 = {
+  instrs: [
+    { op:'if_true', then:@block_580, else:@block_581 },
+  ]
+};
+
+block_581 = {
+  instrs: [
+    { op:'jump', to:@block_582 },
+  ]
+};
+
+block_582 = {
+  instrs: [
+    { op:'jump', to:@block_562 },
+  ]
+};
+
+block_562 = {
+  instrs: [
+    { op:'get_local', idx:2 },
+    { op:'push', val:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_add' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_583, num_args:2 },
+  ]
+};
+
+block_583 = {
+  instrs: [
+    { op:'dup', idx:0 },
+    { op:'set_local', idx:2 },
+    { op:'pop' },
+    { op:'jump', to:@block_560 },
+  ]
+};
+
+block_563 = {
+  instrs: [
+    { op:'push', val:$true },
+    { op:'ret' },
+  ]
+};
+
+fun_559 = {
+  entry:@block_558,
+  num_params:2,
+  num_locals:3,
+};
+
+block_584 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'length' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_586, num_args:2 },
+  ]
+};
+
+block_586 = {
+  instrs: [
+    { op:'push', val:0 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_gt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_587, num_args:2 },
+  ]
+};
+
+block_587 = {
+  instrs: [
+    { op:'if_true', then:@block_588, else:@block_589 },
+  ]
+};
+
+block_588 = {
+  instrs: [
+    { op:'jump', to:@block_590 },
+  ]
+};
+
+block_589 = {
+  instrs: [
+    { op:'push', val:'assertion failed' },
+    { op:'abort' },
+    { op:'jump', to:@block_590 },
+  ]
+};
+
+block_590 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'dup', idx:1 },
+    { op:'push', val:'next' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_591, num_args:2 },
+  ]
+};
+
+block_591 = {
+  instrs: [
+    { op:'call', ret_to:@block_592, num_args:2 },
+  ]
+};
+
+block_593 = {
+  instrs: [
+    { op:'push', val:0 },
+    { op:'set_local', idx:2 },
+    { op:'jump', to:@block_594 },
+  ]
+};
+
+block_594 = {
+  instrs: [
+    { op:'get_local', idx:2 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'length' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_598, num_args:2 },
+  ]
+};
+
+block_598 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_lt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_599, num_args:2 },
+  ]
+};
+
+block_599 = {
+  instrs: [
+    { op:'if_true', then:@block_595, else:@block_597 },
+  ]
+};
+
+block_595 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'dup', idx:0 },
+    { op:'push', val:'readCh' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_600, num_args:2 },
+  ]
+};
+
+block_600 = {
+  instrs: [
+    { op:'call', ret_to:@block_601, num_args:1 },
+  ]
+};
+
+block_601 = {
+  instrs: [
+    { op:'pop' },
+    { op:'jump', to:@block_596 },
+  ]
+};
+
+block_596 = {
+  instrs: [
+    { op:'get_local', idx:2 },
+    { op:'push', val:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_add' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_602, num_args:2 },
+  ]
+};
+
+block_602 = {
+  instrs: [
+    { op:'dup', idx:0 },
+    { op:'set_local', idx:2 },
+    { op:'pop' },
+    { op:'jump', to:@block_594 },
+  ]
+};
+
+block_597 = {
+  instrs: [
+    { op:'push', val:$true },
+    { op:'ret' },
+  ]
+};
+
+block_592 = {
+  instrs: [
+    { op:'if_true', then:@block_593, else:@block_603 },
+  ]
+};
+
+block_603 = {
+  instrs: [
+    { op:'jump', to:@block_604 },
+  ]
+};
+
+block_604 = {
+  instrs: [
+    { op:'push', val:$false },
+    { op:'ret' },
+  ]
+};
+
+fun_585 = {
+  entry:@block_584,
+  num_params:2,
+  num_locals:3,
+};
+
+block_605 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'dup', idx:1 },
+    { op:'push', val:'match' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_607, num_args:2 },
+  ]
+};
+
+block_607 = {
+  instrs: [
+    { op:'call', ret_to:@block_608, num_args:2 },
+  ]
+};
+
+block_608 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_not' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_609, num_args:1 },
+  ]
+};
+
+block_610 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:'expected to find \'' },
+    { op:'get_local', idx:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_add' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_611, num_args:2 },
+  ]
+};
+
+block_611 = {
+  instrs: [
+    { op:'push', val:'\'' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_add' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_612, num_args:2 },
+  ]
+};
+
+block_612 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'parseError' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_613, num_args:2 },
+  ]
+};
+
+block_609 = {
+  instrs: [
+    { op:'if_true', then:@block_610, else:@block_614 },
+  ]
+};
+
+block_613 = {
+  instrs: [
+    { op:'pop' },
+    { op:'jump', to:@block_615 },
+  ]
+};
+
+block_614 = {
+  instrs: [
+    { op:'jump', to:@block_615 },
+  ]
+};
+
+block_615 = {
+  instrs: [
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+fun_606 = {
+  entry:@block_605,
+  num_params:2,
+  num_locals:2,
+};
+
+block_616 = {
+  instrs: [
+    { op:'push', val:$true },
+    { op:'pop' },
+    { op:'jump', to:@block_618 },
+  ]
+};
+
+block_618 = {
+  instrs: [
+    { op:'push', val:$true },
+    { op:'if_true', then:@block_619, else:@block_621 },
+  ]
+};
+
+block_619 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'dup', idx:0 },
+    { op:'push', val:'eof' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_622, num_args:2 },
+  ]
+};
+
+block_622 = {
+  instrs: [
+    { op:'call', ret_to:@block_623, num_args:1 },
+  ]
+};
+
+block_624 = {
+  instrs: [
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_623 = {
+  instrs: [
+    { op:'if_true', then:@block_624, else:@block_625 },
+  ]
+};
+
+block_625 = {
+  instrs: [
+    { op:'jump', to:@block_626 },
+  ]
+};
+
+block_626 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'dup', idx:0 },
+    { op:'push', val:'peekCh' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_627, num_args:2 },
+  ]
+};
+
+block_627 = {
+  instrs: [
+    { op:'call', ret_to:@block_628, num_args:1 },
+  ]
+};
+
+block_628 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'isSpace' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_629, num_args:1 },
+  ]
+};
+
+block_630 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'dup', idx:0 },
+    { op:'push', val:'readCh' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_631, num_args:2 },
+  ]
+};
+
+block_631 = {
+  instrs: [
+    { op:'call', ret_to:@block_632, num_args:1 },
+  ]
+};
+
+block_632 = {
+  instrs: [
+    { op:'pop' },
+    { op:'jump', to:@block_620 },
+  ]
+};
+
+block_629 = {
+  instrs: [
+    { op:'if_true', then:@block_630, else:@block_633 },
+  ]
+};
+
+block_633 = {
+  instrs: [
+    { op:'jump', to:@block_634 },
+  ]
+};
+
+block_634 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:'//' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'match' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_635, num_args:2 },
+  ]
+};
+
+block_635 = {
+  instrs: [
+    { op:'call', ret_to:@block_636, num_args:2 },
+  ]
+};
+
+block_637 = {
+  instrs: [
+    { op:'push', val:$true },
+    { op:'pop' },
+    { op:'jump', to:@block_638 },
+  ]
+};
+
+block_638 = {
+  instrs: [
+    { op:'push', val:$true },
+    { op:'if_true', then:@block_639, else:@block_641 },
+  ]
+};
+
+block_639 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'dup', idx:0 },
+    { op:'push', val:'eof' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_642, num_args:2 },
+  ]
+};
+
+block_642 = {
+  instrs: [
+    { op:'call', ret_to:@block_643, num_args:1 },
+  ]
+};
+
+block_644 = {
+  instrs: [
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_643 = {
+  instrs: [
+    { op:'if_true', then:@block_644, else:@block_645 },
+  ]
+};
+
+block_645 = {
+  instrs: [
+    { op:'jump', to:@block_646 },
+  ]
+};
+
+block_646 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'dup', idx:0 },
+    { op:'push', val:'readCh' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_647, num_args:2 },
+  ]
+};
+
+block_647 = {
+  instrs: [
+    { op:'call', ret_to:@block_648, num_args:1 },
+  ]
+};
+
+block_648 = {
+  instrs: [
+    { op:'push', val:'\x0A' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_649, num_args:2 },
+  ]
+};
+
+block_650 = {
+  instrs: [
+    { op:'jump', to:@block_641 },
+  ]
+};
+
+block_649 = {
+  instrs: [
+    { op:'if_true', then:@block_650, else:@block_651 },
+  ]
+};
+
+block_651 = {
+  instrs: [
+    { op:'jump', to:@block_652 },
+  ]
+};
+
+block_652 = {
+  instrs: [
+    { op:'jump', to:@block_640 },
+  ]
+};
+
+block_640 = {
+  instrs: [
+    { op:'push', val:$true },
+    { op:'pop' },
+    { op:'jump', to:@block_638 },
+  ]
+};
+
+block_641 = {
+  instrs: [
+    { op:'jump', to:@block_620 },
+  ]
+};
+
+block_636 = {
+  instrs: [
+    { op:'if_true', then:@block_637, else:@block_653 },
+  ]
+};
+
+block_653 = {
+  instrs: [
+    { op:'jump', to:@block_654 },
+  ]
+};
+
+block_654 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:'/*' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'match' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_655, num_args:2 },
+  ]
+};
+
+block_655 = {
+  instrs: [
+    { op:'call', ret_to:@block_656, num_args:2 },
+  ]
+};
+
+block_657 = {
+  instrs: [
+    { op:'push', val:$true },
+    { op:'pop' },
+    { op:'jump', to:@block_658 },
+  ]
+};
+
+block_658 = {
+  instrs: [
+    { op:'push', val:$true },
+    { op:'if_true', then:@block_659, else:@block_661 },
+  ]
+};
+
+block_659 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'dup', idx:0 },
+    { op:'push', val:'eof' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_662, num_args:2 },
+  ]
+};
+
+block_662 = {
+  instrs: [
+    { op:'call', ret_to:@block_663, num_args:1 },
+  ]
+};
+
+block_664 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:'end of input in multiline comment' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'parseError' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_665, num_args:2 },
+  ]
+};
+
+block_663 = {
+  instrs: [
+    { op:'if_true', then:@block_664, else:@block_666 },
+  ]
+};
+
+block_665 = {
+  instrs: [
+    { op:'pop' },
+    { op:'jump', to:@block_667 },
+  ]
+};
+
+block_666 = {
+  instrs: [
+    { op:'jump', to:@block_667 },
+  ]
+};
+
+block_667 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'dup', idx:0 },
+    { op:'push', val:'readCh' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_670, num_args:2 },
+  ]
+};
+
+block_670 = {
+  instrs: [
+    { op:'call', ret_to:@block_671, num_args:1 },
+  ]
+};
+
+block_671 = {
+  instrs: [
+    { op:'push', val:'*' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_672, num_args:2 },
+  ]
+};
+
+block_672 = {
+  instrs: [
+    { op:'dup', idx:0 },
+    { op:'if_true', then:@block_668, else:@block_669 },
+  ]
+};
+
+block_668 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -5068,100 +5833,100 @@ block_567 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_572, num_args:2 },
+    { op:'call', ret_to:@block_673, num_args:2 },
   ]
 };
 
-block_572 = {
+block_673 = {
   instrs: [
-    { op:'call', ret_to:@block_573, num_args:2 },
+    { op:'call', ret_to:@block_674, num_args:2 },
   ]
 };
 
-block_573 = {
+block_674 = {
   instrs: [
-    { op:'jump', to:@block_568 },
+    { op:'jump', to:@block_669 },
   ]
 };
 
-block_574 = {
+block_675 = {
   instrs: [
-    { op:'jump', to:@block_560 },
+    { op:'jump', to:@block_661 },
   ]
 };
 
-block_568 = {
+block_669 = {
   instrs: [
-    { op:'if_true', then:@block_574, else:@block_575 },
+    { op:'if_true', then:@block_675, else:@block_676 },
   ]
 };
 
-block_575 = {
+block_676 = {
   instrs: [
-    { op:'jump', to:@block_576 },
+    { op:'jump', to:@block_677 },
   ]
 };
 
-block_576 = {
+block_677 = {
   instrs: [
-    { op:'jump', to:@block_559 },
+    { op:'jump', to:@block_660 },
   ]
 };
 
-block_559 = {
-  instrs: [
-    { op:'push', val:$true },
-    { op:'pop' },
-    { op:'jump', to:@block_557 },
-  ]
-};
-
-block_560 = {
-  instrs: [
-    { op:'jump', to:@block_519 },
-  ]
-};
-
-block_555 = {
-  instrs: [
-    { op:'if_true', then:@block_556, else:@block_577 },
-  ]
-};
-
-block_577 = {
-  instrs: [
-    { op:'jump', to:@block_578 },
-  ]
-};
-
-block_578 = {
-  instrs: [
-    { op:'jump', to:@block_520 },
-  ]
-};
-
-block_519 = {
+block_660 = {
   instrs: [
     { op:'push', val:$true },
     { op:'pop' },
-    { op:'jump', to:@block_517 },
+    { op:'jump', to:@block_658 },
   ]
 };
 
-block_520 = {
+block_661 = {
+  instrs: [
+    { op:'jump', to:@block_620 },
+  ]
+};
+
+block_656 = {
+  instrs: [
+    { op:'if_true', then:@block_657, else:@block_678 },
+  ]
+};
+
+block_678 = {
+  instrs: [
+    { op:'jump', to:@block_679 },
+  ]
+};
+
+block_679 = {
+  instrs: [
+    { op:'jump', to:@block_621 },
+  ]
+};
+
+block_620 = {
+  instrs: [
+    { op:'push', val:$true },
+    { op:'pop' },
+    { op:'jump', to:@block_618 },
+  ]
+};
+
+block_621 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-fun_516 = {
-  entry:@block_515,
+fun_617 = {
+  entry:@block_616,
   num_params:1,
   num_locals:1,
 };
 
-block_579 = {
+block_680 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'dup', idx:0 },
@@ -5169,17 +5934,17 @@ block_579 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_581, num_args:2 },
+    { op:'call', ret_to:@block_682, num_args:2 },
   ]
 };
 
-block_581 = {
+block_682 = {
   instrs: [
-    { op:'call', ret_to:@block_582, num_args:1 },
+    { op:'call', ret_to:@block_683, num_args:1 },
   ]
 };
 
-block_582 = {
+block_683 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -5189,29 +5954,29 @@ block_582 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_583, num_args:2 },
+    { op:'call', ret_to:@block_684, num_args:2 },
   ]
 };
 
-block_583 = {
+block_684 = {
   instrs: [
-    { op:'call', ret_to:@block_584, num_args:2 },
+    { op:'call', ret_to:@block_685, num_args:2 },
   ]
 };
 
-block_584 = {
+block_685 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-fun_580 = {
-  entry:@block_579,
+fun_681 = {
+  entry:@block_680,
   num_params:2,
   num_locals:2,
 };
 
-block_585 = {
+block_686 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'dup', idx:0 },
@@ -5219,17 +5984,17 @@ block_585 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_587, num_args:2 },
+    { op:'call', ret_to:@block_688, num_args:2 },
   ]
 };
 
-block_587 = {
+block_688 = {
   instrs: [
-    { op:'call', ret_to:@block_588, num_args:1 },
+    { op:'call', ret_to:@block_689, num_args:1 },
   ]
 };
 
-block_588 = {
+block_689 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -5239,29 +6004,29 @@ block_588 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_589, num_args:2 },
+    { op:'call', ret_to:@block_690, num_args:2 },
   ]
 };
 
-block_589 = {
+block_690 = {
   instrs: [
-    { op:'call', ret_to:@block_590, num_args:2 },
+    { op:'call', ret_to:@block_691, num_args:2 },
   ]
 };
 
-block_590 = {
+block_691 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-fun_586 = {
-  entry:@block_585,
+fun_687 = {
+  entry:@block_686,
   num_params:2,
   num_locals:2,
 };
 
-block_591 = {
+block_692 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'dup', idx:0 },
@@ -5269,17 +6034,17 @@ block_591 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_593, num_args:2 },
+    { op:'call', ret_to:@block_694, num_args:2 },
   ]
 };
 
-block_593 = {
+block_694 = {
   instrs: [
-    { op:'call', ret_to:@block_594, num_args:1 },
+    { op:'call', ret_to:@block_695, num_args:1 },
   ]
 };
 
-block_594 = {
+block_695 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -5289,17 +6054,17 @@ block_594 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_595, num_args:2 },
+    { op:'call', ret_to:@block_696, num_args:2 },
   ]
 };
 
-block_595 = {
+block_696 = {
   instrs: [
-    { op:'call', ret_to:@block_596, num_args:2 },
+    { op:'call', ret_to:@block_697, num_args:2 },
   ]
 };
 
-block_596 = {
+block_697 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -5307,30 +6072,30 @@ block_596 = {
   ]
 };
 
-fun_592 = {
-  entry:@block_591,
+fun_693 = {
+  entry:@block_692,
   num_params:2,
   num_locals:2,
 };
 
-block_597 = {
+block_698 = {
   instrs: [
     { op:'push', val:0 },
     { op:'set_local', idx:2 },
     { op:'push', val:$true },
     { op:'pop' },
-    { op:'jump', to:@block_599 },
+    { op:'jump', to:@block_700 },
   ]
 };
 
-block_599 = {
+block_700 = {
   instrs: [
     { op:'push', val:$true },
-    { op:'if_true', then:@block_600, else:@block_602 },
+    { op:'if_true', then:@block_701, else:@block_703 },
   ]
 };
 
-block_600 = {
+block_701 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'dup', idx:0 },
@@ -5338,89 +6103,89 @@ block_600 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_603, num_args:2 },
+    { op:'call', ret_to:@block_704, num_args:2 },
   ]
 };
 
-block_603 = {
+block_704 = {
   instrs: [
-    { op:'call', ret_to:@block_604, num_args:1 },
+    { op:'call', ret_to:@block_705, num_args:1 },
   ]
 };
 
-block_604 = {
+block_705 = {
   instrs: [
     { op:'set_local', idx:3 },
     { op:'get_local', idx:3 },
     { op:'push', val:@global_obj },
     { op:'push', val:'isDigit' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_605, num_args:1 },
+    { op:'call', ret_to:@block_706, num_args:1 },
   ]
 };
 
-block_605 = {
+block_706 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_not' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_606, num_args:1 },
+    { op:'call', ret_to:@block_707, num_args:1 },
   ]
 };
 
-block_607 = {
+block_708 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'expected digit' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseError' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_608, num_args:2 },
+    { op:'call', ret_to:@block_709, num_args:2 },
   ]
 };
 
-block_606 = {
+block_707 = {
   instrs: [
-    { op:'if_true', then:@block_607, else:@block_609 },
+    { op:'if_true', then:@block_708, else:@block_710 },
   ]
 };
 
-block_608 = {
+block_709 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_610 },
+    { op:'jump', to:@block_711 },
   ]
 };
 
-block_609 = {
+block_710 = {
   instrs: [
-    { op:'jump', to:@block_610 },
+    { op:'jump', to:@block_711 },
   ]
 };
 
-block_610 = {
+block_711 = {
   instrs: [
     { op:'push', val:0 },
     { op:'push', val:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_sub' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_611, num_args:2 },
+    { op:'call', ret_to:@block_712, num_args:2 },
   ]
 };
 
-block_611 = {
+block_712 = {
   instrs: [
     { op:'set_local', idx:4 },
     { op:'push', val:'0123456789' },
     { op:'set_local', idx:5 },
     { op:'push', val:0 },
     { op:'set_local', idx:6 },
-    { op:'jump', to:@block_612 },
+    { op:'jump', to:@block_713 },
   ]
 };
 
-block_612 = {
+block_713 = {
   instrs: [
     { op:'get_local', idx:6 },
     { op:'get_local', idx:5 },
@@ -5428,18 +6193,26 @@ block_612 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_616, num_args:2 },
+    { op:'call', ret_to:@block_717, num_args:2 },
   ]
 };
 
-block_616 = {
+block_717 = {
   instrs: [
-    { op:'lt_i32' },
-    { op:'if_true', then:@block_613, else:@block_615 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_lt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_718, num_args:2 },
   ]
 };
 
-block_613 = {
+block_718 = {
+  instrs: [
+    { op:'if_true', then:@block_714, else:@block_716 },
+  ]
+};
+
+block_714 = {
   instrs: [
     { op:'get_local', idx:3 },
     { op:'get_local', idx:5 },
@@ -5447,68 +6220,68 @@ block_613 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getElem' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_617, num_args:2 },
+    { op:'call', ret_to:@block_719, num_args:2 },
   ]
 };
 
-block_617 = {
+block_719 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_618, num_args:2 },
+    { op:'call', ret_to:@block_720, num_args:2 },
   ]
 };
 
-block_619 = {
+block_721 = {
   instrs: [
     { op:'get_local', idx:6 },
     { op:'dup', idx:0 },
     { op:'set_local', idx:4 },
     { op:'pop' },
-    { op:'jump', to:@block_615 },
+    { op:'jump', to:@block_716 },
   ]
 };
 
-block_618 = {
+block_720 = {
   instrs: [
-    { op:'if_true', then:@block_619, else:@block_620 },
+    { op:'if_true', then:@block_721, else:@block_722 },
   ]
 };
 
-block_620 = {
+block_722 = {
   instrs: [
-    { op:'jump', to:@block_621 },
+    { op:'jump', to:@block_723 },
   ]
 };
 
-block_621 = {
+block_723 = {
   instrs: [
-    { op:'jump', to:@block_614 },
+    { op:'jump', to:@block_715 },
   ]
 };
 
-block_614 = {
+block_715 = {
   instrs: [
     { op:'get_local', idx:6 },
     { op:'push', val:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_add' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_622, num_args:2 },
+    { op:'call', ret_to:@block_724, num_args:2 },
   ]
 };
 
-block_622 = {
+block_724 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'set_local', idx:6 },
     { op:'pop' },
-    { op:'jump', to:@block_612 },
+    { op:'jump', to:@block_713 },
   ]
 };
 
-block_615 = {
+block_716 = {
   instrs: [
     { op:'get_local', idx:4 },
     { op:'push', val:0 },
@@ -5516,61 +6289,61 @@ block_615 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_sub' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_623, num_args:2 },
+    { op:'call', ret_to:@block_725, num_args:2 },
   ]
 };
 
-block_623 = {
+block_725 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_ne' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_624, num_args:2 },
+    { op:'call', ret_to:@block_726, num_args:2 },
   ]
 };
 
-block_624 = {
+block_726 = {
   instrs: [
-    { op:'if_true', then:@block_625, else:@block_626 },
+    { op:'if_true', then:@block_727, else:@block_728 },
   ]
 };
 
-block_625 = {
+block_727 = {
   instrs: [
-    { op:'jump', to:@block_627 },
+    { op:'jump', to:@block_729 },
   ]
 };
 
-block_626 = {
+block_728 = {
   instrs: [
     { op:'push', val:'digit not found' },
     { op:'abort' },
-    { op:'jump', to:@block_627 },
+    { op:'jump', to:@block_729 },
   ]
 };
 
-block_627 = {
+block_729 = {
   instrs: [
     { op:'push', val:10 },
     { op:'get_local', idx:2 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_mul' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_628, num_args:2 },
+    { op:'call', ret_to:@block_730, num_args:2 },
   ]
 };
 
-block_628 = {
+block_730 = {
   instrs: [
     { op:'get_local', idx:4 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_add' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_629, num_args:2 },
+    { op:'call', ret_to:@block_731, num_args:2 },
   ]
 };
 
-block_629 = {
+block_731 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'set_local', idx:2 },
@@ -5581,67 +6354,67 @@ block_629 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_630, num_args:2 },
+    { op:'call', ret_to:@block_732, num_args:2 },
   ]
 };
 
-block_630 = {
+block_732 = {
   instrs: [
-    { op:'call', ret_to:@block_631, num_args:1 },
+    { op:'call', ret_to:@block_733, num_args:1 },
   ]
 };
 
-block_631 = {
+block_733 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'isDigit' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_632, num_args:1 },
+    { op:'call', ret_to:@block_734, num_args:1 },
   ]
 };
 
-block_632 = {
+block_734 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_not' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_633, num_args:1 },
+    { op:'call', ret_to:@block_735, num_args:1 },
   ]
 };
 
-block_634 = {
+block_736 = {
   instrs: [
-    { op:'jump', to:@block_602 },
+    { op:'jump', to:@block_703 },
   ]
 };
 
-block_633 = {
+block_735 = {
   instrs: [
-    { op:'if_true', then:@block_634, else:@block_635 },
+    { op:'if_true', then:@block_736, else:@block_737 },
   ]
 };
 
-block_635 = {
+block_737 = {
   instrs: [
-    { op:'jump', to:@block_636 },
+    { op:'jump', to:@block_738 },
   ]
 };
 
-block_636 = {
+block_738 = {
   instrs: [
-    { op:'jump', to:@block_601 },
+    { op:'jump', to:@block_702 },
   ]
 };
 
-block_601 = {
+block_702 = {
   instrs: [
     { op:'push', val:$true },
     { op:'pop' },
-    { op:'jump', to:@block_599 },
+    { op:'jump', to:@block_700 },
   ]
 };
 
-block_637 = {
+block_739 = {
   instrs: [
     { op:'get_local', idx:2 },
     { op:'push', val:0 },
@@ -5649,42 +6422,42 @@ block_637 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_sub' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_638, num_args:2 },
+    { op:'call', ret_to:@block_740, num_args:2 },
   ]
 };
 
-block_638 = {
+block_740 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_mul' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_639, num_args:2 },
+    { op:'call', ret_to:@block_741, num_args:2 },
   ]
 };
 
-block_602 = {
+block_703 = {
   instrs: [
     { op:'get_local', idx:1 },
-    { op:'if_true', then:@block_637, else:@block_640 },
+    { op:'if_true', then:@block_739, else:@block_742 },
   ]
 };
 
-block_639 = {
+block_741 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'set_local', idx:2 },
     { op:'pop' },
-    { op:'jump', to:@block_641 },
+    { op:'jump', to:@block_743 },
   ]
 };
 
-block_640 = {
+block_742 = {
   instrs: [
-    { op:'jump', to:@block_641 },
+    { op:'jump', to:@block_743 },
   ]
 };
 
-block_641 = {
+block_743 = {
   instrs: [
     { op:'push', val:1 },
     { op:'new_object' },
@@ -5702,13 +6475,13 @@ block_641 = {
   ]
 };
 
-fun_598 = {
-  entry:@block_597,
+fun_699 = {
+  entry:@block_698,
   num_params:2,
   num_locals:7,
 };
 
-block_642 = {
+block_744 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'dup', idx:0 },
@@ -5716,17 +6489,17 @@ block_642 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_644, num_args:2 },
+    { op:'call', ret_to:@block_746, num_args:2 },
   ]
 };
 
-block_644 = {
+block_746 = {
   instrs: [
-    { op:'call', ret_to:@block_645, num_args:1 },
+    { op:'call', ret_to:@block_747, num_args:1 },
   ]
 };
 
-block_645 = {
+block_747 = {
   instrs: [
     { op:'set_local', idx:1 },
     { op:'get_local', idx:1 },
@@ -5734,241 +6507,241 @@ block_645 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_646, num_args:2 },
+    { op:'call', ret_to:@block_748, num_args:2 },
   ]
 };
 
-block_647 = {
+block_749 = {
   instrs: [
     { op:'push', val:'\x0A' },
     { op:'ret' },
   ]
 };
 
-block_646 = {
+block_748 = {
   instrs: [
-    { op:'if_true', then:@block_647, else:@block_648 },
+    { op:'if_true', then:@block_749, else:@block_750 },
   ]
 };
 
-block_648 = {
+block_750 = {
   instrs: [
-    { op:'jump', to:@block_649 },
+    { op:'jump', to:@block_751 },
   ]
 };
 
-block_649 = {
+block_751 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'t' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_650, num_args:2 },
+    { op:'call', ret_to:@block_752, num_args:2 },
   ]
 };
 
-block_651 = {
+block_753 = {
   instrs: [
     { op:'push', val:'\x09' },
     { op:'ret' },
   ]
 };
 
-block_650 = {
+block_752 = {
   instrs: [
-    { op:'if_true', then:@block_651, else:@block_652 },
+    { op:'if_true', then:@block_753, else:@block_754 },
   ]
 };
 
-block_652 = {
+block_754 = {
   instrs: [
-    { op:'jump', to:@block_653 },
+    { op:'jump', to:@block_755 },
   ]
 };
 
-block_653 = {
+block_755 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'0' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_654, num_args:2 },
+    { op:'call', ret_to:@block_756, num_args:2 },
   ]
 };
 
-block_655 = {
+block_757 = {
   instrs: [
     { op:'push', val:'\x00' },
     { op:'ret' },
   ]
 };
 
-block_654 = {
+block_756 = {
   instrs: [
-    { op:'if_true', then:@block_655, else:@block_656 },
+    { op:'if_true', then:@block_757, else:@block_758 },
   ]
 };
 
-block_656 = {
+block_758 = {
   instrs: [
-    { op:'jump', to:@block_657 },
+    { op:'jump', to:@block_759 },
   ]
 };
 
-block_657 = {
+block_759 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'\'' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_658, num_args:2 },
+    { op:'call', ret_to:@block_760, num_args:2 },
   ]
 };
 
-block_659 = {
+block_761 = {
   instrs: [
     { op:'push', val:'\'' },
     { op:'ret' },
   ]
 };
 
-block_658 = {
+block_760 = {
   instrs: [
-    { op:'if_true', then:@block_659, else:@block_660 },
+    { op:'if_true', then:@block_761, else:@block_762 },
   ]
 };
 
-block_660 = {
+block_762 = {
   instrs: [
-    { op:'jump', to:@block_661 },
+    { op:'jump', to:@block_763 },
   ]
 };
 
-block_661 = {
+block_763 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'\"' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_662, num_args:2 },
+    { op:'call', ret_to:@block_764, num_args:2 },
   ]
 };
 
-block_663 = {
+block_765 = {
   instrs: [
     { op:'push', val:'\"' },
     { op:'ret' },
   ]
 };
 
-block_662 = {
+block_764 = {
   instrs: [
-    { op:'if_true', then:@block_663, else:@block_664 },
+    { op:'if_true', then:@block_765, else:@block_766 },
   ]
 };
 
-block_664 = {
+block_766 = {
   instrs: [
-    { op:'jump', to:@block_665 },
+    { op:'jump', to:@block_767 },
   ]
 };
 
-block_665 = {
+block_767 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'\\' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_666, num_args:2 },
+    { op:'call', ret_to:@block_768, num_args:2 },
   ]
 };
 
-block_667 = {
+block_769 = {
   instrs: [
     { op:'push', val:'\\' },
     { op:'ret' },
   ]
 };
 
-block_666 = {
+block_768 = {
   instrs: [
-    { op:'if_true', then:@block_667, else:@block_668 },
+    { op:'if_true', then:@block_769, else:@block_770 },
   ]
 };
 
-block_668 = {
+block_770 = {
   instrs: [
-    { op:'jump', to:@block_669 },
+    { op:'jump', to:@block_771 },
   ]
 };
 
-block_669 = {
+block_771 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'x' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_670, num_args:2 },
+    { op:'call', ret_to:@block_772, num_args:2 },
   ]
 };
 
-block_671 = {
+block_773 = {
   instrs: [
     { op:'push', val:$false },
-    { op:'if_true', then:@block_672, else:@block_673 },
+    { op:'if_true', then:@block_774, else:@block_775 },
   ]
 };
 
-block_672 = {
+block_774 = {
   instrs: [
-    { op:'jump', to:@block_674 },
+    { op:'jump', to:@block_776 },
   ]
 };
 
-block_673 = {
+block_775 = {
   instrs: [
     { op:'push', val:'hexadecimal escape sequence' },
     { op:'abort' },
-    { op:'jump', to:@block_674 },
+    { op:'jump', to:@block_776 },
   ]
 };
 
-block_670 = {
+block_772 = {
   instrs: [
-    { op:'if_true', then:@block_671, else:@block_675 },
+    { op:'if_true', then:@block_773, else:@block_777 },
   ]
 };
 
-block_674 = {
+block_776 = {
   instrs: [
-    { op:'jump', to:@block_676 },
+    { op:'jump', to:@block_778 },
   ]
 };
 
-block_675 = {
+block_777 = {
   instrs: [
-    { op:'jump', to:@block_676 },
+    { op:'jump', to:@block_778 },
   ]
 };
 
-block_676 = {
+block_778 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'invalid character escape sequence' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseError' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_677, num_args:2 },
+    { op:'call', ret_to:@block_779, num_args:2 },
   ]
 };
 
-block_677 = {
+block_779 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -5976,30 +6749,30 @@ block_677 = {
   ]
 };
 
-fun_643 = {
-  entry:@block_642,
+fun_745 = {
+  entry:@block_744,
   num_params:1,
   num_locals:2,
 };
 
-block_678 = {
+block_780 = {
   instrs: [
     { op:'push', val:'' },
     { op:'set_local', idx:2 },
     { op:'push', val:$true },
     { op:'pop' },
-    { op:'jump', to:@block_680 },
+    { op:'jump', to:@block_782 },
   ]
 };
 
-block_680 = {
+block_782 = {
   instrs: [
     { op:'push', val:$true },
-    { op:'if_true', then:@block_681, else:@block_683 },
+    { op:'if_true', then:@block_783, else:@block_785 },
   ]
 };
 
-block_681 = {
+block_783 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'dup', idx:0 },
@@ -6007,47 +6780,47 @@ block_681 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_684, num_args:2 },
+    { op:'call', ret_to:@block_786, num_args:2 },
   ]
 };
 
-block_684 = {
+block_786 = {
   instrs: [
-    { op:'call', ret_to:@block_685, num_args:1 },
+    { op:'call', ret_to:@block_787, num_args:1 },
   ]
 };
 
-block_686 = {
+block_788 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'end of input inside string literal' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseError' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_687, num_args:2 },
+    { op:'call', ret_to:@block_789, num_args:2 },
   ]
 };
 
-block_685 = {
+block_787 = {
   instrs: [
-    { op:'if_true', then:@block_686, else:@block_688 },
+    { op:'if_true', then:@block_788, else:@block_790 },
   ]
 };
 
-block_687 = {
+block_789 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_689 },
+    { op:'jump', to:@block_791 },
   ]
 };
 
-block_688 = {
+block_790 = {
   instrs: [
-    { op:'jump', to:@block_689 },
+    { op:'jump', to:@block_791 },
   ]
 };
 
-block_689 = {
+block_791 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'dup', idx:0 },
@@ -6055,17 +6828,17 @@ block_689 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_690, num_args:2 },
+    { op:'call', ret_to:@block_792, num_args:2 },
   ]
 };
 
-block_690 = {
+block_792 = {
   instrs: [
-    { op:'call', ret_to:@block_691, num_args:1 },
+    { op:'call', ret_to:@block_793, num_args:1 },
   ]
 };
 
-block_691 = {
+block_793 = {
   instrs: [
     { op:'set_local', idx:3 },
     { op:'get_local', idx:3 },
@@ -6073,47 +6846,47 @@ block_691 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_692, num_args:2 },
+    { op:'call', ret_to:@block_794, num_args:2 },
   ]
 };
 
-block_693 = {
+block_795 = {
   instrs: [
-    { op:'jump', to:@block_683 },
+    { op:'jump', to:@block_785 },
   ]
 };
 
-block_692 = {
+block_794 = {
   instrs: [
-    { op:'if_true', then:@block_693, else:@block_694 },
+    { op:'if_true', then:@block_795, else:@block_796 },
   ]
 };
 
-block_694 = {
+block_796 = {
   instrs: [
-    { op:'jump', to:@block_695 },
+    { op:'jump', to:@block_797 },
   ]
 };
 
-block_695 = {
+block_797 = {
   instrs: [
     { op:'get_local', idx:3 },
     { op:'push', val:'\x0D' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_698, num_args:2 },
+    { op:'call', ret_to:@block_800, num_args:2 },
   ]
 };
 
-block_698 = {
+block_800 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_697, else:@block_696 },
+    { op:'if_true', then:@block_799, else:@block_798 },
   ]
 };
 
-block_696 = {
+block_798 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:3 },
@@ -6121,117 +6894,117 @@ block_696 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_699, num_args:2 },
+    { op:'call', ret_to:@block_801, num_args:2 },
   ]
 };
 
-block_699 = {
+block_801 = {
   instrs: [
-    { op:'jump', to:@block_697 },
+    { op:'jump', to:@block_799 },
   ]
 };
 
-block_700 = {
+block_802 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'newline character in string literal' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseError' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_701, num_args:2 },
+    { op:'call', ret_to:@block_803, num_args:2 },
   ]
 };
 
-block_697 = {
+block_799 = {
   instrs: [
-    { op:'if_true', then:@block_700, else:@block_702 },
+    { op:'if_true', then:@block_802, else:@block_804 },
   ]
 };
 
-block_701 = {
+block_803 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_703 },
+    { op:'jump', to:@block_805 },
   ]
 };
 
-block_702 = {
+block_804 = {
   instrs: [
-    { op:'jump', to:@block_703 },
+    { op:'jump', to:@block_805 },
   ]
 };
 
-block_703 = {
+block_805 = {
   instrs: [
     { op:'get_local', idx:3 },
     { op:'push', val:'\\' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_704, num_args:2 },
+    { op:'call', ret_to:@block_806, num_args:2 },
   ]
 };
 
-block_705 = {
+block_807 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseEscSeq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_706, num_args:1 },
+    { op:'call', ret_to:@block_808, num_args:1 },
   ]
 };
 
-block_704 = {
+block_806 = {
   instrs: [
-    { op:'if_true', then:@block_705, else:@block_707 },
+    { op:'if_true', then:@block_807, else:@block_809 },
   ]
 };
 
-block_706 = {
+block_808 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'set_local', idx:3 },
     { op:'pop' },
-    { op:'jump', to:@block_708 },
+    { op:'jump', to:@block_810 },
   ]
 };
 
-block_707 = {
+block_809 = {
   instrs: [
-    { op:'jump', to:@block_708 },
+    { op:'jump', to:@block_810 },
   ]
 };
 
-block_708 = {
+block_810 = {
   instrs: [
     { op:'get_local', idx:2 },
     { op:'get_local', idx:3 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_add' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_709, num_args:2 },
+    { op:'call', ret_to:@block_811, num_args:2 },
   ]
 };
 
-block_709 = {
+block_811 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'set_local', idx:2 },
     { op:'pop' },
-    { op:'jump', to:@block_682 },
+    { op:'jump', to:@block_784 },
   ]
 };
 
-block_682 = {
+block_784 = {
   instrs: [
     { op:'push', val:$true },
     { op:'pop' },
-    { op:'jump', to:@block_680 },
+    { op:'jump', to:@block_782 },
   ]
 };
 
-block_683 = {
+block_785 = {
   instrs: [
     { op:'push', val:1 },
     { op:'new_object' },
@@ -6249,13 +7022,13 @@ block_683 = {
   ]
 };
 
-fun_679 = {
-  entry:@block_678,
+fun_781 = {
+  entry:@block_780,
   num_params:2,
   num_locals:4,
 };
 
-block_710 = {
+block_812 = {
   instrs: [
     { op:'push', val:'' },
     { op:'set_local', idx:1 },
@@ -6265,17 +7038,17 @@ block_710 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_712, num_args:2 },
+    { op:'call', ret_to:@block_814, num_args:2 },
   ]
 };
 
-block_712 = {
+block_814 = {
   instrs: [
-    { op:'call', ret_to:@block_713, num_args:1 },
+    { op:'call', ret_to:@block_815, num_args:1 },
   ]
 };
 
-block_713 = {
+block_815 = {
   instrs: [
     { op:'set_local', idx:2 },
     { op:'get_local', idx:2 },
@@ -6283,89 +7056,89 @@ block_713 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_ne' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_716, num_args:2 },
+    { op:'call', ret_to:@block_818, num_args:2 },
   ]
 };
 
-block_716 = {
+block_818 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_714, else:@block_715 },
+    { op:'if_true', then:@block_816, else:@block_817 },
   ]
 };
 
-block_714 = {
+block_816 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:2 },
     { op:'push', val:@global_obj },
     { op:'push', val:'isAlpha' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_717, num_args:1 },
+    { op:'call', ret_to:@block_819, num_args:1 },
   ]
 };
 
-block_717 = {
+block_819 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_not' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_718, num_args:1 },
+    { op:'call', ret_to:@block_820, num_args:1 },
   ]
 };
 
-block_718 = {
+block_820 = {
   instrs: [
-    { op:'jump', to:@block_715 },
+    { op:'jump', to:@block_817 },
   ]
 };
 
-block_719 = {
+block_821 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'invalid identifier start' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseError' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_720, num_args:2 },
+    { op:'call', ret_to:@block_822, num_args:2 },
   ]
 };
 
-block_715 = {
+block_817 = {
   instrs: [
-    { op:'if_true', then:@block_719, else:@block_721 },
+    { op:'if_true', then:@block_821, else:@block_823 },
   ]
 };
 
-block_720 = {
+block_822 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_722 },
+    { op:'jump', to:@block_824 },
   ]
 };
 
-block_721 = {
+block_823 = {
   instrs: [
-    { op:'jump', to:@block_722 },
+    { op:'jump', to:@block_824 },
   ]
 };
 
-block_722 = {
+block_824 = {
   instrs: [
     { op:'push', val:$true },
     { op:'pop' },
-    { op:'jump', to:@block_723 },
+    { op:'jump', to:@block_825 },
   ]
 };
 
-block_723 = {
+block_825 = {
   instrs: [
     { op:'push', val:$true },
-    { op:'if_true', then:@block_724, else:@block_726 },
+    { op:'if_true', then:@block_826, else:@block_828 },
   ]
 };
 
-block_724 = {
+block_826 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'dup', idx:0 },
@@ -6373,44 +7146,44 @@ block_724 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_727, num_args:2 },
+    { op:'call', ret_to:@block_829, num_args:2 },
   ]
 };
 
-block_727 = {
+block_829 = {
   instrs: [
-    { op:'call', ret_to:@block_728, num_args:1 },
+    { op:'call', ret_to:@block_830, num_args:1 },
   ]
 };
 
-block_728 = {
+block_830 = {
   instrs: [
     { op:'set_local', idx:3 },
     { op:'get_local', idx:3 },
     { op:'push', val:@global_obj },
     { op:'push', val:'isAlnum' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_731, num_args:1 },
+    { op:'call', ret_to:@block_833, num_args:1 },
   ]
 };
 
-block_731 = {
+block_833 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_not' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_732, num_args:1 },
+    { op:'call', ret_to:@block_834, num_args:1 },
   ]
 };
 
-block_732 = {
+block_834 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_729, else:@block_730 },
+    { op:'if_true', then:@block_831, else:@block_832 },
   ]
 };
 
-block_729 = {
+block_831 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:3 },
@@ -6418,35 +7191,35 @@ block_729 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_ne' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_733, num_args:2 },
+    { op:'call', ret_to:@block_835, num_args:2 },
   ]
 };
 
-block_733 = {
+block_835 = {
   instrs: [
-    { op:'jump', to:@block_730 },
+    { op:'jump', to:@block_832 },
   ]
 };
 
-block_734 = {
+block_836 = {
   instrs: [
-    { op:'jump', to:@block_726 },
+    { op:'jump', to:@block_828 },
   ]
 };
 
-block_730 = {
+block_832 = {
   instrs: [
-    { op:'if_true', then:@block_734, else:@block_735 },
+    { op:'if_true', then:@block_836, else:@block_837 },
   ]
 };
 
-block_735 = {
+block_837 = {
   instrs: [
-    { op:'jump', to:@block_736 },
+    { op:'jump', to:@block_838 },
   ]
 };
 
-block_736 = {
+block_838 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'get_local', idx:0 },
@@ -6455,107 +7228,107 @@ block_736 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_737, num_args:2 },
+    { op:'call', ret_to:@block_839, num_args:2 },
   ]
 };
 
-block_737 = {
+block_839 = {
   instrs: [
-    { op:'call', ret_to:@block_738, num_args:1 },
+    { op:'call', ret_to:@block_840, num_args:1 },
   ]
 };
 
-block_738 = {
+block_840 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_add' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_739, num_args:2 },
+    { op:'call', ret_to:@block_841, num_args:2 },
   ]
 };
 
-block_739 = {
+block_841 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'set_local', idx:1 },
     { op:'pop' },
-    { op:'jump', to:@block_725 },
+    { op:'jump', to:@block_827 },
   ]
 };
 
-block_725 = {
+block_827 = {
   instrs: [
     { op:'push', val:$true },
     { op:'pop' },
-    { op:'jump', to:@block_723 },
+    { op:'jump', to:@block_825 },
   ]
 };
 
-block_726 = {
+block_828 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_740, num_args:2 },
+    { op:'call', ret_to:@block_842, num_args:2 },
   ]
 };
 
-block_740 = {
+block_842 = {
   instrs: [
     { op:'push', val:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_741, num_args:2 },
+    { op:'call', ret_to:@block_843, num_args:2 },
   ]
 };
 
-block_742 = {
+block_844 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'invalid identifier' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseError' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_743, num_args:2 },
+    { op:'call', ret_to:@block_845, num_args:2 },
   ]
 };
 
-block_741 = {
+block_843 = {
   instrs: [
-    { op:'if_true', then:@block_742, else:@block_744 },
+    { op:'if_true', then:@block_844, else:@block_846 },
   ]
 };
 
-block_743 = {
+block_845 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_745 },
+    { op:'jump', to:@block_847 },
   ]
 };
 
-block_744 = {
+block_846 = {
   instrs: [
-    { op:'jump', to:@block_745 },
+    { op:'jump', to:@block_847 },
   ]
 };
 
-block_745 = {
+block_847 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'ret' },
   ]
 };
 
-fun_711 = {
-  entry:@block_710,
+fun_813 = {
+  entry:@block_812,
   num_params:1,
   num_locals:4,
 };
 
-block_746 = {
+block_848 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'(' },
@@ -6564,28 +7337,28 @@ block_746 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_748, num_args:2 },
+    { op:'call', ret_to:@block_850, num_args:2 },
   ]
 };
 
-block_748 = {
+block_850 = {
   instrs: [
-    { op:'call', ret_to:@block_749, num_args:2 },
+    { op:'call', ret_to:@block_851, num_args:2 },
   ]
 };
 
-block_749 = {
+block_851 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_750, num_args:1 },
+    { op:'call', ret_to:@block_852, num_args:1 },
   ]
 };
 
-block_750 = {
+block_852 = {
   instrs: [
     { op:'set_local', idx:1 },
     { op:'get_local', idx:0 },
@@ -6595,28 +7368,28 @@ block_750 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_751, num_args:2 },
+    { op:'call', ret_to:@block_853, num_args:2 },
   ]
 };
 
-block_751 = {
+block_853 = {
   instrs: [
-    { op:'call', ret_to:@block_752, num_args:2 },
+    { op:'call', ret_to:@block_854, num_args:2 },
   ]
 };
 
-block_752 = {
+block_854 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseStmt' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_753, num_args:1 },
+    { op:'call', ret_to:@block_855, num_args:1 },
   ]
 };
 
-block_753 = {
+block_855 = {
   instrs: [
     { op:'set_local', idx:2 },
     { op:'get_local', idx:0 },
@@ -6626,40 +7399,40 @@ block_753 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_754, num_args:2 },
+    { op:'call', ret_to:@block_856, num_args:2 },
   ]
 };
 
-block_754 = {
+block_856 = {
   instrs: [
-    { op:'call', ret_to:@block_755, num_args:2 },
+    { op:'call', ret_to:@block_857, num_args:2 },
   ]
 };
 
-block_756 = {
+block_858 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseStmt' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_757, num_args:1 },
+    { op:'call', ret_to:@block_859, num_args:1 },
   ]
 };
 
-block_755 = {
+block_857 = {
   instrs: [
-    { op:'if_true', then:@block_756, else:@block_758 },
+    { op:'if_true', then:@block_858, else:@block_860 },
   ]
 };
 
-block_757 = {
+block_859 = {
   instrs: [
     { op:'set_local', idx:3 },
-    { op:'jump', to:@block_759 },
+    { op:'jump', to:@block_861 },
   ]
 };
 
-block_758 = {
+block_860 = {
   instrs: [
     { op:'push', val:1 },
     { op:'new_object' },
@@ -6675,11 +7448,11 @@ block_758 = {
     { op:'new_array' },
     { op:'set_field' },
     { op:'set_local', idx:3 },
-    { op:'jump', to:@block_759 },
+    { op:'jump', to:@block_861 },
   ]
 };
 
-block_759 = {
+block_861 = {
   instrs: [
     { op:'push', val:3 },
     { op:'new_object' },
@@ -6705,13 +7478,13 @@ block_759 = {
   ]
 };
 
-fun_747 = {
-  entry:@block_746,
+fun_849 = {
+  entry:@block_848,
   num_params:1,
   num_locals:4,
 };
 
-block_760 = {
+block_862 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'(' },
@@ -6720,17 +7493,17 @@ block_760 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_762, num_args:2 },
+    { op:'call', ret_to:@block_864, num_args:2 },
   ]
 };
 
-block_762 = {
+block_864 = {
   instrs: [
-    { op:'call', ret_to:@block_763, num_args:2 },
+    { op:'call', ret_to:@block_865, num_args:2 },
   ]
 };
 
-block_763 = {
+block_865 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$false },
@@ -6742,33 +7515,33 @@ block_763 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_764, num_args:2 },
+    { op:'call', ret_to:@block_866, num_args:2 },
   ]
 };
 
-block_764 = {
+block_866 = {
   instrs: [
-    { op:'call', ret_to:@block_765, num_args:2 },
+    { op:'call', ret_to:@block_867, num_args:2 },
   ]
 };
 
-block_767 = {
+block_869 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseStmt' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_768, num_args:1 },
+    { op:'call', ret_to:@block_870, num_args:1 },
   ]
 };
 
-block_765 = {
+block_867 = {
   instrs: [
-    { op:'if_true', then:@block_766, else:@block_767 },
+    { op:'if_true', then:@block_868, else:@block_869 },
   ]
 };
 
-block_766 = {
+block_868 = {
   instrs: [
     { op:'push', val:1 },
     { op:'new_object' },
@@ -6796,20 +7569,20 @@ block_766 = {
     { op:'dup', idx:0 },
     { op:'set_local', idx:1 },
     { op:'pop' },
-    { op:'jump', to:@block_769 },
+    { op:'jump', to:@block_871 },
   ]
 };
 
-block_768 = {
+block_870 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'set_local', idx:1 },
     { op:'pop' },
-    { op:'jump', to:@block_769 },
+    { op:'jump', to:@block_871 },
   ]
 };
 
-block_769 = {
+block_871 = {
   instrs: [
     { op:'push', val:$false },
     { op:'set_local', idx:2 },
@@ -6820,27 +7593,27 @@ block_769 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_770, num_args:2 },
+    { op:'call', ret_to:@block_872, num_args:2 },
   ]
 };
 
-block_770 = {
+block_872 = {
   instrs: [
-    { op:'call', ret_to:@block_771, num_args:2 },
+    { op:'call', ret_to:@block_873, num_args:2 },
   ]
 };
 
-block_773 = {
+block_875 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_774, num_args:1 },
+    { op:'call', ret_to:@block_876, num_args:1 },
   ]
 };
 
-block_774 = {
+block_876 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'set_local', idx:2 },
@@ -6852,23 +7625,23 @@ block_774 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_775, num_args:2 },
+    { op:'call', ret_to:@block_877, num_args:2 },
   ]
 };
 
-block_775 = {
+block_877 = {
   instrs: [
-    { op:'call', ret_to:@block_776, num_args:2 },
+    { op:'call', ret_to:@block_878, num_args:2 },
   ]
 };
 
-block_771 = {
+block_873 = {
   instrs: [
-    { op:'if_true', then:@block_772, else:@block_773 },
+    { op:'if_true', then:@block_874, else:@block_875 },
   ]
 };
 
-block_772 = {
+block_874 = {
   instrs: [
     { op:'push', val:1 },
     { op:'new_object' },
@@ -6885,18 +7658,18 @@ block_772 = {
     { op:'dup', idx:0 },
     { op:'set_local', idx:2 },
     { op:'pop' },
-    { op:'jump', to:@block_777 },
+    { op:'jump', to:@block_879 },
   ]
 };
 
-block_776 = {
+block_878 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_777 },
+    { op:'jump', to:@block_879 },
   ]
 };
 
-block_777 = {
+block_879 = {
   instrs: [
     { op:'push', val:$false },
     { op:'set_local', idx:3 },
@@ -6907,27 +7680,27 @@ block_777 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_778, num_args:2 },
+    { op:'call', ret_to:@block_880, num_args:2 },
   ]
 };
 
-block_778 = {
+block_880 = {
   instrs: [
-    { op:'call', ret_to:@block_779, num_args:2 },
+    { op:'call', ret_to:@block_881, num_args:2 },
   ]
 };
 
-block_781 = {
+block_883 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_782, num_args:1 },
+    { op:'call', ret_to:@block_884, num_args:1 },
   ]
 };
 
-block_782 = {
+block_884 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'set_local', idx:3 },
@@ -6939,23 +7712,23 @@ block_782 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_783, num_args:2 },
+    { op:'call', ret_to:@block_885, num_args:2 },
   ]
 };
 
-block_783 = {
+block_885 = {
   instrs: [
-    { op:'call', ret_to:@block_784, num_args:2 },
+    { op:'call', ret_to:@block_886, num_args:2 },
   ]
 };
 
-block_779 = {
+block_881 = {
   instrs: [
-    { op:'if_true', then:@block_780, else:@block_781 },
+    { op:'if_true', then:@block_882, else:@block_883 },
   ]
 };
 
-block_780 = {
+block_882 = {
   instrs: [
     { op:'push', val:1 },
     { op:'new_object' },
@@ -6972,28 +7745,28 @@ block_780 = {
     { op:'dup', idx:0 },
     { op:'set_local', idx:3 },
     { op:'pop' },
-    { op:'jump', to:@block_785 },
+    { op:'jump', to:@block_887 },
   ]
 };
 
-block_784 = {
+block_886 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_785 },
+    { op:'jump', to:@block_887 },
   ]
 };
 
-block_785 = {
+block_887 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseStmt' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_786, num_args:1 },
+    { op:'call', ret_to:@block_888, num_args:1 },
   ]
 };
 
-block_786 = {
+block_888 = {
   instrs: [
     { op:'set_local', idx:4 },
     { op:'push', val:4 },
@@ -7024,31 +7797,31 @@ block_786 = {
   ]
 };
 
-fun_761 = {
-  entry:@block_760,
+fun_863 = {
+  entry:@block_862,
   num_params:1,
   num_locals:5,
 };
 
-block_787 = {
+block_889 = {
   instrs: [
     { op:'push', val:0 },
     { op:'new_array' },
     { op:'set_local', idx:2 },
     { op:'push', val:$true },
     { op:'pop' },
-    { op:'jump', to:@block_789 },
+    { op:'jump', to:@block_891 },
   ]
 };
 
-block_789 = {
+block_891 = {
   instrs: [
     { op:'push', val:$true },
-    { op:'if_true', then:@block_790, else:@block_792 },
+    { op:'if_true', then:@block_892, else:@block_894 },
   ]
 };
 
-block_790 = {
+block_892 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
@@ -7057,45 +7830,45 @@ block_790 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_793, num_args:2 },
+    { op:'call', ret_to:@block_895, num_args:2 },
   ]
 };
 
-block_793 = {
+block_895 = {
   instrs: [
-    { op:'call', ret_to:@block_794, num_args:2 },
+    { op:'call', ret_to:@block_896, num_args:2 },
   ]
 };
 
-block_795 = {
+block_897 = {
   instrs: [
-    { op:'jump', to:@block_792 },
+    { op:'jump', to:@block_894 },
   ]
 };
 
-block_794 = {
+block_896 = {
   instrs: [
-    { op:'if_true', then:@block_795, else:@block_796 },
+    { op:'if_true', then:@block_897, else:@block_898 },
   ]
 };
 
-block_796 = {
+block_898 = {
   instrs: [
-    { op:'jump', to:@block_797 },
+    { op:'jump', to:@block_899 },
   ]
 };
 
-block_797 = {
+block_899 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_798, num_args:1 },
+    { op:'call', ret_to:@block_900, num_args:1 },
   ]
 };
 
-block_798 = {
+block_900 = {
   instrs: [
     { op:'set_local', idx:3 },
     { op:'get_local', idx:2 },
@@ -7105,17 +7878,17 @@ block_798 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_799, num_args:2 },
+    { op:'call', ret_to:@block_901, num_args:2 },
   ]
 };
 
-block_799 = {
+block_901 = {
   instrs: [
-    { op:'call', ret_to:@block_800, num_args:2 },
+    { op:'call', ret_to:@block_902, num_args:2 },
   ]
 };
 
-block_800 = {
+block_902 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -7125,35 +7898,35 @@ block_800 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_801, num_args:2 },
+    { op:'call', ret_to:@block_903, num_args:2 },
   ]
 };
 
-block_801 = {
+block_903 = {
   instrs: [
-    { op:'call', ret_to:@block_802, num_args:2 },
+    { op:'call', ret_to:@block_904, num_args:2 },
   ]
 };
 
-block_803 = {
+block_905 = {
   instrs: [
-    { op:'jump', to:@block_792 },
+    { op:'jump', to:@block_894 },
   ]
 };
 
-block_802 = {
+block_904 = {
   instrs: [
-    { op:'if_true', then:@block_803, else:@block_804 },
+    { op:'if_true', then:@block_905, else:@block_906 },
   ]
 };
 
-block_804 = {
+block_906 = {
   instrs: [
-    { op:'jump', to:@block_805 },
+    { op:'jump', to:@block_907 },
   ]
 };
 
-block_805 = {
+block_907 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:',' },
@@ -7162,45 +7935,45 @@ block_805 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_806, num_args:2 },
+    { op:'call', ret_to:@block_908, num_args:2 },
   ]
 };
 
-block_806 = {
+block_908 = {
   instrs: [
-    { op:'call', ret_to:@block_807, num_args:2 },
+    { op:'call', ret_to:@block_909, num_args:2 },
   ]
 };
 
-block_807 = {
+block_909 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_791 },
+    { op:'jump', to:@block_893 },
   ]
 };
 
-block_791 = {
+block_893 = {
   instrs: [
     { op:'push', val:$true },
     { op:'pop' },
-    { op:'jump', to:@block_789 },
+    { op:'jump', to:@block_891 },
   ]
 };
 
-block_792 = {
+block_894 = {
   instrs: [
     { op:'get_local', idx:2 },
     { op:'ret' },
   ]
 };
 
-fun_788 = {
-  entry:@block_787,
+fun_890 = {
+  entry:@block_889,
   num_params:2,
   num_locals:4,
 };
 
-block_808 = {
+block_910 = {
   instrs: [
     { op:'push', val:0 },
     { op:'new_array' },
@@ -7210,18 +7983,18 @@ block_808 = {
     { op:'set_local', idx:2 },
     { op:'push', val:$true },
     { op:'pop' },
-    { op:'jump', to:@block_810 },
+    { op:'jump', to:@block_912 },
   ]
 };
 
-block_810 = {
+block_912 = {
   instrs: [
     { op:'push', val:$true },
-    { op:'if_true', then:@block_811, else:@block_813 },
+    { op:'if_true', then:@block_913, else:@block_915 },
   ]
 };
 
-block_811 = {
+block_913 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'}' },
@@ -7230,45 +8003,45 @@ block_811 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_814, num_args:2 },
+    { op:'call', ret_to:@block_916, num_args:2 },
   ]
 };
 
-block_814 = {
+block_916 = {
   instrs: [
-    { op:'call', ret_to:@block_815, num_args:2 },
+    { op:'call', ret_to:@block_917, num_args:2 },
   ]
 };
 
-block_816 = {
+block_918 = {
   instrs: [
-    { op:'jump', to:@block_813 },
+    { op:'jump', to:@block_915 },
   ]
 };
 
-block_815 = {
+block_917 = {
   instrs: [
-    { op:'if_true', then:@block_816, else:@block_817 },
+    { op:'if_true', then:@block_918, else:@block_919 },
   ]
 };
 
-block_817 = {
+block_919 = {
   instrs: [
-    { op:'jump', to:@block_818 },
+    { op:'jump', to:@block_920 },
   ]
 };
 
-block_818 = {
+block_920 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseIdentStr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_819, num_args:1 },
+    { op:'call', ret_to:@block_921, num_args:1 },
   ]
 };
 
-block_819 = {
+block_921 = {
   instrs: [
     { op:'set_local', idx:3 },
     { op:'get_local', idx:0 },
@@ -7278,28 +8051,28 @@ block_819 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_820, num_args:2 },
+    { op:'call', ret_to:@block_922, num_args:2 },
   ]
 };
 
-block_820 = {
+block_922 = {
   instrs: [
-    { op:'call', ret_to:@block_821, num_args:2 },
+    { op:'call', ret_to:@block_923, num_args:2 },
   ]
 };
 
-block_821 = {
+block_923 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_822, num_args:1 },
+    { op:'call', ret_to:@block_924, num_args:1 },
   ]
 };
 
-block_822 = {
+block_924 = {
   instrs: [
     { op:'set_local', idx:4 },
     { op:'get_local', idx:1 },
@@ -7309,17 +8082,17 @@ block_822 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_823, num_args:2 },
+    { op:'call', ret_to:@block_925, num_args:2 },
   ]
 };
 
-block_823 = {
+block_925 = {
   instrs: [
-    { op:'call', ret_to:@block_824, num_args:2 },
+    { op:'call', ret_to:@block_926, num_args:2 },
   ]
 };
 
-block_824 = {
+block_926 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:2 },
@@ -7329,17 +8102,17 @@ block_824 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_825, num_args:2 },
+    { op:'call', ret_to:@block_927, num_args:2 },
   ]
 };
 
-block_825 = {
+block_927 = {
   instrs: [
-    { op:'call', ret_to:@block_826, num_args:2 },
+    { op:'call', ret_to:@block_928, num_args:2 },
   ]
 };
 
-block_826 = {
+block_928 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -7349,35 +8122,35 @@ block_826 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_827, num_args:2 },
+    { op:'call', ret_to:@block_929, num_args:2 },
   ]
 };
 
-block_827 = {
+block_929 = {
   instrs: [
-    { op:'call', ret_to:@block_828, num_args:2 },
+    { op:'call', ret_to:@block_930, num_args:2 },
   ]
 };
 
-block_829 = {
+block_931 = {
   instrs: [
-    { op:'jump', to:@block_813 },
+    { op:'jump', to:@block_915 },
   ]
 };
 
-block_828 = {
+block_930 = {
   instrs: [
-    { op:'if_true', then:@block_829, else:@block_830 },
+    { op:'if_true', then:@block_931, else:@block_932 },
   ]
 };
 
-block_830 = {
+block_932 = {
   instrs: [
-    { op:'jump', to:@block_831 },
+    { op:'jump', to:@block_933 },
   ]
 };
 
-block_831 = {
+block_933 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:',' },
@@ -7386,32 +8159,32 @@ block_831 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_832, num_args:2 },
+    { op:'call', ret_to:@block_934, num_args:2 },
   ]
 };
 
-block_832 = {
+block_934 = {
   instrs: [
-    { op:'call', ret_to:@block_833, num_args:2 },
+    { op:'call', ret_to:@block_935, num_args:2 },
   ]
 };
 
-block_833 = {
+block_935 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_812 },
+    { op:'jump', to:@block_914 },
   ]
 };
 
-block_812 = {
+block_914 = {
   instrs: [
     { op:'push', val:$true },
     { op:'pop' },
-    { op:'jump', to:@block_810 },
+    { op:'jump', to:@block_912 },
   ]
 };
 
-block_813 = {
+block_915 = {
   instrs: [
     { op:'push', val:2 },
     { op:'new_object' },
@@ -7433,13 +8206,13 @@ block_813 = {
   ]
 };
 
-fun_809 = {
-  entry:@block_808,
+fun_911 = {
+  entry:@block_910,
   num_params:1,
   num_locals:5,
 };
 
-block_834 = {
+block_936 = {
   instrs: [
     { op:'push', val:'' },
     { op:'set_local', idx:1 },
@@ -7450,57 +8223,57 @@ block_834 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_836, num_args:2 },
+    { op:'call', ret_to:@block_938, num_args:2 },
   ]
 };
 
-block_836 = {
+block_938 = {
   instrs: [
-    { op:'call', ret_to:@block_837, num_args:2 },
+    { op:'call', ret_to:@block_939, num_args:2 },
   ]
 };
 
-block_837 = {
+block_939 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_not' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_838, num_args:1 },
+    { op:'call', ret_to:@block_940, num_args:1 },
   ]
 };
 
-block_839 = {
+block_941 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseIdentStr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_840, num_args:1 },
+    { op:'call', ret_to:@block_942, num_args:1 },
   ]
 };
 
-block_838 = {
+block_940 = {
   instrs: [
-    { op:'if_true', then:@block_839, else:@block_841 },
+    { op:'if_true', then:@block_941, else:@block_943 },
   ]
 };
 
-block_840 = {
+block_942 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'set_local', idx:1 },
     { op:'pop' },
-    { op:'jump', to:@block_842 },
+    { op:'jump', to:@block_944 },
   ]
 };
 
-block_841 = {
+block_943 = {
   instrs: [
-    { op:'jump', to:@block_842 },
+    { op:'jump', to:@block_944 },
   ]
 };
 
-block_842 = {
+block_944 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'(' },
@@ -7509,17 +8282,17 @@ block_842 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_843, num_args:2 },
+    { op:'call', ret_to:@block_945, num_args:2 },
   ]
 };
 
-block_843 = {
+block_945 = {
   instrs: [
-    { op:'call', ret_to:@block_844, num_args:2 },
+    { op:'call', ret_to:@block_946, num_args:2 },
   ]
 };
 
-block_844 = {
+block_946 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:0 },
@@ -7527,18 +8300,18 @@ block_844 = {
     { op:'set_local', idx:2 },
     { op:'push', val:$true },
     { op:'pop' },
-    { op:'jump', to:@block_845 },
+    { op:'jump', to:@block_947 },
   ]
 };
 
-block_845 = {
+block_947 = {
   instrs: [
     { op:'push', val:$true },
-    { op:'if_true', then:@block_846, else:@block_848 },
+    { op:'if_true', then:@block_948, else:@block_950 },
   ]
 };
 
-block_846 = {
+block_948 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:')' },
@@ -7547,45 +8320,45 @@ block_846 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_849, num_args:2 },
+    { op:'call', ret_to:@block_951, num_args:2 },
   ]
 };
 
-block_849 = {
+block_951 = {
   instrs: [
-    { op:'call', ret_to:@block_850, num_args:2 },
+    { op:'call', ret_to:@block_952, num_args:2 },
   ]
 };
 
-block_851 = {
+block_953 = {
   instrs: [
-    { op:'jump', to:@block_848 },
+    { op:'jump', to:@block_950 },
   ]
 };
 
-block_850 = {
+block_952 = {
   instrs: [
-    { op:'if_true', then:@block_851, else:@block_852 },
+    { op:'if_true', then:@block_953, else:@block_954 },
   ]
 };
 
-block_852 = {
+block_954 = {
   instrs: [
-    { op:'jump', to:@block_853 },
+    { op:'jump', to:@block_955 },
   ]
 };
 
-block_853 = {
+block_955 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseIdentStr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_854, num_args:1 },
+    { op:'call', ret_to:@block_956, num_args:1 },
   ]
 };
 
-block_854 = {
+block_956 = {
   instrs: [
     { op:'set_local', idx:3 },
     { op:'get_local', idx:2 },
@@ -7595,17 +8368,17 @@ block_854 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_855, num_args:2 },
+    { op:'call', ret_to:@block_957, num_args:2 },
   ]
 };
 
-block_855 = {
+block_957 = {
   instrs: [
-    { op:'call', ret_to:@block_856, num_args:2 },
+    { op:'call', ret_to:@block_958, num_args:2 },
   ]
 };
 
-block_856 = {
+block_958 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -7615,35 +8388,35 @@ block_856 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_857, num_args:2 },
+    { op:'call', ret_to:@block_959, num_args:2 },
   ]
 };
 
-block_857 = {
+block_959 = {
   instrs: [
-    { op:'call', ret_to:@block_858, num_args:2 },
+    { op:'call', ret_to:@block_960, num_args:2 },
   ]
 };
 
-block_859 = {
+block_961 = {
   instrs: [
-    { op:'jump', to:@block_848 },
+    { op:'jump', to:@block_950 },
   ]
 };
 
-block_858 = {
+block_960 = {
   instrs: [
-    { op:'if_true', then:@block_859, else:@block_860 },
+    { op:'if_true', then:@block_961, else:@block_962 },
   ]
 };
 
-block_860 = {
+block_962 = {
   instrs: [
-    { op:'jump', to:@block_861 },
+    { op:'jump', to:@block_963 },
   ]
 };
 
-block_861 = {
+block_963 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:',' },
@@ -7652,32 +8425,32 @@ block_861 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_862, num_args:2 },
+    { op:'call', ret_to:@block_964, num_args:2 },
   ]
 };
 
-block_862 = {
+block_964 = {
   instrs: [
-    { op:'call', ret_to:@block_863, num_args:2 },
+    { op:'call', ret_to:@block_965, num_args:2 },
   ]
 };
 
-block_863 = {
+block_965 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_847 },
+    { op:'jump', to:@block_949 },
   ]
 };
 
-block_847 = {
+block_949 = {
   instrs: [
     { op:'push', val:$true },
     { op:'pop' },
-    { op:'jump', to:@block_845 },
+    { op:'jump', to:@block_947 },
   ]
 };
 
-block_848 = {
+block_950 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'{' },
@@ -7686,17 +8459,17 @@ block_848 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_864, num_args:2 },
+    { op:'call', ret_to:@block_966, num_args:2 },
   ]
 };
 
-block_864 = {
+block_966 = {
   instrs: [
-    { op:'call', ret_to:@block_865, num_args:2 },
+    { op:'call', ret_to:@block_967, num_args:2 },
   ]
 };
 
-block_865 = {
+block_967 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -7704,11 +8477,11 @@ block_865 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'parseBlockStmt' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_866, num_args:2 },
+    { op:'call', ret_to:@block_968, num_args:2 },
   ]
 };
 
-block_866 = {
+block_968 = {
   instrs: [
     { op:'set_local', idx:4 },
     { op:'push', val:3 },
@@ -7735,13 +8508,13 @@ block_866 = {
   ]
 };
 
-fun_835 = {
-  entry:@block_834,
+fun_937 = {
+  entry:@block_936,
   num_params:1,
   num_locals:5,
 };
 
-block_867 = {
+block_969 = {
   instrs: [
     { op:'push', val:$false },
     { op:'set_local', idx:3 },
@@ -7749,11 +8522,11 @@ block_867 = {
     { op:'set_local', idx:4 },
     { op:'push', val:0 },
     { op:'set_local', idx:5 },
-    { op:'jump', to:@block_869 },
+    { op:'jump', to:@block_971 },
   ]
 };
 
-block_869 = {
+block_971 = {
   instrs: [
     { op:'get_local', idx:5 },
     { op:'push', val:@global_obj },
@@ -7763,18 +8536,26 @@ block_869 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_873, num_args:2 },
+    { op:'call', ret_to:@block_975, num_args:2 },
   ]
 };
 
-block_873 = {
+block_975 = {
   instrs: [
-    { op:'lt_i32' },
-    { op:'if_true', then:@block_870, else:@block_872 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_lt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_976, num_args:2 },
   ]
 };
 
-block_870 = {
+block_976 = {
+  instrs: [
+    { op:'if_true', then:@block_972, else:@block_974 },
+  ]
+};
+
+block_972 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'opList' },
@@ -7783,11 +8564,11 @@ block_870 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getElem' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_874, num_args:2 },
+    { op:'call', ret_to:@block_977, num_args:2 },
   ]
 };
 
-block_874 = {
+block_977 = {
   instrs: [
     { op:'set_local', idx:6 },
     { op:'get_local', idx:0 },
@@ -7796,84 +8577,92 @@ block_874 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_875, num_args:2 },
+    { op:'call', ret_to:@block_978, num_args:2 },
   ]
 };
 
-block_875 = {
+block_978 = {
   instrs: [
     { op:'dup', idx:1 },
     { op:'push', val:'next' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_876, num_args:2 },
+    { op:'call', ret_to:@block_979, num_args:2 },
   ]
 };
 
-block_876 = {
+block_979 = {
   instrs: [
-    { op:'call', ret_to:@block_877, num_args:2 },
+    { op:'call', ret_to:@block_980, num_args:2 },
   ]
 };
 
-block_877 = {
+block_980 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_not' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_878, num_args:1 },
+    { op:'call', ret_to:@block_981, num_args:1 },
   ]
 };
 
-block_879 = {
+block_982 = {
   instrs: [
-    { op:'jump', to:@block_871 },
+    { op:'jump', to:@block_973 },
   ]
 };
 
-block_878 = {
+block_981 = {
   instrs: [
-    { op:'if_true', then:@block_879, else:@block_880 },
+    { op:'if_true', then:@block_982, else:@block_983 },
   ]
 };
 
-block_880 = {
+block_983 = {
   instrs: [
-    { op:'jump', to:@block_881 },
+    { op:'jump', to:@block_984 },
   ]
 };
 
-block_881 = {
+block_984 = {
   instrs: [
     { op:'get_local', idx:6 },
     { op:'push', val:'prec' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_888, num_args:2 },
+    { op:'call', ret_to:@block_991, num_args:2 },
   ]
 };
 
-block_888 = {
+block_991 = {
   instrs: [
     { op:'get_local', idx:1 },
-    { op:'lt_i32' },
-    { op:'dup', idx:0 },
-    { op:'if_true', then:@block_887, else:@block_886 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_lt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_992, num_args:2 },
   ]
 };
 
-block_886 = {
+block_992 = {
+  instrs: [
+    { op:'dup', idx:0 },
+    { op:'if_true', then:@block_990, else:@block_989 },
+  ]
+};
+
+block_989 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:2 },
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_889, else:@block_890 },
+    { op:'if_true', then:@block_993, else:@block_994 },
   ]
 };
 
-block_889 = {
+block_993 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:6 },
@@ -7881,58 +8670,58 @@ block_889 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_891, num_args:2 },
+    { op:'call', ret_to:@block_995, num_args:2 },
   ]
 };
 
-block_891 = {
+block_995 = {
   instrs: [
     { op:'push', val:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_ne' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_892, num_args:2 },
+    { op:'call', ret_to:@block_996, num_args:2 },
   ]
 };
 
-block_892 = {
+block_996 = {
   instrs: [
-    { op:'jump', to:@block_890 },
+    { op:'jump', to:@block_994 },
   ]
 };
 
-block_890 = {
+block_994 = {
   instrs: [
-    { op:'jump', to:@block_887 },
+    { op:'jump', to:@block_990 },
   ]
 };
 
-block_887 = {
+block_990 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_885, else:@block_884 },
+    { op:'if_true', then:@block_988, else:@block_987 },
   ]
 };
 
-block_884 = {
+block_987 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:2 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_not' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_895, num_args:1 },
+    { op:'call', ret_to:@block_999, num_args:1 },
   ]
 };
 
-block_895 = {
+block_999 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_893, else:@block_894 },
+    { op:'if_true', then:@block_997, else:@block_998 },
   ]
 };
 
-block_893 = {
+block_997 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:6 },
@@ -7940,49 +8729,49 @@ block_893 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_896, num_args:2 },
+    { op:'call', ret_to:@block_1000, num_args:2 },
   ]
 };
 
-block_896 = {
+block_1000 = {
   instrs: [
     { op:'push', val:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_897, num_args:2 },
+    { op:'call', ret_to:@block_1001, num_args:2 },
   ]
 };
 
-block_897 = {
+block_1001 = {
   instrs: [
-    { op:'jump', to:@block_894 },
+    { op:'jump', to:@block_998 },
   ]
 };
 
-block_894 = {
+block_998 = {
   instrs: [
-    { op:'jump', to:@block_885 },
+    { op:'jump', to:@block_988 },
   ]
 };
 
-block_885 = {
+block_988 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_883, else:@block_882 },
+    { op:'if_true', then:@block_986, else:@block_985 },
   ]
 };
 
-block_882 = {
+block_985 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:2 },
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_898, else:@block_899 },
+    { op:'if_true', then:@block_1002, else:@block_1003 },
   ]
 };
 
-block_898 = {
+block_1002 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:6 },
@@ -7990,82 +8779,90 @@ block_898 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_900, num_args:2 },
+    { op:'call', ret_to:@block_1004, num_args:2 },
   ]
 };
 
-block_900 = {
+block_1004 = {
   instrs: [
     { op:'push', val:'r' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_ne' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_901, num_args:2 },
+    { op:'call', ret_to:@block_1005, num_args:2 },
   ]
 };
 
-block_901 = {
+block_1005 = {
   instrs: [
-    { op:'jump', to:@block_899 },
+    { op:'jump', to:@block_1003 },
   ]
 };
 
-block_899 = {
+block_1003 = {
   instrs: [
-    { op:'jump', to:@block_883 },
+    { op:'jump', to:@block_986 },
   ]
 };
 
-block_902 = {
+block_1006 = {
   instrs: [
-    { op:'jump', to:@block_871 },
+    { op:'jump', to:@block_973 },
   ]
 };
 
-block_883 = {
+block_986 = {
   instrs: [
-    { op:'if_true', then:@block_902, else:@block_903 },
+    { op:'if_true', then:@block_1006, else:@block_1007 },
   ]
 };
 
-block_903 = {
+block_1007 = {
   instrs: [
-    { op:'jump', to:@block_904 },
+    { op:'jump', to:@block_1008 },
   ]
 };
 
-block_904 = {
+block_1008 = {
   instrs: [
     { op:'get_local', idx:6 },
     { op:'push', val:'str' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_905, num_args:2 },
+    { op:'call', ret_to:@block_1009, num_args:2 },
   ]
 };
 
-block_905 = {
+block_1009 = {
   instrs: [
     { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_906, num_args:2 },
+    { op:'call', ret_to:@block_1010, num_args:2 },
   ]
 };
 
-block_906 = {
+block_1010 = {
   instrs: [
     { op:'set_local', idx:7 },
     { op:'get_local', idx:7 },
     { op:'get_local', idx:4 },
-    { op:'gt_i32' },
-    { op:'if_true', then:@block_907, else:@block_908 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_gt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1011, num_args:2 },
   ]
 };
 
-block_907 = {
+block_1011 = {
+  instrs: [
+    { op:'if_true', then:@block_1012, else:@block_1013 },
+  ]
+};
+
+block_1012 = {
   instrs: [
     { op:'get_local', idx:6 },
     { op:'dup', idx:0 },
@@ -8075,73 +8872,73 @@ block_907 = {
     { op:'dup', idx:0 },
     { op:'set_local', idx:4 },
     { op:'pop' },
-    { op:'jump', to:@block_909 },
+    { op:'jump', to:@block_1014 },
   ]
 };
 
-block_908 = {
+block_1013 = {
   instrs: [
-    { op:'jump', to:@block_909 },
+    { op:'jump', to:@block_1014 },
   ]
 };
 
-block_909 = {
+block_1014 = {
   instrs: [
-    { op:'jump', to:@block_871 },
+    { op:'jump', to:@block_973 },
   ]
 };
 
-block_871 = {
+block_973 = {
   instrs: [
     { op:'get_local', idx:5 },
     { op:'push', val:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_add' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_910, num_args:2 },
+    { op:'call', ret_to:@block_1015, num_args:2 },
   ]
 };
 
-block_910 = {
+block_1015 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'set_local', idx:5 },
     { op:'pop' },
-    { op:'jump', to:@block_869 },
+    { op:'jump', to:@block_971 },
   ]
 };
 
-block_872 = {
+block_974 = {
   instrs: [
     { op:'get_local', idx:3 },
     { op:'push', val:$false },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_911, num_args:2 },
+    { op:'call', ret_to:@block_1016, num_args:2 },
   ]
 };
 
-block_912 = {
+block_1017 = {
   instrs: [
     { op:'push', val:$false },
     { op:'ret' },
   ]
 };
 
-block_911 = {
+block_1016 = {
   instrs: [
-    { op:'if_true', then:@block_912, else:@block_913 },
+    { op:'if_true', then:@block_1017, else:@block_1018 },
   ]
 };
 
-block_913 = {
+block_1018 = {
   instrs: [
-    { op:'jump', to:@block_914 },
+    { op:'jump', to:@block_1019 },
   ]
 };
 
-block_914 = {
+block_1019 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:3 },
@@ -8149,28 +8946,28 @@ block_914 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_915, num_args:2 },
+    { op:'call', ret_to:@block_1020, num_args:2 },
   ]
 };
 
-block_915 = {
+block_1020 = {
   instrs: [
     { op:'dup', idx:1 },
     { op:'push', val:'expect' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_916, num_args:2 },
+    { op:'call', ret_to:@block_1021, num_args:2 },
   ]
 };
 
-block_916 = {
+block_1021 = {
   instrs: [
-    { op:'call', ret_to:@block_917, num_args:2 },
+    { op:'call', ret_to:@block_1022, num_args:2 },
   ]
 };
 
-block_917 = {
+block_1022 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:3 },
@@ -8178,13 +8975,13 @@ block_917 = {
   ]
 };
 
-fun_868 = {
-  entry:@block_867,
+fun_970 = {
+  entry:@block_969,
   num_params:3,
   num_locals:8,
 };
 
-block_918 = {
+block_1023 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'dup', idx:0 },
@@ -8192,17 +8989,17 @@ block_918 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_920, num_args:2 },
+    { op:'call', ret_to:@block_1025, num_args:2 },
   ]
 };
 
-block_920 = {
+block_1025 = {
   instrs: [
-    { op:'call', ret_to:@block_921, num_args:1 },
+    { op:'call', ret_to:@block_1026, num_args:1 },
   ]
 };
 
-block_921 = {
+block_1026 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -8211,55 +9008,55 @@ block_921 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_922, num_args:2 },
+    { op:'call', ret_to:@block_1027, num_args:2 },
   ]
 };
 
-block_922 = {
+block_1027 = {
   instrs: [
-    { op:'call', ret_to:@block_923, num_args:1 },
+    { op:'call', ret_to:@block_1028, num_args:1 },
   ]
 };
 
-block_923 = {
+block_1028 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'isDigit' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_924, num_args:1 },
+    { op:'call', ret_to:@block_1029, num_args:1 },
   ]
 };
 
-block_925 = {
+block_1030 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:$false },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseInt' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_926, num_args:2 },
+    { op:'call', ret_to:@block_1031, num_args:2 },
   ]
 };
 
-block_926 = {
+block_1031 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-block_924 = {
+block_1029 = {
   instrs: [
-    { op:'if_true', then:@block_925, else:@block_927 },
+    { op:'if_true', then:@block_1030, else:@block_1032 },
   ]
 };
 
-block_927 = {
+block_1032 = {
   instrs: [
-    { op:'jump', to:@block_928 },
+    { op:'jump', to:@block_1033 },
   ]
 };
 
-block_928 = {
+block_1033 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'\'' },
@@ -8268,46 +9065,46 @@ block_928 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_929, num_args:2 },
+    { op:'call', ret_to:@block_1034, num_args:2 },
   ]
 };
 
-block_929 = {
+block_1034 = {
   instrs: [
-    { op:'call', ret_to:@block_930, num_args:2 },
+    { op:'call', ret_to:@block_1035, num_args:2 },
   ]
 };
 
-block_931 = {
+block_1036 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'\'' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseStringLit' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_932, num_args:2 },
+    { op:'call', ret_to:@block_1037, num_args:2 },
   ]
 };
 
-block_932 = {
+block_1037 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-block_930 = {
+block_1035 = {
   instrs: [
-    { op:'if_true', then:@block_931, else:@block_933 },
+    { op:'if_true', then:@block_1036, else:@block_1038 },
   ]
 };
 
-block_933 = {
+block_1038 = {
   instrs: [
-    { op:'jump', to:@block_934 },
+    { op:'jump', to:@block_1039 },
   ]
 };
 
-block_934 = {
+block_1039 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'\"' },
@@ -8316,46 +9113,46 @@ block_934 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_935, num_args:2 },
+    { op:'call', ret_to:@block_1040, num_args:2 },
   ]
 };
 
-block_935 = {
+block_1040 = {
   instrs: [
-    { op:'call', ret_to:@block_936, num_args:2 },
+    { op:'call', ret_to:@block_1041, num_args:2 },
   ]
 };
 
-block_937 = {
+block_1042 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'\"' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseStringLit' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_938, num_args:2 },
+    { op:'call', ret_to:@block_1043, num_args:2 },
   ]
 };
 
-block_938 = {
+block_1043 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-block_936 = {
+block_1041 = {
   instrs: [
-    { op:'if_true', then:@block_937, else:@block_939 },
+    { op:'if_true', then:@block_1042, else:@block_1044 },
   ]
 };
 
-block_939 = {
+block_1044 = {
   instrs: [
-    { op:'jump', to:@block_940 },
+    { op:'jump', to:@block_1045 },
   ]
 };
 
-block_940 = {
+block_1045 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'[' },
@@ -8364,17 +9161,17 @@ block_940 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_941, num_args:2 },
+    { op:'call', ret_to:@block_1046, num_args:2 },
   ]
 };
 
-block_941 = {
+block_1046 = {
   instrs: [
-    { op:'call', ret_to:@block_942, num_args:2 },
+    { op:'call', ret_to:@block_1047, num_args:2 },
   ]
 };
 
-block_943 = {
+block_1048 = {
   instrs: [
     { op:'push', val:1 },
     { op:'new_object' },
@@ -8391,30 +9188,30 @@ block_943 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExprList' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_944, num_args:2 },
+    { op:'call', ret_to:@block_1049, num_args:2 },
   ]
 };
 
-block_944 = {
+block_1049 = {
   instrs: [
     { op:'set_field' },
     { op:'ret' },
   ]
 };
 
-block_942 = {
+block_1047 = {
   instrs: [
-    { op:'if_true', then:@block_943, else:@block_945 },
+    { op:'if_true', then:@block_1048, else:@block_1050 },
   ]
 };
 
-block_945 = {
+block_1050 = {
   instrs: [
-    { op:'jump', to:@block_946 },
+    { op:'jump', to:@block_1051 },
   ]
 };
 
-block_946 = {
+block_1051 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'{' },
@@ -8423,45 +9220,45 @@ block_946 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_947, num_args:2 },
+    { op:'call', ret_to:@block_1052, num_args:2 },
   ]
 };
 
-block_947 = {
+block_1052 = {
   instrs: [
-    { op:'call', ret_to:@block_948, num_args:2 },
+    { op:'call', ret_to:@block_1053, num_args:2 },
   ]
 };
 
-block_949 = {
+block_1054 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseObjExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_950, num_args:1 },
+    { op:'call', ret_to:@block_1055, num_args:1 },
   ]
 };
 
-block_950 = {
+block_1055 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-block_948 = {
+block_1053 = {
   instrs: [
-    { op:'if_true', then:@block_949, else:@block_951 },
+    { op:'if_true', then:@block_1054, else:@block_1056 },
   ]
 };
 
-block_951 = {
+block_1056 = {
   instrs: [
-    { op:'jump', to:@block_952 },
+    { op:'jump', to:@block_1057 },
   ]
 };
 
-block_952 = {
+block_1057 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'(' },
@@ -8470,27 +9267,27 @@ block_952 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_953, num_args:2 },
+    { op:'call', ret_to:@block_1058, num_args:2 },
   ]
 };
 
-block_953 = {
+block_1058 = {
   instrs: [
-    { op:'call', ret_to:@block_954, num_args:2 },
+    { op:'call', ret_to:@block_1059, num_args:2 },
   ]
 };
 
-block_955 = {
+block_1060 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_956, num_args:1 },
+    { op:'call', ret_to:@block_1061, num_args:1 },
   ]
 };
 
-block_956 = {
+block_1061 = {
   instrs: [
     { op:'set_local', idx:1 },
     { op:'get_local', idx:0 },
@@ -8500,17 +9297,17 @@ block_956 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_957, num_args:2 },
+    { op:'call', ret_to:@block_1062, num_args:2 },
   ]
 };
 
-block_957 = {
+block_1062 = {
   instrs: [
-    { op:'call', ret_to:@block_958, num_args:2 },
+    { op:'call', ret_to:@block_1063, num_args:2 },
   ]
 };
 
-block_958 = {
+block_1063 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:1 },
@@ -8518,19 +9315,19 @@ block_958 = {
   ]
 };
 
-block_954 = {
+block_1059 = {
   instrs: [
-    { op:'if_true', then:@block_955, else:@block_959 },
+    { op:'if_true', then:@block_1060, else:@block_1064 },
   ]
 };
 
-block_959 = {
+block_1064 = {
   instrs: [
-    { op:'jump', to:@block_960 },
+    { op:'jump', to:@block_1065 },
   ]
 };
 
-block_960 = {
+block_1065 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:0 },
@@ -8538,11 +9335,11 @@ block_960 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'matchOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_961, num_args:3 },
+    { op:'call', ret_to:@block_1066, num_args:3 },
   ]
 };
 
-block_961 = {
+block_1066 = {
   instrs: [
     { op:'set_local', idx:2 },
     { op:'get_local', idx:2 },
@@ -8550,11 +9347,11 @@ block_961 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_ne' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_962, num_args:2 },
+    { op:'call', ret_to:@block_1067, num_args:2 },
   ]
 };
 
-block_963 = {
+block_1068 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:2 },
@@ -8562,20 +9359,20 @@ block_963 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_964, num_args:2 },
+    { op:'call', ret_to:@block_1069, num_args:2 },
   ]
 };
 
-block_964 = {
+block_1069 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExprPrec' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_965, num_args:2 },
+    { op:'call', ret_to:@block_1070, num_args:2 },
   ]
 };
 
-block_965 = {
+block_1070 = {
   instrs: [
     { op:'set_local', idx:1 },
     { op:'push', val:2 },
@@ -8598,19 +9395,19 @@ block_965 = {
   ]
 };
 
-block_962 = {
+block_1067 = {
   instrs: [
-    { op:'if_true', then:@block_963, else:@block_966 },
+    { op:'if_true', then:@block_1068, else:@block_1071 },
   ]
 };
 
-block_966 = {
+block_1071 = {
   instrs: [
-    { op:'jump', to:@block_967 },
+    { op:'jump', to:@block_1072 },
   ]
 };
 
-block_967 = {
+block_1072 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'dup', idx:0 },
@@ -8618,26 +9415,26 @@ block_967 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_968, num_args:2 },
+    { op:'call', ret_to:@block_1073, num_args:2 },
   ]
 };
 
-block_968 = {
+block_1073 = {
   instrs: [
-    { op:'call', ret_to:@block_969, num_args:1 },
+    { op:'call', ret_to:@block_1074, num_args:1 },
   ]
 };
 
-block_969 = {
+block_1074 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'isAlnum' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_970, num_args:1 },
+    { op:'call', ret_to:@block_1075, num_args:1 },
   ]
 };
 
-block_971 = {
+block_1076 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'function' },
@@ -8646,45 +9443,45 @@ block_971 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_972, num_args:2 },
+    { op:'call', ret_to:@block_1077, num_args:2 },
   ]
 };
 
-block_972 = {
+block_1077 = {
   instrs: [
-    { op:'call', ret_to:@block_973, num_args:2 },
+    { op:'call', ret_to:@block_1078, num_args:2 },
   ]
 };
 
-block_974 = {
+block_1079 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseFunExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_975, num_args:1 },
+    { op:'call', ret_to:@block_1080, num_args:1 },
   ]
 };
 
-block_975 = {
+block_1080 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-block_973 = {
+block_1078 = {
   instrs: [
-    { op:'if_true', then:@block_974, else:@block_976 },
+    { op:'if_true', then:@block_1079, else:@block_1081 },
   ]
 };
 
-block_976 = {
+block_1081 = {
   instrs: [
-    { op:'jump', to:@block_977 },
+    { op:'jump', to:@block_1082 },
   ]
 };
 
-block_977 = {
+block_1082 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'import' },
@@ -8693,27 +9490,27 @@ block_977 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_978, num_args:2 },
+    { op:'call', ret_to:@block_1083, num_args:2 },
   ]
 };
 
-block_978 = {
+block_1083 = {
   instrs: [
-    { op:'call', ret_to:@block_979, num_args:2 },
+    { op:'call', ret_to:@block_1084, num_args:2 },
   ]
 };
 
-block_980 = {
+block_1085 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseAtom' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_981, num_args:1 },
+    { op:'call', ret_to:@block_1086, num_args:1 },
   ]
 };
 
-block_981 = {
+block_1086 = {
   instrs: [
     { op:'set_local', idx:3 },
     { op:'push', val:'val' },
@@ -8721,50 +9518,50 @@ block_981 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_in' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_982, num_args:2 },
+    { op:'call', ret_to:@block_1087, num_args:2 },
   ]
 };
 
-block_982 = {
+block_1087 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_not' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_983, num_args:1 },
+    { op:'call', ret_to:@block_1088, num_args:1 },
   ]
 };
 
-block_984 = {
+block_1089 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'invalid package name expression' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseError' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_985, num_args:2 },
+    { op:'call', ret_to:@block_1090, num_args:2 },
   ]
 };
 
-block_983 = {
+block_1088 = {
   instrs: [
-    { op:'if_true', then:@block_984, else:@block_986 },
+    { op:'if_true', then:@block_1089, else:@block_1091 },
   ]
 };
 
-block_985 = {
+block_1090 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_987 },
+    { op:'jump', to:@block_1092 },
   ]
 };
 
-block_986 = {
+block_1091 = {
   instrs: [
-    { op:'jump', to:@block_987 },
+    { op:'jump', to:@block_1092 },
   ]
 };
 
-block_987 = {
+block_1092 = {
   instrs: [
     { op:'push', val:1 },
     { op:'new_object' },
@@ -8781,30 +9578,30 @@ block_987 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_988, num_args:2 },
+    { op:'call', ret_to:@block_1093, num_args:2 },
   ]
 };
 
-block_988 = {
+block_1093 = {
   instrs: [
     { op:'set_field' },
     { op:'ret' },
   ]
 };
 
-block_979 = {
+block_1084 = {
   instrs: [
-    { op:'if_true', then:@block_980, else:@block_989 },
+    { op:'if_true', then:@block_1085, else:@block_1094 },
   ]
 };
 
-block_989 = {
+block_1094 = {
   instrs: [
-    { op:'jump', to:@block_990 },
+    { op:'jump', to:@block_1095 },
   ]
 };
 
-block_990 = {
+block_1095 = {
   instrs: [
     { op:'push', val:1 },
     { op:'new_object' },
@@ -8820,30 +9617,30 @@ block_990 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'parseIdentStr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_991, num_args:1 },
+    { op:'call', ret_to:@block_1096, num_args:1 },
   ]
 };
 
-block_991 = {
+block_1096 = {
   instrs: [
     { op:'set_field' },
     { op:'ret' },
   ]
 };
 
-block_970 = {
+block_1075 = {
   instrs: [
-    { op:'if_true', then:@block_971, else:@block_992 },
+    { op:'if_true', then:@block_1076, else:@block_1097 },
   ]
 };
 
-block_992 = {
+block_1097 = {
   instrs: [
-    { op:'jump', to:@block_993 },
+    { op:'jump', to:@block_1098 },
   ]
 };
 
-block_993 = {
+block_1098 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'$' },
@@ -8852,27 +9649,27 @@ block_993 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_994, num_args:2 },
+    { op:'call', ret_to:@block_1099, num_args:2 },
   ]
 };
 
-block_994 = {
+block_1099 = {
   instrs: [
-    { op:'call', ret_to:@block_995, num_args:2 },
+    { op:'call', ret_to:@block_1100, num_args:2 },
   ]
 };
 
-block_996 = {
+block_1101 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseIdentStr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_997, num_args:1 },
+    { op:'call', ret_to:@block_1102, num_args:1 },
   ]
 };
 
-block_997 = {
+block_1102 = {
   instrs: [
     { op:'set_local', idx:4 },
     { op:'get_local', idx:0 },
@@ -8882,17 +9679,17 @@ block_997 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_998, num_args:2 },
+    { op:'call', ret_to:@block_1103, num_args:2 },
   ]
 };
 
-block_998 = {
+block_1103 = {
   instrs: [
-    { op:'call', ret_to:@block_999, num_args:2 },
+    { op:'call', ret_to:@block_1104, num_args:2 },
   ]
 };
 
-block_999 = {
+block_1104 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -8900,11 +9697,11 @@ block_999 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExprList' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1000, num_args:2 },
+    { op:'call', ret_to:@block_1105, num_args:2 },
   ]
 };
 
-block_1000 = {
+block_1105 = {
   instrs: [
     { op:'set_local', idx:5 },
     { op:'push', val:2 },
@@ -8927,30 +9724,30 @@ block_1000 = {
   ]
 };
 
-block_995 = {
+block_1100 = {
   instrs: [
-    { op:'if_true', then:@block_996, else:@block_1001 },
+    { op:'if_true', then:@block_1101, else:@block_1106 },
   ]
 };
 
-block_1001 = {
+block_1106 = {
   instrs: [
-    { op:'jump', to:@block_1002 },
+    { op:'jump', to:@block_1107 },
   ]
 };
 
-block_1002 = {
+block_1107 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'expected atomic expression' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseError' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1003, num_args:2 },
+    { op:'call', ret_to:@block_1108, num_args:2 },
   ]
 };
 
-block_1003 = {
+block_1108 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -8958,39 +9755,39 @@ block_1003 = {
   ]
 };
 
-fun_919 = {
-  entry:@block_918,
+fun_1024 = {
+  entry:@block_1023,
   num_params:1,
   num_locals:6,
 };
 
-block_1004 = {
+block_1109 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseAtom' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1006, num_args:1 },
+    { op:'call', ret_to:@block_1111, num_args:1 },
   ]
 };
 
-block_1006 = {
+block_1111 = {
   instrs: [
     { op:'set_local', idx:2 },
     { op:'push', val:$true },
     { op:'pop' },
-    { op:'jump', to:@block_1007 },
+    { op:'jump', to:@block_1112 },
   ]
 };
 
-block_1007 = {
+block_1112 = {
   instrs: [
     { op:'push', val:$true },
-    { op:'if_true', then:@block_1008, else:@block_1010 },
+    { op:'if_true', then:@block_1113, else:@block_1115 },
   ]
 };
 
-block_1008 = {
+block_1113 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'dup', idx:0 },
@@ -8998,17 +9795,17 @@ block_1008 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1011, num_args:2 },
+    { op:'call', ret_to:@block_1116, num_args:2 },
   ]
 };
 
-block_1011 = {
+block_1116 = {
   instrs: [
-    { op:'call', ret_to:@block_1012, num_args:1 },
+    { op:'call', ret_to:@block_1117, num_args:1 },
   ]
 };
 
-block_1012 = {
+block_1117 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -9017,17 +9814,17 @@ block_1012 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1013, num_args:2 },
+    { op:'call', ret_to:@block_1118, num_args:2 },
   ]
 };
 
-block_1013 = {
+block_1118 = {
   instrs: [
-    { op:'call', ret_to:@block_1014, num_args:1 },
+    { op:'call', ret_to:@block_1119, num_args:1 },
   ]
 };
 
-block_1014 = {
+block_1119 = {
   instrs: [
     { op:'set_local', idx:3 },
     { op:'get_local', idx:0 },
@@ -9036,11 +9833,11 @@ block_1014 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'matchOp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1015, num_args:3 },
+    { op:'call', ret_to:@block_1120, num_args:3 },
   ]
 };
 
-block_1015 = {
+block_1120 = {
   instrs: [
     { op:'set_local', idx:4 },
     { op:'get_local', idx:4 },
@@ -9048,40 +9845,40 @@ block_1015 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1016, num_args:2 },
+    { op:'call', ret_to:@block_1121, num_args:2 },
   ]
 };
 
-block_1017 = {
+block_1122 = {
   instrs: [
-    { op:'jump', to:@block_1010 },
+    { op:'jump', to:@block_1115 },
   ]
 };
 
-block_1016 = {
+block_1121 = {
   instrs: [
-    { op:'if_true', then:@block_1017, else:@block_1018 },
+    { op:'if_true', then:@block_1122, else:@block_1123 },
   ]
 };
 
-block_1018 = {
+block_1123 = {
   instrs: [
-    { op:'jump', to:@block_1019 },
+    { op:'jump', to:@block_1124 },
   ]
 };
 
-block_1019 = {
+block_1124 = {
   instrs: [
     { op:'get_local', idx:4 },
     { op:'push', val:'prec' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1020, num_args:2 },
+    { op:'call', ret_to:@block_1125, num_args:2 },
   ]
 };
 
-block_1020 = {
+block_1125 = {
   instrs: [
     { op:'set_local', idx:5 },
     { op:'get_local', idx:4 },
@@ -9089,108 +9886,116 @@ block_1020 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1021, num_args:2 },
+    { op:'call', ret_to:@block_1126, num_args:2 },
   ]
 };
 
-block_1021 = {
+block_1126 = {
   instrs: [
     { op:'push', val:'l' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1022, num_args:2 },
+    { op:'call', ret_to:@block_1127, num_args:2 },
   ]
 };
 
-block_1023 = {
+block_1128 = {
   instrs: [
     { op:'get_local', idx:4 },
     { op:'push', val:'closeStr' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1024, num_args:2 },
+    { op:'call', ret_to:@block_1129, num_args:2 },
   ]
 };
 
-block_1024 = {
+block_1129 = {
   instrs: [
     { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1025, num_args:2 },
+    { op:'call', ret_to:@block_1130, num_args:2 },
   ]
 };
 
-block_1027 = {
+block_1130 = {
+  instrs: [
+    { op:'push', val:0 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_gt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1131, num_args:2 },
+  ]
+};
+
+block_1133 = {
   instrs: [
     { op:'get_local', idx:4 },
     { op:'push', val:'prec' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1028, num_args:2 },
+    { op:'call', ret_to:@block_1134, num_args:2 },
   ]
 };
 
-block_1028 = {
+block_1134 = {
   instrs: [
     { op:'push', val:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_add' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1029, num_args:2 },
+    { op:'call', ret_to:@block_1135, num_args:2 },
   ]
 };
 
-block_1025 = {
+block_1131 = {
   instrs: [
-    { op:'push', val:0 },
-    { op:'gt_i32' },
-    { op:'if_true', then:@block_1026, else:@block_1027 },
+    { op:'if_true', then:@block_1132, else:@block_1133 },
   ]
 };
 
-block_1026 = {
+block_1132 = {
   instrs: [
     { op:'push', val:0 },
     { op:'dup', idx:0 },
     { op:'set_local', idx:5 },
     { op:'pop' },
-    { op:'jump', to:@block_1030 },
+    { op:'jump', to:@block_1136 },
   ]
 };
 
-block_1029 = {
+block_1135 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'set_local', idx:5 },
     { op:'pop' },
-    { op:'jump', to:@block_1030 },
+    { op:'jump', to:@block_1136 },
   ]
 };
 
-block_1022 = {
+block_1127 = {
   instrs: [
-    { op:'if_true', then:@block_1023, else:@block_1031 },
+    { op:'if_true', then:@block_1128, else:@block_1137 },
   ]
 };
 
-block_1030 = {
+block_1136 = {
   instrs: [
-    { op:'jump', to:@block_1032 },
+    { op:'jump', to:@block_1138 },
   ]
 };
 
-block_1031 = {
+block_1137 = {
   instrs: [
-    { op:'jump', to:@block_1032 },
+    { op:'jump', to:@block_1138 },
   ]
 };
 
-block_1032 = {
+block_1138 = {
   instrs: [
     { op:'get_local', idx:4 },
     { op:'push', val:@global_obj },
@@ -9199,22 +10004,22 @@ block_1032 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1033, num_args:2 },
+    { op:'call', ret_to:@block_1139, num_args:2 },
   ]
 };
 
-block_1034 = {
+block_1140 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:')' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExprList' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1035, num_args:2 },
+    { op:'call', ret_to:@block_1141, num_args:2 },
   ]
 };
 
-block_1036 = {
+block_1142 = {
   instrs: [
     { op:'get_local', idx:4 },
     { op:'push', val:@global_obj },
@@ -9223,21 +10028,21 @@ block_1036 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1037, num_args:2 },
+    { op:'call', ret_to:@block_1143, num_args:2 },
   ]
 };
 
-block_1038 = {
+block_1144 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseIdentStr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1039, num_args:1 },
+    { op:'call', ret_to:@block_1145, num_args:1 },
   ]
 };
 
-block_1039 = {
+block_1145 = {
   instrs: [
     { op:'set_local', idx:7 },
     { op:'get_local', idx:0 },
@@ -9247,17 +10052,17 @@ block_1039 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1040, num_args:2 },
+    { op:'call', ret_to:@block_1146, num_args:2 },
   ]
 };
 
-block_1040 = {
+block_1146 = {
   instrs: [
-    { op:'call', ret_to:@block_1041, num_args:2 },
+    { op:'call', ret_to:@block_1147, num_args:2 },
   ]
 };
 
-block_1041 = {
+block_1147 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -9265,11 +10070,11 @@ block_1041 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExprList' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1042, num_args:2 },
+    { op:'call', ret_to:@block_1148, num_args:2 },
   ]
 };
 
-block_1043 = {
+block_1149 = {
   instrs: [
     { op:'get_local', idx:4 },
     { op:'push', val:@global_obj },
@@ -9278,60 +10083,60 @@ block_1043 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1044, num_args:2 },
+    { op:'call', ret_to:@block_1150, num_args:2 },
   ]
 };
 
-block_1045 = {
+block_1151 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseIdentStr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1046, num_args:1 },
+    { op:'call', ret_to:@block_1152, num_args:1 },
   ]
 };
 
-block_1047 = {
+block_1153 = {
   instrs: [
     { op:'get_local', idx:4 },
     { op:'push', val:'arity' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1048, num_args:2 },
+    { op:'call', ret_to:@block_1154, num_args:2 },
   ]
 };
 
-block_1048 = {
+block_1154 = {
   instrs: [
     { op:'push', val:2 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1049, num_args:2 },
+    { op:'call', ret_to:@block_1155, num_args:2 },
   ]
 };
 
-block_1050 = {
+block_1156 = {
   instrs: [
     { op:'get_local', idx:4 },
     { op:'push', val:'foldAssign' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1053, num_args:2 },
+    { op:'call', ret_to:@block_1159, num_args:2 },
   ]
 };
 
-block_1053 = {
+block_1159 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_1051, else:@block_1052 },
+    { op:'if_true', then:@block_1157, else:@block_1158 },
   ]
 };
 
-block_1051 = {
+block_1157 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -9341,23 +10146,23 @@ block_1051 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1054, num_args:2 },
+    { op:'call', ret_to:@block_1160, num_args:2 },
   ]
 };
 
-block_1054 = {
+block_1160 = {
   instrs: [
-    { op:'call', ret_to:@block_1055, num_args:2 },
+    { op:'call', ret_to:@block_1161, num_args:2 },
   ]
 };
 
-block_1055 = {
+block_1161 = {
   instrs: [
-    { op:'jump', to:@block_1052 },
+    { op:'jump', to:@block_1158 },
   ]
 };
 
-block_1056 = {
+block_1162 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
@@ -9367,41 +10172,41 @@ block_1056 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1057, num_args:2 },
+    { op:'call', ret_to:@block_1163, num_args:2 },
   ]
 };
 
-block_1057 = {
+block_1163 = {
   instrs: [
     { op:'push', val:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_add' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1058, num_args:2 },
+    { op:'call', ret_to:@block_1164, num_args:2 },
   ]
 };
 
-block_1058 = {
+block_1164 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExprPrec' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1059, num_args:2 },
+    { op:'call', ret_to:@block_1165, num_args:2 },
   ]
 };
 
-block_1060 = {
+block_1166 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:5 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExprPrec' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1061, num_args:2 },
+    { op:'call', ret_to:@block_1167, num_args:2 },
   ]
 };
 
-block_1061 = {
+block_1167 = {
   instrs: [
     { op:'set_local', idx:8 },
     { op:'push', val:3 },
@@ -9432,30 +10237,38 @@ block_1061 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1064, num_args:2 },
+    { op:'call', ret_to:@block_1170, num_args:2 },
   ]
 };
 
-block_1064 = {
+block_1170 = {
   instrs: [
     { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1065, num_args:2 },
+    { op:'call', ret_to:@block_1171, num_args:2 },
   ]
 };
 
-block_1065 = {
+block_1171 = {
   instrs: [
     { op:'push', val:0 },
-    { op:'gt_i32' },
-    { op:'dup', idx:0 },
-    { op:'if_true', then:@block_1062, else:@block_1063 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_gt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1172, num_args:2 },
   ]
 };
 
-block_1062 = {
+block_1172 = {
+  instrs: [
+    { op:'dup', idx:0 },
+    { op:'if_true', then:@block_1168, else:@block_1169 },
+  ]
+};
+
+block_1168 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -9464,79 +10277,79 @@ block_1062 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1066, num_args:2 },
+    { op:'call', ret_to:@block_1173, num_args:2 },
   ]
 };
 
-block_1066 = {
+block_1173 = {
   instrs: [
     { op:'dup', idx:1 },
     { op:'push', val:'matchWS' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1067, num_args:2 },
+    { op:'call', ret_to:@block_1174, num_args:2 },
   ]
 };
 
-block_1067 = {
+block_1174 = {
   instrs: [
-    { op:'call', ret_to:@block_1068, num_args:2 },
+    { op:'call', ret_to:@block_1175, num_args:2 },
   ]
 };
 
-block_1068 = {
+block_1175 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_not' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1069, num_args:1 },
+    { op:'call', ret_to:@block_1176, num_args:1 },
   ]
 };
 
-block_1069 = {
+block_1176 = {
   instrs: [
-    { op:'jump', to:@block_1063 },
+    { op:'jump', to:@block_1169 },
   ]
 };
 
-block_1070 = {
+block_1177 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'expected operator closing' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseError' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1071, num_args:2 },
+    { op:'call', ret_to:@block_1178, num_args:2 },
   ]
 };
 
-block_1063 = {
+block_1169 = {
   instrs: [
-    { op:'if_true', then:@block_1070, else:@block_1072 },
+    { op:'if_true', then:@block_1177, else:@block_1179 },
   ]
 };
 
-block_1071 = {
+block_1178 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_1073 },
+    { op:'jump', to:@block_1180 },
   ]
 };
 
-block_1072 = {
+block_1179 = {
   instrs: [
-    { op:'jump', to:@block_1073 },
+    { op:'jump', to:@block_1180 },
   ]
 };
 
-block_1052 = {
+block_1158 = {
   instrs: [
-    { op:'if_true', then:@block_1056, else:@block_1060 },
+    { op:'if_true', then:@block_1162, else:@block_1166 },
   ]
 };
 
-block_1059 = {
+block_1165 = {
   instrs: [
     { op:'set_local', idx:8 },
     { op:'push', val:3 },
@@ -9587,62 +10400,62 @@ block_1059 = {
     { op:'dup', idx:0 },
     { op:'set_local', idx:2 },
     { op:'pop' },
-    { op:'jump', to:@block_1074 },
+    { op:'jump', to:@block_1181 },
   ]
 };
 
-block_1073 = {
+block_1180 = {
   instrs: [
-    { op:'jump', to:@block_1074 },
+    { op:'jump', to:@block_1181 },
   ]
 };
 
-block_1075 = {
+block_1182 = {
   instrs: [
     { op:'push', val:$false },
-    { op:'if_true', then:@block_1076, else:@block_1077 },
+    { op:'if_true', then:@block_1183, else:@block_1184 },
   ]
 };
 
-block_1076 = {
+block_1183 = {
   instrs: [
-    { op:'jump', to:@block_1078 },
+    { op:'jump', to:@block_1185 },
   ]
 };
 
-block_1077 = {
+block_1184 = {
   instrs: [
     { op:'push', val:'operator not handled correctly' },
     { op:'abort' },
-    { op:'jump', to:@block_1078 },
+    { op:'jump', to:@block_1185 },
   ]
 };
 
-block_1049 = {
+block_1155 = {
   instrs: [
-    { op:'if_true', then:@block_1050, else:@block_1075 },
+    { op:'if_true', then:@block_1156, else:@block_1182 },
   ]
 };
 
-block_1074 = {
+block_1181 = {
   instrs: [
-    { op:'jump', to:@block_1079 },
+    { op:'jump', to:@block_1186 },
   ]
 };
 
-block_1078 = {
+block_1185 = {
   instrs: [
-    { op:'jump', to:@block_1079 },
+    { op:'jump', to:@block_1186 },
   ]
 };
 
-block_1044 = {
+block_1150 = {
   instrs: [
-    { op:'if_true', then:@block_1045, else:@block_1047 },
+    { op:'if_true', then:@block_1151, else:@block_1153 },
   ]
 };
 
-block_1046 = {
+block_1152 = {
   instrs: [
     { op:'set_local', idx:7 },
     { op:'push', val:3 },
@@ -9679,23 +10492,23 @@ block_1046 = {
     { op:'dup', idx:0 },
     { op:'set_local', idx:2 },
     { op:'pop' },
-    { op:'jump', to:@block_1080 },
+    { op:'jump', to:@block_1187 },
   ]
 };
 
-block_1079 = {
+block_1186 = {
   instrs: [
-    { op:'jump', to:@block_1080 },
+    { op:'jump', to:@block_1187 },
   ]
 };
 
-block_1037 = {
+block_1143 = {
   instrs: [
-    { op:'if_true', then:@block_1038, else:@block_1043 },
+    { op:'if_true', then:@block_1144, else:@block_1149 },
   ]
 };
 
-block_1042 = {
+block_1148 = {
   instrs: [
     { op:'set_local', idx:6 },
     { op:'push', val:4 },
@@ -9725,23 +10538,23 @@ block_1042 = {
     { op:'dup', idx:0 },
     { op:'set_local', idx:2 },
     { op:'pop' },
-    { op:'jump', to:@block_1081 },
+    { op:'jump', to:@block_1188 },
   ]
 };
 
-block_1080 = {
+block_1187 = {
   instrs: [
-    { op:'jump', to:@block_1081 },
+    { op:'jump', to:@block_1188 },
   ]
 };
 
-block_1033 = {
+block_1139 = {
   instrs: [
-    { op:'if_true', then:@block_1034, else:@block_1036 },
+    { op:'if_true', then:@block_1140, else:@block_1142 },
   ]
 };
 
-block_1035 = {
+block_1141 = {
   instrs: [
     { op:'set_local', idx:6 },
     { op:'push', val:3 },
@@ -9767,85 +10580,85 @@ block_1035 = {
     { op:'dup', idx:0 },
     { op:'set_local', idx:2 },
     { op:'pop' },
-    { op:'jump', to:@block_1082 },
+    { op:'jump', to:@block_1189 },
   ]
 };
 
-block_1081 = {
+block_1188 = {
   instrs: [
-    { op:'jump', to:@block_1082 },
+    { op:'jump', to:@block_1189 },
   ]
 };
 
-block_1082 = {
+block_1189 = {
   instrs: [
-    { op:'jump', to:@block_1009 },
+    { op:'jump', to:@block_1114 },
   ]
 };
 
-block_1009 = {
+block_1114 = {
   instrs: [
     { op:'push', val:$true },
     { op:'pop' },
-    { op:'jump', to:@block_1007 },
+    { op:'jump', to:@block_1112 },
   ]
 };
 
-block_1010 = {
+block_1115 = {
   instrs: [
     { op:'get_local', idx:2 },
     { op:'ret' },
   ]
 };
 
-fun_1005 = {
-  entry:@block_1004,
+fun_1110 = {
+  entry:@block_1109,
   num_params:2,
   num_locals:11,
 };
 
-block_1083 = {
+block_1190 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExprPrec' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1085, num_args:2 },
+    { op:'call', ret_to:@block_1192, num_args:2 },
   ]
 };
 
-block_1085 = {
+block_1192 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-fun_1084 = {
-  entry:@block_1083,
+fun_1191 = {
+  entry:@block_1190,
   num_params:1,
   num_locals:1,
 };
 
-block_1086 = {
+block_1193 = {
   instrs: [
     { op:'push', val:0 },
     { op:'new_array' },
     { op:'set_local', idx:2 },
     { op:'push', val:$true },
     { op:'pop' },
-    { op:'jump', to:@block_1088 },
+    { op:'jump', to:@block_1195 },
   ]
 };
 
-block_1088 = {
+block_1195 = {
   instrs: [
     { op:'push', val:$true },
-    { op:'if_true', then:@block_1089, else:@block_1091 },
+    { op:'if_true', then:@block_1196, else:@block_1198 },
   ]
 };
 
-block_1089 = {
+block_1196 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'dup', idx:0 },
@@ -9853,17 +10666,17 @@ block_1089 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1092, num_args:2 },
+    { op:'call', ret_to:@block_1199, num_args:2 },
   ]
 };
 
-block_1092 = {
+block_1199 = {
   instrs: [
-    { op:'call', ret_to:@block_1093, num_args:1 },
+    { op:'call', ret_to:@block_1200, num_args:1 },
   ]
 };
 
-block_1093 = {
+block_1200 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:1 },
@@ -9871,18 +10684,18 @@ block_1093 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1098, num_args:2 },
+    { op:'call', ret_to:@block_1205, num_args:2 },
   ]
 };
 
-block_1098 = {
+block_1205 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_1096, else:@block_1097 },
+    { op:'if_true', then:@block_1203, else:@block_1204 },
   ]
 };
 
-block_1096 = {
+block_1203 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -9891,30 +10704,30 @@ block_1096 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1099, num_args:2 },
+    { op:'call', ret_to:@block_1206, num_args:2 },
   ]
 };
 
-block_1099 = {
+block_1206 = {
   instrs: [
-    { op:'call', ret_to:@block_1100, num_args:1 },
+    { op:'call', ret_to:@block_1207, num_args:1 },
   ]
 };
 
-block_1100 = {
+block_1207 = {
   instrs: [
-    { op:'jump', to:@block_1097 },
+    { op:'jump', to:@block_1204 },
   ]
 };
 
-block_1097 = {
+block_1204 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_1095, else:@block_1094 },
+    { op:'if_true', then:@block_1202, else:@block_1201 },
   ]
 };
 
-block_1094 = {
+block_1201 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:1 },
@@ -9922,18 +10735,18 @@ block_1094 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_ne' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1103, num_args:2 },
+    { op:'call', ret_to:@block_1210, num_args:2 },
   ]
 };
 
-block_1103 = {
+block_1210 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_1101, else:@block_1102 },
+    { op:'if_true', then:@block_1208, else:@block_1209 },
   ]
 };
 
-block_1101 = {
+block_1208 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -9943,57 +10756,57 @@ block_1101 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1104, num_args:2 },
+    { op:'call', ret_to:@block_1211, num_args:2 },
   ]
 };
 
-block_1104 = {
+block_1211 = {
   instrs: [
-    { op:'call', ret_to:@block_1105, num_args:2 },
+    { op:'call', ret_to:@block_1212, num_args:2 },
   ]
 };
 
-block_1105 = {
+block_1212 = {
   instrs: [
-    { op:'jump', to:@block_1102 },
+    { op:'jump', to:@block_1209 },
   ]
 };
 
-block_1102 = {
+block_1209 = {
   instrs: [
-    { op:'jump', to:@block_1095 },
+    { op:'jump', to:@block_1202 },
   ]
 };
 
-block_1106 = {
+block_1213 = {
   instrs: [
-    { op:'jump', to:@block_1091 },
+    { op:'jump', to:@block_1198 },
   ]
 };
 
-block_1095 = {
+block_1202 = {
   instrs: [
-    { op:'if_true', then:@block_1106, else:@block_1107 },
+    { op:'if_true', then:@block_1213, else:@block_1214 },
   ]
 };
 
-block_1107 = {
+block_1214 = {
   instrs: [
-    { op:'jump', to:@block_1108 },
+    { op:'jump', to:@block_1215 },
   ]
 };
 
-block_1108 = {
+block_1215 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseStmt' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1109, num_args:1 },
+    { op:'call', ret_to:@block_1216, num_args:1 },
   ]
 };
 
-block_1109 = {
+block_1216 = {
   instrs: [
     { op:'set_local', idx:3 },
     { op:'get_local', idx:2 },
@@ -10003,32 +10816,32 @@ block_1109 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1110, num_args:2 },
+    { op:'call', ret_to:@block_1217, num_args:2 },
   ]
 };
 
-block_1110 = {
+block_1217 = {
   instrs: [
-    { op:'call', ret_to:@block_1111, num_args:2 },
+    { op:'call', ret_to:@block_1218, num_args:2 },
   ]
 };
 
-block_1111 = {
+block_1218 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_1090 },
+    { op:'jump', to:@block_1197 },
   ]
 };
 
-block_1090 = {
+block_1197 = {
   instrs: [
     { op:'push', val:$true },
     { op:'pop' },
-    { op:'jump', to:@block_1088 },
+    { op:'jump', to:@block_1195 },
   ]
 };
 
-block_1091 = {
+block_1198 = {
   instrs: [
     { op:'push', val:1 },
     { op:'new_object' },
@@ -10046,13 +10859,13 @@ block_1091 = {
   ]
 };
 
-fun_1087 = {
-  entry:@block_1086,
+fun_1194 = {
+  entry:@block_1193,
   num_params:2,
   num_locals:4,
 };
 
-block_1112 = {
+block_1219 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'{' },
@@ -10061,46 +10874,46 @@ block_1112 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1114, num_args:2 },
+    { op:'call', ret_to:@block_1221, num_args:2 },
   ]
 };
 
-block_1114 = {
+block_1221 = {
   instrs: [
-    { op:'call', ret_to:@block_1115, num_args:2 },
+    { op:'call', ret_to:@block_1222, num_args:2 },
   ]
 };
 
-block_1116 = {
+block_1223 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'}' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseBlockStmt' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1117, num_args:2 },
+    { op:'call', ret_to:@block_1224, num_args:2 },
   ]
 };
 
-block_1117 = {
+block_1224 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-block_1115 = {
+block_1222 = {
   instrs: [
-    { op:'if_true', then:@block_1116, else:@block_1118 },
+    { op:'if_true', then:@block_1223, else:@block_1225 },
   ]
 };
 
-block_1118 = {
+block_1225 = {
   instrs: [
-    { op:'jump', to:@block_1119 },
+    { op:'jump', to:@block_1226 },
   ]
 };
 
-block_1119 = {
+block_1226 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'var' },
@@ -10109,17 +10922,17 @@ block_1119 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1120, num_args:2 },
+    { op:'call', ret_to:@block_1227, num_args:2 },
   ]
 };
 
-block_1120 = {
+block_1227 = {
   instrs: [
-    { op:'call', ret_to:@block_1121, num_args:2 },
+    { op:'call', ret_to:@block_1228, num_args:2 },
   ]
 };
 
-block_1122 = {
+block_1229 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'dup', idx:0 },
@@ -10127,28 +10940,28 @@ block_1122 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1123, num_args:2 },
+    { op:'call', ret_to:@block_1230, num_args:2 },
   ]
 };
 
-block_1123 = {
+block_1230 = {
   instrs: [
-    { op:'call', ret_to:@block_1124, num_args:1 },
+    { op:'call', ret_to:@block_1231, num_args:1 },
   ]
 };
 
-block_1124 = {
+block_1231 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseIdentStr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1125, num_args:1 },
+    { op:'call', ret_to:@block_1232, num_args:1 },
   ]
 };
 
-block_1125 = {
+block_1232 = {
   instrs: [
     { op:'set_local', idx:1 },
     { op:'get_local', idx:0 },
@@ -10158,28 +10971,28 @@ block_1125 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1126, num_args:2 },
+    { op:'call', ret_to:@block_1233, num_args:2 },
   ]
 };
 
-block_1126 = {
+block_1233 = {
   instrs: [
-    { op:'call', ret_to:@block_1127, num_args:2 },
+    { op:'call', ret_to:@block_1234, num_args:2 },
   ]
 };
 
-block_1127 = {
+block_1234 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1128, num_args:1 },
+    { op:'call', ret_to:@block_1235, num_args:1 },
   ]
 };
 
-block_1128 = {
+block_1235 = {
   instrs: [
     { op:'set_local', idx:2 },
     { op:'get_local', idx:0 },
@@ -10189,17 +11002,17 @@ block_1128 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1129, num_args:2 },
+    { op:'call', ret_to:@block_1236, num_args:2 },
   ]
 };
 
-block_1129 = {
+block_1236 = {
   instrs: [
-    { op:'call', ret_to:@block_1130, num_args:2 },
+    { op:'call', ret_to:@block_1237, num_args:2 },
   ]
 };
 
-block_1130 = {
+block_1237 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:2 },
@@ -10222,19 +11035,19 @@ block_1130 = {
   ]
 };
 
-block_1121 = {
+block_1228 = {
   instrs: [
-    { op:'if_true', then:@block_1122, else:@block_1131 },
+    { op:'if_true', then:@block_1229, else:@block_1238 },
   ]
 };
 
-block_1131 = {
+block_1238 = {
   instrs: [
-    { op:'jump', to:@block_1132 },
+    { op:'jump', to:@block_1239 },
   ]
 };
 
-block_1132 = {
+block_1239 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'if' },
@@ -10243,45 +11056,45 @@ block_1132 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1133, num_args:2 },
+    { op:'call', ret_to:@block_1240, num_args:2 },
   ]
 };
 
-block_1133 = {
+block_1240 = {
   instrs: [
-    { op:'call', ret_to:@block_1134, num_args:2 },
+    { op:'call', ret_to:@block_1241, num_args:2 },
   ]
 };
 
-block_1135 = {
+block_1242 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseIfStmt' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1136, num_args:1 },
+    { op:'call', ret_to:@block_1243, num_args:1 },
   ]
 };
 
-block_1136 = {
+block_1243 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-block_1134 = {
+block_1241 = {
   instrs: [
-    { op:'if_true', then:@block_1135, else:@block_1137 },
+    { op:'if_true', then:@block_1242, else:@block_1244 },
   ]
 };
 
-block_1137 = {
+block_1244 = {
   instrs: [
-    { op:'jump', to:@block_1138 },
+    { op:'jump', to:@block_1245 },
   ]
 };
 
-block_1138 = {
+block_1245 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'for' },
@@ -10290,45 +11103,45 @@ block_1138 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1139, num_args:2 },
+    { op:'call', ret_to:@block_1246, num_args:2 },
   ]
 };
 
-block_1139 = {
+block_1246 = {
   instrs: [
-    { op:'call', ret_to:@block_1140, num_args:2 },
+    { op:'call', ret_to:@block_1247, num_args:2 },
   ]
 };
 
-block_1141 = {
+block_1248 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseForStmt' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1142, num_args:1 },
+    { op:'call', ret_to:@block_1249, num_args:1 },
   ]
 };
 
-block_1142 = {
+block_1249 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-block_1140 = {
+block_1247 = {
   instrs: [
-    { op:'if_true', then:@block_1141, else:@block_1143 },
+    { op:'if_true', then:@block_1248, else:@block_1250 },
   ]
 };
 
-block_1143 = {
+block_1250 = {
   instrs: [
-    { op:'jump', to:@block_1144 },
+    { op:'jump', to:@block_1251 },
   ]
 };
 
-block_1144 = {
+block_1251 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'break' },
@@ -10337,17 +11150,17 @@ block_1144 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1145, num_args:2 },
+    { op:'call', ret_to:@block_1252, num_args:2 },
   ]
 };
 
-block_1145 = {
+block_1252 = {
   instrs: [
-    { op:'call', ret_to:@block_1146, num_args:2 },
+    { op:'call', ret_to:@block_1253, num_args:2 },
   ]
 };
 
-block_1147 = {
+block_1254 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:';' },
@@ -10356,17 +11169,17 @@ block_1147 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1148, num_args:2 },
+    { op:'call', ret_to:@block_1255, num_args:2 },
   ]
 };
 
-block_1148 = {
+block_1255 = {
   instrs: [
-    { op:'call', ret_to:@block_1149, num_args:2 },
+    { op:'call', ret_to:@block_1256, num_args:2 },
   ]
 };
 
-block_1149 = {
+block_1256 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:0 },
@@ -10381,19 +11194,19 @@ block_1149 = {
   ]
 };
 
-block_1146 = {
+block_1253 = {
   instrs: [
-    { op:'if_true', then:@block_1147, else:@block_1150 },
+    { op:'if_true', then:@block_1254, else:@block_1257 },
   ]
 };
 
-block_1150 = {
+block_1257 = {
   instrs: [
-    { op:'jump', to:@block_1151 },
+    { op:'jump', to:@block_1258 },
   ]
 };
 
-block_1151 = {
+block_1258 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'continue' },
@@ -10402,17 +11215,17 @@ block_1151 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1152, num_args:2 },
+    { op:'call', ret_to:@block_1259, num_args:2 },
   ]
 };
 
-block_1152 = {
+block_1259 = {
   instrs: [
-    { op:'call', ret_to:@block_1153, num_args:2 },
+    { op:'call', ret_to:@block_1260, num_args:2 },
   ]
 };
 
-block_1154 = {
+block_1261 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:';' },
@@ -10421,17 +11234,17 @@ block_1154 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1155, num_args:2 },
+    { op:'call', ret_to:@block_1262, num_args:2 },
   ]
 };
 
-block_1155 = {
+block_1262 = {
   instrs: [
-    { op:'call', ret_to:@block_1156, num_args:2 },
+    { op:'call', ret_to:@block_1263, num_args:2 },
   ]
 };
 
-block_1156 = {
+block_1263 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:0 },
@@ -10446,19 +11259,19 @@ block_1156 = {
   ]
 };
 
-block_1153 = {
+block_1260 = {
   instrs: [
-    { op:'if_true', then:@block_1154, else:@block_1157 },
+    { op:'if_true', then:@block_1261, else:@block_1264 },
   ]
 };
 
-block_1157 = {
+block_1264 = {
   instrs: [
-    { op:'jump', to:@block_1158 },
+    { op:'jump', to:@block_1265 },
   ]
 };
 
-block_1158 = {
+block_1265 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'return' },
@@ -10467,17 +11280,17 @@ block_1158 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1159, num_args:2 },
+    { op:'call', ret_to:@block_1266, num_args:2 },
   ]
 };
 
-block_1159 = {
+block_1266 = {
   instrs: [
-    { op:'call', ret_to:@block_1160, num_args:2 },
+    { op:'call', ret_to:@block_1267, num_args:2 },
   ]
 };
 
-block_1161 = {
+block_1268 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:';' },
@@ -10486,17 +11299,17 @@ block_1161 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1162, num_args:2 },
+    { op:'call', ret_to:@block_1269, num_args:2 },
   ]
 };
 
-block_1162 = {
+block_1269 = {
   instrs: [
-    { op:'call', ret_to:@block_1163, num_args:2 },
+    { op:'call', ret_to:@block_1270, num_args:2 },
   ]
 };
 
-block_1164 = {
+block_1271 = {
   instrs: [
     { op:'push', val:1 },
     { op:'new_object' },
@@ -10525,29 +11338,29 @@ block_1164 = {
   ]
 };
 
-block_1163 = {
+block_1270 = {
   instrs: [
-    { op:'if_true', then:@block_1164, else:@block_1165 },
+    { op:'if_true', then:@block_1271, else:@block_1272 },
   ]
 };
 
-block_1165 = {
+block_1272 = {
   instrs: [
-    { op:'jump', to:@block_1166 },
+    { op:'jump', to:@block_1273 },
   ]
 };
 
-block_1166 = {
+block_1273 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1167, num_args:1 },
+    { op:'call', ret_to:@block_1274, num_args:1 },
   ]
 };
 
-block_1167 = {
+block_1274 = {
   instrs: [
     { op:'set_local', idx:3 },
     { op:'get_local', idx:0 },
@@ -10557,17 +11370,17 @@ block_1167 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1168, num_args:2 },
+    { op:'call', ret_to:@block_1275, num_args:2 },
   ]
 };
 
-block_1168 = {
+block_1275 = {
   instrs: [
-    { op:'call', ret_to:@block_1169, num_args:2 },
+    { op:'call', ret_to:@block_1276, num_args:2 },
   ]
 };
 
-block_1169 = {
+block_1276 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:1 },
@@ -10586,19 +11399,19 @@ block_1169 = {
   ]
 };
 
-block_1160 = {
+block_1267 = {
   instrs: [
-    { op:'if_true', then:@block_1161, else:@block_1170 },
+    { op:'if_true', then:@block_1268, else:@block_1277 },
   ]
 };
 
-block_1170 = {
+block_1277 = {
   instrs: [
-    { op:'jump', to:@block_1171 },
+    { op:'jump', to:@block_1278 },
   ]
 };
 
-block_1171 = {
+block_1278 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'assert' },
@@ -10607,17 +11420,17 @@ block_1171 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1172, num_args:2 },
+    { op:'call', ret_to:@block_1279, num_args:2 },
   ]
 };
 
-block_1172 = {
+block_1279 = {
   instrs: [
-    { op:'call', ret_to:@block_1173, num_args:2 },
+    { op:'call', ret_to:@block_1280, num_args:2 },
   ]
 };
 
-block_1174 = {
+block_1281 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'dup', idx:0 },
@@ -10625,17 +11438,17 @@ block_1174 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1175, num_args:2 },
+    { op:'call', ret_to:@block_1282, num_args:2 },
   ]
 };
 
-block_1175 = {
+block_1282 = {
   instrs: [
-    { op:'call', ret_to:@block_1176, num_args:1 },
+    { op:'call', ret_to:@block_1283, num_args:1 },
   ]
 };
 
-block_1176 = {
+block_1283 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -10644,17 +11457,17 @@ block_1176 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1177, num_args:2 },
+    { op:'call', ret_to:@block_1284, num_args:2 },
   ]
 };
 
-block_1177 = {
+block_1284 = {
   instrs: [
-    { op:'call', ret_to:@block_1178, num_args:1 },
+    { op:'call', ret_to:@block_1285, num_args:1 },
   ]
 };
 
-block_1178 = {
+block_1285 = {
   instrs: [
     { op:'set_local', idx:4 },
     { op:'get_local', idx:0 },
@@ -10664,17 +11477,17 @@ block_1178 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1179, num_args:2 },
+    { op:'call', ret_to:@block_1286, num_args:2 },
   ]
 };
 
-block_1179 = {
+block_1286 = {
   instrs: [
-    { op:'call', ret_to:@block_1180, num_args:2 },
+    { op:'call', ret_to:@block_1287, num_args:2 },
   ]
 };
 
-block_1180 = {
+block_1287 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -10684,28 +11497,28 @@ block_1180 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1181, num_args:2 },
+    { op:'call', ret_to:@block_1288, num_args:2 },
   ]
 };
 
-block_1181 = {
+block_1288 = {
   instrs: [
-    { op:'call', ret_to:@block_1182, num_args:2 },
+    { op:'call', ret_to:@block_1289, num_args:2 },
   ]
 };
 
-block_1182 = {
+block_1289 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1183, num_args:1 },
+    { op:'call', ret_to:@block_1290, num_args:1 },
   ]
 };
 
-block_1183 = {
+block_1290 = {
   instrs: [
     { op:'set_local', idx:5 },
     { op:'push', val:$false },
@@ -10717,42 +11530,42 @@ block_1183 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1184, num_args:2 },
+    { op:'call', ret_to:@block_1291, num_args:2 },
   ]
 };
 
-block_1184 = {
+block_1291 = {
   instrs: [
-    { op:'call', ret_to:@block_1185, num_args:2 },
+    { op:'call', ret_to:@block_1292, num_args:2 },
   ]
 };
 
-block_1186 = {
+block_1293 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1187, num_args:1 },
+    { op:'call', ret_to:@block_1294, num_args:1 },
   ]
 };
 
-block_1185 = {
+block_1292 = {
   instrs: [
-    { op:'if_true', then:@block_1186, else:@block_1188 },
+    { op:'if_true', then:@block_1293, else:@block_1295 },
   ]
 };
 
-block_1187 = {
+block_1294 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'set_local', idx:6 },
     { op:'pop' },
-    { op:'jump', to:@block_1189 },
+    { op:'jump', to:@block_1296 },
   ]
 };
 
-block_1188 = {
+block_1295 = {
   instrs: [
     { op:'push', val:1 },
     { op:'new_object' },
@@ -10769,11 +11582,11 @@ block_1188 = {
     { op:'dup', idx:0 },
     { op:'set_local', idx:6 },
     { op:'pop' },
-    { op:'jump', to:@block_1189 },
+    { op:'jump', to:@block_1296 },
   ]
 };
 
-block_1189 = {
+block_1296 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:')' },
@@ -10782,17 +11595,17 @@ block_1189 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1190, num_args:2 },
+    { op:'call', ret_to:@block_1297, num_args:2 },
   ]
 };
 
-block_1190 = {
+block_1297 = {
   instrs: [
-    { op:'call', ret_to:@block_1191, num_args:2 },
+    { op:'call', ret_to:@block_1298, num_args:2 },
   ]
 };
 
-block_1191 = {
+block_1298 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -10802,17 +11615,17 @@ block_1191 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1192, num_args:2 },
+    { op:'call', ret_to:@block_1299, num_args:2 },
   ]
 };
 
-block_1192 = {
+block_1299 = {
   instrs: [
-    { op:'call', ret_to:@block_1193, num_args:2 },
+    { op:'call', ret_to:@block_1300, num_args:2 },
   ]
 };
 
-block_1193 = {
+block_1300 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:3 },
@@ -10879,29 +11692,29 @@ block_1193 = {
   ]
 };
 
-block_1173 = {
+block_1280 = {
   instrs: [
-    { op:'if_true', then:@block_1174, else:@block_1194 },
+    { op:'if_true', then:@block_1281, else:@block_1301 },
   ]
 };
 
-block_1194 = {
+block_1301 = {
   instrs: [
-    { op:'jump', to:@block_1195 },
+    { op:'jump', to:@block_1302 },
   ]
 };
 
-block_1195 = {
+block_1302 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1196, num_args:1 },
+    { op:'call', ret_to:@block_1303, num_args:1 },
   ]
 };
 
-block_1196 = {
+block_1303 = {
   instrs: [
     { op:'set_local', idx:3 },
     { op:'get_local', idx:0 },
@@ -10911,17 +11724,17 @@ block_1196 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1197, num_args:2 },
+    { op:'call', ret_to:@block_1304, num_args:2 },
   ]
 };
 
-block_1197 = {
+block_1304 = {
   instrs: [
-    { op:'call', ret_to:@block_1198, num_args:2 },
+    { op:'call', ret_to:@block_1305, num_args:2 },
   ]
 };
 
-block_1198 = {
+block_1305 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:1 },
@@ -10940,24 +11753,24 @@ block_1198 = {
   ]
 };
 
-fun_1113 = {
-  entry:@block_1112,
+fun_1220 = {
+  entry:@block_1219,
   num_params:1,
   num_locals:7,
 };
 
-block_1199 = {
+block_1306 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseBlockStmt' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1201, num_args:2 },
+    { op:'call', ret_to:@block_1308, num_args:2 },
   ]
 };
 
-block_1201 = {
+block_1308 = {
   instrs: [
     { op:'set_local', idx:1 },
     { op:'push', val:3 },
@@ -10985,13 +11798,13 @@ block_1201 = {
   ]
 };
 
-fun_1200 = {
-  entry:@block_1199,
+fun_1307 = {
+  entry:@block_1306,
   num_params:1,
   num_locals:2,
 };
 
-block_1202 = {
+block_1309 = {
   instrs: [
     { op:'push', val:2 },
     { op:'new_object' },
@@ -11014,33 +11827,33 @@ block_1202 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'parseUnit' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1204, num_args:1 },
+    { op:'call', ret_to:@block_1311, num_args:1 },
   ]
 };
 
-block_1204 = {
+block_1311 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-fun_1203 = {
-  entry:@block_1202,
+fun_1310 = {
+  entry:@block_1309,
   num_params:2,
   num_locals:3,
 };
 
-block_1205 = {
+block_1312 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'readFile' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1207, num_args:1 },
+    { op:'call', ret_to:@block_1314, num_args:1 },
   ]
 };
 
-block_1207 = {
+block_1314 = {
   instrs: [
     { op:'set_local', idx:1 },
     { op:'push', val:2 },
@@ -11064,23 +11877,23 @@ block_1207 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'parseUnit' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1208, num_args:1 },
+    { op:'call', ret_to:@block_1315, num_args:1 },
   ]
 };
 
-block_1208 = {
+block_1315 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-fun_1206 = {
-  entry:@block_1205,
+fun_1313 = {
+  entry:@block_1312,
   num_params:1,
   num_locals:3,
 };
 
-block_1209 = {
+block_1316 = {
   instrs: [
     { op:'push', val:1 },
     { op:'new_object' },
@@ -11099,114 +11912,114 @@ block_1209 = {
   ]
 };
 
-fun_1210 = {
-  entry:@block_1209,
+fun_1317 = {
+  entry:@block_1316,
   num_params:0,
   num_locals:0,
 };
 
-block_1211 = {
+block_1318 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'instrs' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1213, num_args:2 },
+    { op:'call', ret_to:@block_1320, num_args:2 },
   ]
 };
 
-block_1213 = {
+block_1320 = {
   instrs: [
     { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1214, num_args:2 },
+    { op:'call', ret_to:@block_1321, num_args:2 },
   ]
 };
 
-block_1214 = {
+block_1321 = {
   instrs: [
     { op:'push', val:0 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1215, num_args:2 },
+    { op:'call', ret_to:@block_1322, num_args:2 },
   ]
 };
 
-block_1216 = {
+block_1323 = {
   instrs: [
     { op:'push', val:$false },
     { op:'ret' },
   ]
 };
 
-block_1215 = {
+block_1322 = {
   instrs: [
-    { op:'if_true', then:@block_1216, else:@block_1217 },
+    { op:'if_true', then:@block_1323, else:@block_1324 },
   ]
 };
 
-block_1217 = {
+block_1324 = {
   instrs: [
-    { op:'jump', to:@block_1218 },
+    { op:'jump', to:@block_1325 },
   ]
 };
 
-block_1218 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'instrs' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1219, num_args:2 },
-  ]
-};
-
-block_1219 = {
+block_1325 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'instrs' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1220, num_args:2 },
+    { op:'call', ret_to:@block_1326, num_args:2 },
   ]
 };
 
-block_1220 = {
+block_1326 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:'instrs' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1327, num_args:2 },
+  ]
+};
+
+block_1327 = {
   instrs: [
     { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1221, num_args:2 },
+    { op:'call', ret_to:@block_1328, num_args:2 },
   ]
 };
 
-block_1221 = {
+block_1328 = {
   instrs: [
     { op:'push', val:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_sub' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1222, num_args:2 },
+    { op:'call', ret_to:@block_1329, num_args:2 },
   ]
 };
 
-block_1222 = {
+block_1329 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getElem' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1223, num_args:2 },
+    { op:'call', ret_to:@block_1330, num_args:2 },
   ]
 };
 
-block_1223 = {
+block_1330 = {
   instrs: [
     { op:'set_local', idx:1 },
     { op:'get_local', idx:1 },
@@ -11214,11 +12027,11 @@ block_1223 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1224, num_args:2 },
+    { op:'call', ret_to:@block_1331, num_args:2 },
   ]
 };
 
-block_1224 = {
+block_1331 = {
   instrs: [
     { op:'set_local', idx:2 },
     { op:'get_local', idx:2 },
@@ -11226,18 +12039,18 @@ block_1224 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1229, num_args:2 },
+    { op:'call', ret_to:@block_1336, num_args:2 },
   ]
 };
 
-block_1229 = {
+block_1336 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_1228, else:@block_1227 },
+    { op:'if_true', then:@block_1335, else:@block_1334 },
   ]
 };
 
-block_1227 = {
+block_1334 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:2 },
@@ -11245,24 +12058,24 @@ block_1227 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1230, num_args:2 },
+    { op:'call', ret_to:@block_1337, num_args:2 },
   ]
 };
 
-block_1230 = {
+block_1337 = {
   instrs: [
-    { op:'jump', to:@block_1228 },
+    { op:'jump', to:@block_1335 },
   ]
 };
 
-block_1228 = {
+block_1335 = {
   instrs: [
     { op:'dup', idx:0 },
-    { op:'if_true', then:@block_1226, else:@block_1225 },
+    { op:'if_true', then:@block_1333, else:@block_1332 },
   ]
 };
 
-block_1225 = {
+block_1332 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:2 },
@@ -11270,40 +12083,40 @@ block_1225 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1231, num_args:2 },
+    { op:'call', ret_to:@block_1338, num_args:2 },
   ]
 };
 
-block_1231 = {
+block_1338 = {
   instrs: [
-    { op:'jump', to:@block_1226 },
+    { op:'jump', to:@block_1333 },
   ]
 };
 
-block_1226 = {
+block_1333 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-fun_1212 = {
-  entry:@block_1211,
+fun_1319 = {
+  entry:@block_1318,
   num_params:1,
   num_locals:3,
 };
 
-block_1232 = {
+block_1339 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'instrs' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1234, num_args:2 },
+    { op:'call', ret_to:@block_1341, num_args:2 },
   ]
 };
 
-block_1234 = {
+block_1341 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'dup', idx:1 },
@@ -11311,17 +12124,17 @@ block_1234 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1235, num_args:2 },
+    { op:'call', ret_to:@block_1342, num_args:2 },
   ]
 };
 
-block_1235 = {
+block_1342 = {
   instrs: [
-    { op:'call', ret_to:@block_1236, num_args:2 },
+    { op:'call', ret_to:@block_1343, num_args:2 },
   ]
 };
 
-block_1236 = {
+block_1343 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -11329,13 +12142,13 @@ block_1236 = {
   ]
 };
 
-fun_1233 = {
-  entry:@block_1232,
+fun_1340 = {
+  entry:@block_1339,
   num_params:2,
   num_locals:2,
 };
 
-block_1237 = {
+block_1344 = {
   instrs: [
     { op:'push', val:4 },
     { op:'new_object' },
@@ -11366,13 +12179,13 @@ block_1237 = {
   ]
 };
 
-fun_1238 = {
-  entry:@block_1237,
+fun_1345 = {
+  entry:@block_1344,
   num_params:2,
   num_locals:2,
 };
 
-block_1239 = {
+block_1346 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
@@ -11381,47 +12194,47 @@ block_1239 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1241, num_args:2 },
+    { op:'call', ret_to:@block_1348, num_args:2 },
   ]
 };
 
-block_1241 = {
+block_1348 = {
   instrs: [
-    { op:'call', ret_to:@block_1242, num_args:2 },
+    { op:'call', ret_to:@block_1349, num_args:2 },
   ]
 };
 
-block_1243 = {
+block_1350 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-block_1242 = {
+block_1349 = {
   instrs: [
-    { op:'if_true', then:@block_1243, else:@block_1244 },
+    { op:'if_true', then:@block_1350, else:@block_1351 },
   ]
 };
 
-block_1244 = {
+block_1351 = {
   instrs: [
-    { op:'jump', to:@block_1245 },
+    { op:'jump', to:@block_1352 },
   ]
 };
 
-block_1245 = {
+block_1352 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'num_locals' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1246, num_args:2 },
+    { op:'call', ret_to:@block_1353, num_args:2 },
   ]
 };
 
-block_1246 = {
+block_1353 = {
   instrs: [
     { op:'set_local', idx:2 },
     { op:'get_local', idx:0 },
@@ -11429,11 +12242,11 @@ block_1246 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1247, num_args:2 },
+    { op:'call', ret_to:@block_1354, num_args:2 },
   ]
 };
 
-block_1247 = {
+block_1354 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'dup', idx:1 },
@@ -11441,17 +12254,17 @@ block_1247 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1248, num_args:2 },
+    { op:'call', ret_to:@block_1355, num_args:2 },
   ]
 };
 
-block_1248 = {
+block_1355 = {
   instrs: [
-    { op:'call', ret_to:@block_1249, num_args:2 },
+    { op:'call', ret_to:@block_1356, num_args:2 },
   ]
 };
 
-block_1249 = {
+block_1356 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -11459,21 +12272,21 @@ block_1249 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1250, num_args:2 },
+    { op:'call', ret_to:@block_1357, num_args:2 },
   ]
 };
 
-block_1250 = {
+block_1357 = {
   instrs: [
     { op:'push', val:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_add' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1251, num_args:2 },
+    { op:'call', ret_to:@block_1358, num_args:2 },
   ]
 };
 
-block_1251 = {
+block_1358 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'num_locals' },
@@ -11485,13 +12298,13 @@ block_1251 = {
   ]
 };
 
-fun_1240 = {
-  entry:@block_1239,
+fun_1347 = {
+  entry:@block_1346,
   num_params:2,
   num_locals:3,
 };
 
-block_1252 = {
+block_1359 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
@@ -11500,57 +12313,57 @@ block_1252 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1254, num_args:2 },
+    { op:'call', ret_to:@block_1361, num_args:2 },
   ]
 };
 
-block_1254 = {
+block_1361 = {
   instrs: [
-    { op:'call', ret_to:@block_1255, num_args:2 },
+    { op:'call', ret_to:@block_1362, num_args:2 },
   ]
 };
 
-block_1255 = {
+block_1362 = {
   instrs: [
     { op:'push', val:0 },
     { op:'push', val:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_sub' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1256, num_args:2 },
+    { op:'call', ret_to:@block_1363, num_args:2 },
   ]
 };
 
-block_1256 = {
+block_1363 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_ne' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1257, num_args:2 },
+    { op:'call', ret_to:@block_1364, num_args:2 },
   ]
 };
 
-block_1257 = {
+block_1364 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-fun_1253 = {
-  entry:@block_1252,
+fun_1360 = {
+  entry:@block_1359,
   num_params:2,
   num_locals:2,
 };
 
-block_1258 = {
+block_1365 = {
   instrs: [
     { op:'push', val:0 },
     { op:'set_local', idx:2 },
-    { op:'jump', to:@block_1260 },
+    { op:'jump', to:@block_1367 },
   ]
 };
 
-block_1260 = {
+block_1367 = {
   instrs: [
     { op:'get_local', idx:2 },
     { op:'get_local', idx:0 },
@@ -11558,127 +12371,135 @@ block_1260 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1264, num_args:2 },
+    { op:'call', ret_to:@block_1371, num_args:2 },
   ]
 };
 
-block_1264 = {
+block_1371 = {
   instrs: [
     { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1265, num_args:2 },
+    { op:'call', ret_to:@block_1372, num_args:2 },
   ]
 };
 
-block_1265 = {
+block_1372 = {
   instrs: [
-    { op:'lt_i32' },
-    { op:'if_true', then:@block_1261, else:@block_1263 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_lt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1373, num_args:2 },
   ]
 };
 
-block_1261 = {
+block_1373 = {
+  instrs: [
+    { op:'if_true', then:@block_1368, else:@block_1370 },
+  ]
+};
+
+block_1368 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'localNames' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1266, num_args:2 },
+    { op:'call', ret_to:@block_1374, num_args:2 },
   ]
 };
 
-block_1266 = {
+block_1374 = {
   instrs: [
     { op:'get_local', idx:2 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getElem' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1267, num_args:2 },
+    { op:'call', ret_to:@block_1375, num_args:2 },
   ]
 };
 
-block_1267 = {
+block_1375 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1268, num_args:2 },
+    { op:'call', ret_to:@block_1376, num_args:2 },
   ]
 };
 
-block_1269 = {
+block_1377 = {
   instrs: [
     { op:'get_local', idx:2 },
     { op:'ret' },
   ]
 };
 
-block_1268 = {
+block_1376 = {
   instrs: [
-    { op:'if_true', then:@block_1269, else:@block_1270 },
+    { op:'if_true', then:@block_1377, else:@block_1378 },
   ]
 };
 
-block_1270 = {
+block_1378 = {
   instrs: [
-    { op:'jump', to:@block_1271 },
+    { op:'jump', to:@block_1379 },
   ]
 };
 
-block_1271 = {
+block_1379 = {
   instrs: [
-    { op:'jump', to:@block_1262 },
+    { op:'jump', to:@block_1369 },
   ]
 };
 
-block_1262 = {
+block_1369 = {
   instrs: [
     { op:'get_local', idx:2 },
     { op:'push', val:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_add' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1272, num_args:2 },
+    { op:'call', ret_to:@block_1380, num_args:2 },
   ]
 };
 
-block_1272 = {
+block_1380 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'set_local', idx:2 },
     { op:'pop' },
-    { op:'jump', to:@block_1260 },
+    { op:'jump', to:@block_1367 },
   ]
 };
 
-block_1263 = {
+block_1370 = {
   instrs: [
     { op:'push', val:0 },
     { op:'push', val:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_sub' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1273, num_args:2 },
+    { op:'call', ret_to:@block_1381, num_args:2 },
   ]
 };
 
-block_1273 = {
+block_1381 = {
   instrs: [
     { op:'ret' },
   ]
 };
 
-fun_1259 = {
-  entry:@block_1258,
+fun_1366 = {
+  entry:@block_1365,
   num_params:2,
   num_locals:3,
 };
 
-block_1274 = {
+block_1382 = {
   instrs: [
     { op:'push', val:7 },
     { op:'new_object' },
@@ -11720,13 +12541,13 @@ block_1274 = {
   ]
 };
 
-fun_1275 = {
-  entry:@block_1274,
+fun_1383 = {
+  entry:@block_1382,
   num_params:5,
   num_locals:5,
 };
 
-block_1276 = {
+block_1384 = {
   instrs: [
     { op:'push', val:7 },
     { op:'new_object' },
@@ -11743,11 +12564,11 @@ block_1276 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1278, num_args:2 },
+    { op:'call', ret_to:@block_1386, num_args:2 },
   ]
 };
 
-block_1278 = {
+block_1386 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:0 },
@@ -11757,11 +12578,11 @@ block_1278 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1279, num_args:2 },
+    { op:'call', ret_to:@block_1387, num_args:2 },
   ]
 };
 
-block_1279 = {
+block_1387 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:0 },
@@ -11771,11 +12592,11 @@ block_1279 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1280, num_args:2 },
+    { op:'call', ret_to:@block_1388, num_args:2 },
   ]
 };
 
-block_1280 = {
+block_1388 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:0 },
@@ -11785,11 +12606,11 @@ block_1280 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1281, num_args:2 },
+    { op:'call', ret_to:@block_1389, num_args:2 },
   ]
 };
 
-block_1281 = {
+block_1389 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:0 },
@@ -11803,11 +12624,11 @@ block_1281 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1282, num_args:2 },
+    { op:'call', ret_to:@block_1390, num_args:2 },
   ]
 };
 
-block_1282 = {
+block_1390 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:0 },
@@ -11817,24 +12638,24 @@ block_1282 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1283, num_args:2 },
+    { op:'call', ret_to:@block_1391, num_args:2 },
   ]
 };
 
-block_1283 = {
+block_1391 = {
   instrs: [
     { op:'set_field' },
     { op:'ret' },
   ]
 };
 
-fun_1277 = {
-  entry:@block_1276,
+fun_1385 = {
+  entry:@block_1384,
   num_params:2,
   num_locals:2,
 };
 
-block_1284 = {
+block_1392 = {
   instrs: [
     { op:'push', val:7 },
     { op:'new_object' },
@@ -11851,11 +12672,11 @@ block_1284 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1286, num_args:2 },
+    { op:'call', ret_to:@block_1394, num_args:2 },
   ]
 };
 
-block_1286 = {
+block_1394 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:0 },
@@ -11865,11 +12686,11 @@ block_1286 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1287, num_args:2 },
+    { op:'call', ret_to:@block_1395, num_args:2 },
   ]
 };
 
-block_1287 = {
+block_1395 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:0 },
@@ -11879,11 +12700,11 @@ block_1287 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1288, num_args:2 },
+    { op:'call', ret_to:@block_1396, num_args:2 },
   ]
 };
 
-block_1288 = {
+block_1396 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:0 },
@@ -11893,11 +12714,11 @@ block_1288 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1289, num_args:2 },
+    { op:'call', ret_to:@block_1397, num_args:2 },
   ]
 };
 
-block_1289 = {
+block_1397 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:0 },
@@ -11916,13 +12737,13 @@ block_1289 = {
   ]
 };
 
-fun_1285 = {
-  entry:@block_1284,
+fun_1393 = {
+  entry:@block_1392,
   num_params:4,
   num_locals:4,
 };
 
-block_1290 = {
+block_1398 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'get_local', idx:0 },
@@ -11935,65 +12756,65 @@ block_1290 = {
   ]
 };
 
-fun_1291 = {
-  entry:@block_1290,
+fun_1399 = {
+  entry:@block_1398,
   num_params:2,
   num_locals:2,
 };
 
-block_1292 = {
+block_1400 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'curBlock' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1294, num_args:2 },
+    { op:'call', ret_to:@block_1402, num_args:2 },
   ]
 };
 
-block_1294 = {
+block_1402 = {
   instrs: [
     { op:'push', val:$false },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_ne' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1295, num_args:2 },
+    { op:'call', ret_to:@block_1403, num_args:2 },
   ]
 };
 
-block_1295 = {
+block_1403 = {
   instrs: [
-    { op:'if_true', then:@block_1296, else:@block_1297 },
+    { op:'if_true', then:@block_1404, else:@block_1405 },
   ]
 };
 
-block_1296 = {
+block_1404 = {
   instrs: [
-    { op:'jump', to:@block_1298 },
+    { op:'jump', to:@block_1406 },
   ]
 };
 
-block_1297 = {
+block_1405 = {
   instrs: [
     { op:'push', val:'assertion failed' },
     { op:'abort' },
-    { op:'jump', to:@block_1298 },
+    { op:'jump', to:@block_1406 },
   ]
 };
 
-block_1298 = {
+block_1406 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'curBlock' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1299, num_args:2 },
+    { op:'call', ret_to:@block_1407, num_args:2 },
   ]
 };
 
-block_1299 = {
+block_1407 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'dup', idx:1 },
@@ -12001,17 +12822,17 @@ block_1299 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1300, num_args:2 },
+    { op:'call', ret_to:@block_1408, num_args:2 },
   ]
 };
 
-block_1300 = {
+block_1408 = {
   instrs: [
-    { op:'call', ret_to:@block_1301, num_args:2 },
+    { op:'call', ret_to:@block_1409, num_args:2 },
   ]
 };
 
-block_1301 = {
+block_1409 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -12019,24 +12840,24 @@ block_1301 = {
   ]
 };
 
-fun_1293 = {
-  entry:@block_1292,
+fun_1401 = {
+  entry:@block_1400,
   num_params:2,
   num_locals:2,
 };
 
-block_1302 = {
+block_1410 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'curBlock' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1304, num_args:2 },
+    { op:'call', ret_to:@block_1412, num_args:2 },
   ]
 };
 
-block_1304 = {
+block_1412 = {
   instrs: [
     { op:'push', val:1 },
     { op:'new_object' },
@@ -12049,17 +12870,17 @@ block_1304 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1305, num_args:2 },
+    { op:'call', ret_to:@block_1413, num_args:2 },
   ]
 };
 
-block_1305 = {
+block_1413 = {
   instrs: [
-    { op:'call', ret_to:@block_1306, num_args:2 },
+    { op:'call', ret_to:@block_1414, num_args:2 },
   ]
 };
 
-block_1306 = {
+block_1414 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -12067,24 +12888,24 @@ block_1306 = {
   ]
 };
 
-fun_1303 = {
-  entry:@block_1302,
+fun_1411 = {
+  entry:@block_1410,
   num_params:2,
   num_locals:2,
 };
 
-block_1307 = {
+block_1415 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'curBlock' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1309, num_args:2 },
+    { op:'call', ret_to:@block_1417, num_args:2 },
   ]
 };
 
-block_1309 = {
+block_1417 = {
   instrs: [
     { op:'push', val:2 },
     { op:'new_object' },
@@ -12101,17 +12922,17 @@ block_1309 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1310, num_args:2 },
+    { op:'call', ret_to:@block_1418, num_args:2 },
   ]
 };
 
-block_1310 = {
+block_1418 = {
   instrs: [
-    { op:'call', ret_to:@block_1311, num_args:2 },
+    { op:'call', ret_to:@block_1419, num_args:2 },
   ]
 };
 
-block_1311 = {
+block_1419 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -12119,13 +12940,13 @@ block_1311 = {
   ]
 };
 
-fun_1308 = {
-  entry:@block_1307,
+fun_1416 = {
+  entry:@block_1415,
   num_params:2,
   num_locals:2,
 };
 
-block_1312 = {
+block_1420 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -12134,19 +12955,19 @@ block_1312 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1314, num_args:2 },
+    { op:'call', ret_to:@block_1422, num_args:2 },
   ]
 };
 
-block_1315 = {
+block_1423 = {
   instrs: [
     { op:'push', val:0 },
     { op:'set_local', idx:3 },
-    { op:'jump', to:@block_1316 },
+    { op:'jump', to:@block_1424 },
   ]
 };
 
-block_1316 = {
+block_1424 = {
   instrs: [
     { op:'get_local', idx:3 },
     { op:'get_local', idx:1 },
@@ -12154,28 +12975,36 @@ block_1316 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1320, num_args:2 },
+    { op:'call', ret_to:@block_1428, num_args:2 },
   ]
 };
 
-block_1320 = {
+block_1428 = {
   instrs: [
     { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1321, num_args:2 },
+    { op:'call', ret_to:@block_1429, num_args:2 },
   ]
 };
 
-block_1321 = {
+block_1429 = {
   instrs: [
-    { op:'lt_i32' },
-    { op:'if_true', then:@block_1317, else:@block_1319 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_lt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1430, num_args:2 },
   ]
 };
 
-block_1317 = {
+block_1430 = {
+  instrs: [
+    { op:'if_true', then:@block_1425, else:@block_1427 },
+  ]
+};
+
+block_1425 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
@@ -12183,77 +13012,77 @@ block_1317 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1322, num_args:2 },
+    { op:'call', ret_to:@block_1431, num_args:2 },
   ]
 };
 
-block_1322 = {
+block_1431 = {
   instrs: [
     { op:'get_local', idx:3 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getElem' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1323, num_args:2 },
+    { op:'call', ret_to:@block_1432, num_args:2 },
   ]
 };
 
-block_1323 = {
+block_1432 = {
   instrs: [
     { op:'get_local', idx:2 },
     { op:'push', val:@global_obj },
     { op:'push', val:'registerDecls' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1324, num_args:3 },
+    { op:'call', ret_to:@block_1433, num_args:3 },
   ]
 };
 
-block_1324 = {
+block_1433 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_1318 },
+    { op:'jump', to:@block_1426 },
   ]
 };
 
-block_1318 = {
+block_1426 = {
   instrs: [
     { op:'get_local', idx:3 },
     { op:'push', val:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_add' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1325, num_args:2 },
+    { op:'call', ret_to:@block_1434, num_args:2 },
   ]
 };
 
-block_1325 = {
+block_1434 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'set_local', idx:3 },
     { op:'pop' },
-    { op:'jump', to:@block_1316 },
+    { op:'jump', to:@block_1424 },
   ]
 };
 
-block_1319 = {
+block_1427 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-block_1314 = {
+block_1422 = {
   instrs: [
-    { op:'if_true', then:@block_1315, else:@block_1326 },
+    { op:'if_true', then:@block_1423, else:@block_1435 },
   ]
 };
 
-block_1326 = {
+block_1435 = {
   instrs: [
-    { op:'jump', to:@block_1327 },
+    { op:'jump', to:@block_1436 },
   ]
 };
 
-block_1327 = {
+block_1436 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -12262,21 +13091,21 @@ block_1327 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1328, num_args:2 },
+    { op:'call', ret_to:@block_1437, num_args:2 },
   ]
 };
 
-block_1329 = {
+block_1438 = {
   instrs: [
     { op:'get_local', idx:2 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_not' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1330, num_args:1 },
+    { op:'call', ret_to:@block_1439, num_args:1 },
   ]
 };
 
-block_1331 = {
+block_1440 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
@@ -12284,66 +13113,66 @@ block_1331 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1332, num_args:2 },
+    { op:'call', ret_to:@block_1441, num_args:2 },
   ]
 };
 
-block_1332 = {
+block_1441 = {
   instrs: [
     { op:'dup', idx:1 },
     { op:'push', val:'registerDecl' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1333, num_args:2 },
+    { op:'call', ret_to:@block_1442, num_args:2 },
   ]
 };
 
-block_1333 = {
+block_1442 = {
   instrs: [
-    { op:'call', ret_to:@block_1334, num_args:2 },
+    { op:'call', ret_to:@block_1443, num_args:2 },
   ]
 };
 
-block_1330 = {
+block_1439 = {
   instrs: [
-    { op:'if_true', then:@block_1331, else:@block_1335 },
+    { op:'if_true', then:@block_1440, else:@block_1444 },
   ]
 };
 
-block_1334 = {
+block_1443 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_1336 },
+    { op:'jump', to:@block_1445 },
   ]
 };
 
-block_1335 = {
+block_1444 = {
   instrs: [
-    { op:'jump', to:@block_1336 },
+    { op:'jump', to:@block_1445 },
   ]
 };
 
-block_1336 = {
+block_1445 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-block_1328 = {
+block_1437 = {
   instrs: [
-    { op:'if_true', then:@block_1329, else:@block_1337 },
+    { op:'if_true', then:@block_1438, else:@block_1446 },
   ]
 };
 
-block_1337 = {
+block_1446 = {
   instrs: [
-    { op:'jump', to:@block_1338 },
+    { op:'jump', to:@block_1447 },
   ]
 };
 
-block_1338 = {
+block_1447 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -12352,30 +13181,30 @@ block_1338 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1339, num_args:2 },
+    { op:'call', ret_to:@block_1448, num_args:2 },
   ]
 };
 
-block_1340 = {
+block_1449 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-block_1339 = {
+block_1448 = {
   instrs: [
-    { op:'if_true', then:@block_1340, else:@block_1341 },
+    { op:'if_true', then:@block_1449, else:@block_1450 },
   ]
 };
 
-block_1341 = {
+block_1450 = {
   instrs: [
-    { op:'jump', to:@block_1342 },
+    { op:'jump', to:@block_1451 },
   ]
 };
 
-block_1342 = {
+block_1451 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -12384,11 +13213,11 @@ block_1342 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1343, num_args:2 },
+    { op:'call', ret_to:@block_1452, num_args:2 },
   ]
 };
 
-block_1344 = {
+block_1453 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
@@ -12396,21 +13225,21 @@ block_1344 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1345, num_args:2 },
+    { op:'call', ret_to:@block_1454, num_args:2 },
   ]
 };
 
-block_1345 = {
+block_1454 = {
   instrs: [
     { op:'get_local', idx:2 },
     { op:'push', val:@global_obj },
     { op:'push', val:'registerDecls' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1346, num_args:3 },
+    { op:'call', ret_to:@block_1455, num_args:3 },
   ]
 };
 
-block_1346 = {
+block_1455 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -12419,21 +13248,21 @@ block_1346 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1347, num_args:2 },
+    { op:'call', ret_to:@block_1456, num_args:2 },
   ]
 };
 
-block_1347 = {
+block_1456 = {
   instrs: [
     { op:'get_local', idx:2 },
     { op:'push', val:@global_obj },
     { op:'push', val:'registerDecls' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1348, num_args:3 },
+    { op:'call', ret_to:@block_1457, num_args:3 },
   ]
 };
 
-block_1348 = {
+block_1457 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -12441,19 +13270,19 @@ block_1348 = {
   ]
 };
 
-block_1343 = {
+block_1452 = {
   instrs: [
-    { op:'if_true', then:@block_1344, else:@block_1349 },
+    { op:'if_true', then:@block_1453, else:@block_1458 },
   ]
 };
 
-block_1349 = {
+block_1458 = {
   instrs: [
-    { op:'jump', to:@block_1350 },
+    { op:'jump', to:@block_1459 },
   ]
 };
 
-block_1350 = {
+block_1459 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -12462,11 +13291,11 @@ block_1350 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1351, num_args:2 },
+    { op:'call', ret_to:@block_1460, num_args:2 },
   ]
 };
 
-block_1352 = {
+block_1461 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
@@ -12474,21 +13303,21 @@ block_1352 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1353, num_args:2 },
+    { op:'call', ret_to:@block_1462, num_args:2 },
   ]
 };
 
-block_1353 = {
+block_1462 = {
   instrs: [
     { op:'get_local', idx:2 },
     { op:'push', val:@global_obj },
     { op:'push', val:'registerDecls' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1354, num_args:3 },
+    { op:'call', ret_to:@block_1463, num_args:3 },
   ]
 };
 
-block_1354 = {
+block_1463 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -12497,21 +13326,21 @@ block_1354 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1355, num_args:2 },
+    { op:'call', ret_to:@block_1464, num_args:2 },
   ]
 };
 
-block_1355 = {
+block_1464 = {
   instrs: [
     { op:'get_local', idx:2 },
     { op:'push', val:@global_obj },
     { op:'push', val:'registerDecls' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1356, num_args:3 },
+    { op:'call', ret_to:@block_1465, num_args:3 },
   ]
 };
 
-block_1356 = {
+block_1465 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -12519,19 +13348,19 @@ block_1356 = {
   ]
 };
 
-block_1351 = {
+block_1460 = {
   instrs: [
-    { op:'if_true', then:@block_1352, else:@block_1357 },
+    { op:'if_true', then:@block_1461, else:@block_1466 },
   ]
 };
 
-block_1357 = {
+block_1466 = {
   instrs: [
-    { op:'jump', to:@block_1358 },
+    { op:'jump', to:@block_1467 },
   ]
 };
 
-block_1358 = {
+block_1467 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -12540,30 +13369,30 @@ block_1358 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1359, num_args:2 },
+    { op:'call', ret_to:@block_1468, num_args:2 },
   ]
 };
 
-block_1360 = {
+block_1469 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-block_1359 = {
+block_1468 = {
   instrs: [
-    { op:'if_true', then:@block_1360, else:@block_1361 },
+    { op:'if_true', then:@block_1469, else:@block_1470 },
   ]
 };
 
-block_1361 = {
+block_1470 = {
   instrs: [
-    { op:'jump', to:@block_1362 },
+    { op:'jump', to:@block_1471 },
   ]
 };
 
-block_1362 = {
+block_1471 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -12572,30 +13401,30 @@ block_1362 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1363, num_args:2 },
+    { op:'call', ret_to:@block_1472, num_args:2 },
   ]
 };
 
-block_1364 = {
+block_1473 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-block_1363 = {
+block_1472 = {
   instrs: [
-    { op:'if_true', then:@block_1364, else:@block_1365 },
+    { op:'if_true', then:@block_1473, else:@block_1474 },
   ]
 };
 
-block_1365 = {
+block_1474 = {
   instrs: [
-    { op:'jump', to:@block_1366 },
+    { op:'jump', to:@block_1475 },
   ]
 };
 
-block_1366 = {
+block_1475 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -12604,30 +13433,30 @@ block_1366 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1367, num_args:2 },
+    { op:'call', ret_to:@block_1476, num_args:2 },
   ]
 };
 
-block_1368 = {
+block_1477 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-block_1367 = {
+block_1476 = {
   instrs: [
-    { op:'if_true', then:@block_1368, else:@block_1369 },
+    { op:'if_true', then:@block_1477, else:@block_1478 },
   ]
 };
 
-block_1369 = {
+block_1478 = {
   instrs: [
-    { op:'jump', to:@block_1370 },
+    { op:'jump', to:@block_1479 },
   ]
 };
 
-block_1370 = {
+block_1479 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -12636,64 +13465,64 @@ block_1370 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1371, num_args:2 },
+    { op:'call', ret_to:@block_1480, num_args:2 },
   ]
 };
 
-block_1372 = {
+block_1481 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-block_1371 = {
+block_1480 = {
   instrs: [
-    { op:'if_true', then:@block_1372, else:@block_1373 },
+    { op:'if_true', then:@block_1481, else:@block_1482 },
   ]
 };
 
-block_1373 = {
+block_1482 = {
   instrs: [
-    { op:'jump', to:@block_1374 },
+    { op:'jump', to:@block_1483 },
   ]
 };
 
-block_1374 = {
+block_1483 = {
   instrs: [
     { op:'push', val:$false },
-    { op:'if_true', then:@block_1375, else:@block_1376 },
+    { op:'if_true', then:@block_1484, else:@block_1485 },
   ]
 };
 
-block_1375 = {
+block_1484 = {
   instrs: [
-    { op:'jump', to:@block_1377 },
+    { op:'jump', to:@block_1486 },
   ]
 };
 
-block_1376 = {
+block_1485 = {
   instrs: [
     { op:'push', val:'unknown statement type in registerDecls' },
     { op:'abort' },
-    { op:'jump', to:@block_1377 },
+    { op:'jump', to:@block_1486 },
   ]
 };
 
-block_1377 = {
+block_1486 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-fun_1313 = {
-  entry:@block_1312,
+fun_1421 = {
+  entry:@block_1420,
   num_params:3,
   num_locals:4,
 };
 
-block_1378 = {
+block_1487 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'Block' },
@@ -12702,17 +13531,17 @@ block_1378 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1380, num_args:2 },
+    { op:'call', ret_to:@block_1489, num_args:2 },
   ]
 };
 
-block_1380 = {
+block_1489 = {
   instrs: [
-    { op:'call', ret_to:@block_1381, num_args:0 },
+    { op:'call', ret_to:@block_1490, num_args:0 },
   ]
 };
 
-block_1381 = {
+block_1490 = {
   instrs: [
     { op:'set_local', idx:1 },
     { op:'push', val:0 },
@@ -12724,17 +13553,17 @@ block_1381 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1382, num_args:2 },
+    { op:'call', ret_to:@block_1491, num_args:2 },
   ]
 };
 
-block_1382 = {
+block_1491 = {
   instrs: [
-    { op:'call', ret_to:@block_1383, num_args:2 },
+    { op:'call', ret_to:@block_1492, num_args:2 },
   ]
 };
 
-block_1383 = {
+block_1492 = {
   instrs: [
     { op:'set_local', idx:2 },
     { op:'get_local', idx:2 },
@@ -12743,21 +13572,21 @@ block_1383 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1384, num_args:2 },
+    { op:'call', ret_to:@block_1493, num_args:2 },
   ]
 };
 
-block_1384 = {
+block_1493 = {
   instrs: [
     { op:'push', val:$true },
     { op:'push', val:@global_obj },
     { op:'push', val:'registerDecls' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1385, num_args:3 },
+    { op:'call', ret_to:@block_1494, num_args:3 },
   ]
 };
 
-block_1385 = {
+block_1494 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:1 },
@@ -12792,17 +13621,17 @@ block_1385 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1386, num_args:2 },
+    { op:'call', ret_to:@block_1495, num_args:2 },
   ]
 };
 
-block_1386 = {
+block_1495 = {
   instrs: [
-    { op:'call', ret_to:@block_1387, num_args:5 },
+    { op:'call', ret_to:@block_1496, num_args:5 },
   ]
 };
 
-block_1387 = {
+block_1496 = {
   instrs: [
     { op:'set_local', idx:5 },
     { op:'get_local', idx:5 },
@@ -12811,20 +13640,20 @@ block_1387 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1388, num_args:2 },
+    { op:'call', ret_to:@block_1497, num_args:2 },
   ]
 };
 
-block_1388 = {
+block_1497 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'genStmt' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1389, num_args:2 },
+    { op:'call', ret_to:@block_1498, num_args:2 },
   ]
 };
 
-block_1389 = {
+block_1498 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:5 },
@@ -12832,37 +13661,37 @@ block_1389 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1390, num_args:2 },
+    { op:'call', ret_to:@block_1499, num_args:2 },
   ]
 };
 
-block_1390 = {
+block_1499 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'push', val:'hasBranch' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1391, num_args:2 },
+    { op:'call', ret_to:@block_1500, num_args:2 },
   ]
 };
 
-block_1391 = {
+block_1500 = {
   instrs: [
-    { op:'call', ret_to:@block_1392, num_args:1 },
+    { op:'call', ret_to:@block_1501, num_args:1 },
   ]
 };
 
-block_1392 = {
+block_1501 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_not' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1393, num_args:1 },
+    { op:'call', ret_to:@block_1502, num_args:1 },
   ]
 };
 
-block_1394 = {
+block_1503 = {
   instrs: [
     { op:'get_local', idx:5 },
     { op:'push', val:2 },
@@ -12880,17 +13709,17 @@ block_1394 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1395, num_args:2 },
+    { op:'call', ret_to:@block_1504, num_args:2 },
   ]
 };
 
-block_1395 = {
+block_1504 = {
   instrs: [
-    { op:'call', ret_to:@block_1396, num_args:2 },
+    { op:'call', ret_to:@block_1505, num_args:2 },
   ]
 };
 
-block_1396 = {
+block_1505 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:5 },
@@ -12905,49 +13734,49 @@ block_1396 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1397, num_args:2 },
+    { op:'call', ret_to:@block_1506, num_args:2 },
   ]
 };
 
-block_1397 = {
+block_1506 = {
   instrs: [
-    { op:'call', ret_to:@block_1398, num_args:2 },
+    { op:'call', ret_to:@block_1507, num_args:2 },
   ]
 };
 
-block_1393 = {
+block_1502 = {
   instrs: [
-    { op:'if_true', then:@block_1394, else:@block_1399 },
+    { op:'if_true', then:@block_1503, else:@block_1508 },
   ]
 };
 
-block_1398 = {
+block_1507 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_1400 },
+    { op:'jump', to:@block_1509 },
   ]
 };
 
-block_1399 = {
+block_1508 = {
   instrs: [
-    { op:'jump', to:@block_1400 },
+    { op:'jump', to:@block_1509 },
   ]
 };
 
-block_1400 = {
+block_1509 = {
   instrs: [
     { op:'get_local', idx:3 },
     { op:'ret' },
   ]
 };
 
-fun_1379 = {
-  entry:@block_1378,
+fun_1488 = {
+  entry:@block_1487,
   num_params:1,
   num_locals:6,
 };
 
-block_1401 = {
+block_1510 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'Block' },
@@ -12956,17 +13785,17 @@ block_1401 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1403, num_args:2 },
+    { op:'call', ret_to:@block_1512, num_args:2 },
   ]
 };
 
-block_1403 = {
+block_1512 = {
   instrs: [
-    { op:'call', ret_to:@block_1404, num_args:0 },
+    { op:'call', ret_to:@block_1513, num_args:0 },
   ]
 };
 
-block_1404 = {
+block_1513 = {
   instrs: [
     { op:'set_local', idx:2 },
     { op:'get_local', idx:0 },
@@ -12976,17 +13805,17 @@ block_1404 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1405, num_args:2 },
+    { op:'call', ret_to:@block_1514, num_args:2 },
   ]
 };
 
-block_1405 = {
+block_1514 = {
   instrs: [
-    { op:'call', ret_to:@block_1406, num_args:2 },
+    { op:'call', ret_to:@block_1515, num_args:2 },
   ]
 };
 
-block_1406 = {
+block_1515 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -13007,11 +13836,11 @@ block_1406 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1407, num_args:2 },
+    { op:'call', ret_to:@block_1516, num_args:2 },
   ]
 };
 
-block_1407 = {
+block_1516 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:1 },
@@ -13019,17 +13848,17 @@ block_1407 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1408, num_args:2 },
+    { op:'call', ret_to:@block_1517, num_args:2 },
   ]
 };
 
-block_1408 = {
+block_1517 = {
   instrs: [
-    { op:'call', ret_to:@block_1409, num_args:2 },
+    { op:'call', ret_to:@block_1518, num_args:2 },
   ]
 };
 
-block_1409 = {
+block_1518 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -13039,17 +13868,17 @@ block_1409 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1410, num_args:2 },
+    { op:'call', ret_to:@block_1519, num_args:2 },
   ]
 };
 
-block_1410 = {
+block_1519 = {
   instrs: [
-    { op:'call', ret_to:@block_1411, num_args:2 },
+    { op:'call', ret_to:@block_1520, num_args:2 },
   ]
 };
 
-block_1411 = {
+block_1520 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -13057,13 +13886,13 @@ block_1411 = {
   ]
 };
 
-fun_1402 = {
-  entry:@block_1401,
+fun_1511 = {
+  entry:@block_1510,
   num_params:2,
   num_locals:3,
 };
 
-block_1412 = {
+block_1521 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -13072,11 +13901,11 @@ block_1412 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1414, num_args:2 },
+    { op:'call', ret_to:@block_1523, num_args:2 },
   ]
 };
 
-block_1415 = {
+block_1524 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
@@ -13084,28 +13913,28 @@ block_1415 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1416, num_args:2 },
+    { op:'call', ret_to:@block_1525, num_args:2 },
   ]
 };
 
-block_1416 = {
+block_1525 = {
   instrs: [
     { op:'dup', idx:1 },
     { op:'push', val:'addPush' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1417, num_args:2 },
+    { op:'call', ret_to:@block_1526, num_args:2 },
   ]
 };
 
-block_1417 = {
+block_1526 = {
   instrs: [
-    { op:'call', ret_to:@block_1418, num_args:2 },
+    { op:'call', ret_to:@block_1527, num_args:2 },
   ]
 };
 
-block_1418 = {
+block_1527 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -13113,19 +13942,19 @@ block_1418 = {
   ]
 };
 
-block_1414 = {
+block_1523 = {
   instrs: [
-    { op:'if_true', then:@block_1415, else:@block_1419 },
+    { op:'if_true', then:@block_1524, else:@block_1528 },
   ]
 };
 
-block_1419 = {
+block_1528 = {
   instrs: [
-    { op:'jump', to:@block_1420 },
+    { op:'jump', to:@block_1529 },
   ]
 };
 
-block_1420 = {
+block_1529 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -13134,11 +13963,11 @@ block_1420 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1421, num_args:2 },
+    { op:'call', ret_to:@block_1530, num_args:2 },
   ]
 };
 
-block_1422 = {
+block_1531 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
@@ -13146,28 +13975,28 @@ block_1422 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1423, num_args:2 },
+    { op:'call', ret_to:@block_1532, num_args:2 },
   ]
 };
 
-block_1423 = {
+block_1532 = {
   instrs: [
     { op:'dup', idx:1 },
     { op:'push', val:'addPush' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1424, num_args:2 },
+    { op:'call', ret_to:@block_1533, num_args:2 },
   ]
 };
 
-block_1424 = {
+block_1533 = {
   instrs: [
-    { op:'call', ret_to:@block_1425, num_args:2 },
+    { op:'call', ret_to:@block_1534, num_args:2 },
   ]
 };
 
-block_1425 = {
+block_1534 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -13175,19 +14004,19 @@ block_1425 = {
   ]
 };
 
-block_1421 = {
+block_1530 = {
   instrs: [
-    { op:'if_true', then:@block_1422, else:@block_1426 },
+    { op:'if_true', then:@block_1531, else:@block_1535 },
   ]
 };
 
-block_1426 = {
+block_1535 = {
   instrs: [
-    { op:'jump', to:@block_1427 },
+    { op:'jump', to:@block_1536 },
   ]
 };
 
-block_1427 = {
+block_1536 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -13196,32 +14025,32 @@ block_1427 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1428, num_args:2 },
+    { op:'call', ret_to:@block_1537, num_args:2 },
   ]
 };
 
-block_1429 = {
+block_1538 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'name' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1430, num_args:2 },
+    { op:'call', ret_to:@block_1539, num_args:2 },
   ]
 };
 
-block_1430 = {
+block_1539 = {
   instrs: [
     { op:'push', val:'exports' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1431, num_args:2 },
+    { op:'call', ret_to:@block_1540, num_args:2 },
   ]
 };
 
-block_1432 = {
+block_1541 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:0 },
@@ -13229,28 +14058,28 @@ block_1432 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1433, num_args:2 },
+    { op:'call', ret_to:@block_1542, num_args:2 },
   ]
 };
 
-block_1433 = {
+block_1542 = {
   instrs: [
     { op:'dup', idx:1 },
     { op:'push', val:'addPush' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1434, num_args:2 },
+    { op:'call', ret_to:@block_1543, num_args:2 },
   ]
 };
 
-block_1434 = {
+block_1543 = {
   instrs: [
-    { op:'call', ret_to:@block_1435, num_args:2 },
+    { op:'call', ret_to:@block_1544, num_args:2 },
   ]
 };
 
-block_1435 = {
+block_1544 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -13258,40 +14087,40 @@ block_1435 = {
   ]
 };
 
-block_1431 = {
+block_1540 = {
   instrs: [
-    { op:'if_true', then:@block_1432, else:@block_1436 },
+    { op:'if_true', then:@block_1541, else:@block_1545 },
   ]
 };
 
-block_1436 = {
+block_1545 = {
   instrs: [
-    { op:'jump', to:@block_1437 },
+    { op:'jump', to:@block_1546 },
   ]
 };
 
-block_1437 = {
+block_1546 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'name' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1438, num_args:2 },
+    { op:'call', ret_to:@block_1547, num_args:2 },
   ]
 };
 
-block_1438 = {
+block_1547 = {
   instrs: [
     { op:'push', val:'true' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1439, num_args:2 },
+    { op:'call', ret_to:@block_1548, num_args:2 },
   ]
 };
 
-block_1440 = {
+block_1549 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:$true },
@@ -13300,17 +14129,17 @@ block_1440 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1441, num_args:2 },
+    { op:'call', ret_to:@block_1550, num_args:2 },
   ]
 };
 
-block_1441 = {
+block_1550 = {
   instrs: [
-    { op:'call', ret_to:@block_1442, num_args:2 },
+    { op:'call', ret_to:@block_1551, num_args:2 },
   ]
 };
 
-block_1442 = {
+block_1551 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -13318,40 +14147,40 @@ block_1442 = {
   ]
 };
 
-block_1439 = {
+block_1548 = {
   instrs: [
-    { op:'if_true', then:@block_1440, else:@block_1443 },
+    { op:'if_true', then:@block_1549, else:@block_1552 },
   ]
 };
 
-block_1443 = {
+block_1552 = {
   instrs: [
-    { op:'jump', to:@block_1444 },
+    { op:'jump', to:@block_1553 },
   ]
 };
 
-block_1444 = {
+block_1553 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'name' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1445, num_args:2 },
+    { op:'call', ret_to:@block_1554, num_args:2 },
   ]
 };
 
-block_1445 = {
+block_1554 = {
   instrs: [
     { op:'push', val:'false' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1446, num_args:2 },
+    { op:'call', ret_to:@block_1555, num_args:2 },
   ]
 };
 
-block_1447 = {
+block_1556 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:$false },
@@ -13360,17 +14189,17 @@ block_1447 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1448, num_args:2 },
+    { op:'call', ret_to:@block_1557, num_args:2 },
   ]
 };
 
-block_1448 = {
+block_1557 = {
   instrs: [
-    { op:'call', ret_to:@block_1449, num_args:2 },
+    { op:'call', ret_to:@block_1558, num_args:2 },
   ]
 };
 
-block_1449 = {
+block_1558 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -13378,40 +14207,40 @@ block_1449 = {
   ]
 };
 
-block_1446 = {
+block_1555 = {
   instrs: [
-    { op:'if_true', then:@block_1447, else:@block_1450 },
+    { op:'if_true', then:@block_1556, else:@block_1559 },
   ]
 };
 
-block_1450 = {
+block_1559 = {
   instrs: [
-    { op:'jump', to:@block_1451 },
+    { op:'jump', to:@block_1560 },
   ]
 };
 
-block_1451 = {
+block_1560 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'name' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1452, num_args:2 },
+    { op:'call', ret_to:@block_1561, num_args:2 },
   ]
 };
 
-block_1452 = {
+block_1561 = {
   instrs: [
     { op:'push', val:'undef' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1453, num_args:2 },
+    { op:'call', ret_to:@block_1562, num_args:2 },
   ]
 };
 
-block_1454 = {
+block_1563 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:$undef },
@@ -13420,17 +14249,17 @@ block_1454 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1455, num_args:2 },
+    { op:'call', ret_to:@block_1564, num_args:2 },
   ]
 };
 
-block_1455 = {
+block_1564 = {
   instrs: [
-    { op:'call', ret_to:@block_1456, num_args:2 },
+    { op:'call', ret_to:@block_1565, num_args:2 },
   ]
 };
 
-block_1456 = {
+block_1565 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -13438,97 +14267,97 @@ block_1456 = {
   ]
 };
 
-block_1453 = {
+block_1562 = {
   instrs: [
-    { op:'if_true', then:@block_1454, else:@block_1457 },
+    { op:'if_true', then:@block_1563, else:@block_1566 },
   ]
 };
 
-block_1457 = {
+block_1566 = {
   instrs: [
-    { op:'jump', to:@block_1458 },
+    { op:'jump', to:@block_1567 },
   ]
 };
 
-block_1458 = {
+block_1567 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'fun' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1459, num_args:2 },
+    { op:'call', ret_to:@block_1568, num_args:2 },
   ]
 };
 
-block_1459 = {
+block_1568 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'name' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1460, num_args:2 },
+    { op:'call', ret_to:@block_1569, num_args:2 },
   ]
 };
 
-block_1460 = {
+block_1569 = {
   instrs: [
     { op:'dup', idx:1 },
     { op:'push', val:'hasLocal' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1461, num_args:2 },
+    { op:'call', ret_to:@block_1570, num_args:2 },
   ]
 };
 
-block_1461 = {
+block_1570 = {
   instrs: [
-    { op:'call', ret_to:@block_1462, num_args:2 },
+    { op:'call', ret_to:@block_1571, num_args:2 },
   ]
 };
 
-block_1463 = {
+block_1572 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'fun' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1464, num_args:2 },
+    { op:'call', ret_to:@block_1573, num_args:2 },
   ]
 };
 
-block_1464 = {
+block_1573 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'name' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1465, num_args:2 },
+    { op:'call', ret_to:@block_1574, num_args:2 },
   ]
 };
 
-block_1465 = {
+block_1574 = {
   instrs: [
     { op:'dup', idx:1 },
     { op:'push', val:'getLocalIdx' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1466, num_args:2 },
+    { op:'call', ret_to:@block_1575, num_args:2 },
   ]
 };
 
-block_1466 = {
+block_1575 = {
   instrs: [
-    { op:'call', ret_to:@block_1467, num_args:2 },
+    { op:'call', ret_to:@block_1576, num_args:2 },
   ]
 };
 
-block_1467 = {
+block_1576 = {
   instrs: [
     { op:'set_local', idx:2 },
     { op:'get_local', idx:0 },
@@ -13547,1068 +14376,41 @@ block_1467 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1468, num_args:2 },
-  ]
-};
-
-block_1468 = {
-  instrs: [
-    { op:'call', ret_to:@block_1469, num_args:2 },
-  ]
-};
-
-block_1469 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1462 = {
-  instrs: [
-    { op:'if_true', then:@block_1463, else:@block_1470 },
-  ]
-};
-
-block_1470 = {
-  instrs: [
-    { op:'jump', to:@block_1471 },
-  ]
-};
-
-block_1471 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:0 },
-    { op:'push', val:'globalObj' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1472, num_args:2 },
-  ]
-};
-
-block_1472 = {
-  instrs: [
-    { op:'dup', idx:1 },
-    { op:'push', val:'addPush' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1473, num_args:2 },
-  ]
-};
-
-block_1473 = {
-  instrs: [
-    { op:'call', ret_to:@block_1474, num_args:2 },
-  ]
-};
-
-block_1474 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'name' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1475, num_args:2 },
-  ]
-};
-
-block_1475 = {
-  instrs: [
-    { op:'dup', idx:1 },
-    { op:'push', val:'addPush' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1476, num_args:2 },
-  ]
-};
-
-block_1476 = {
-  instrs: [
-    { op:'call', ret_to:@block_1477, num_args:2 },
-  ]
-};
-
-block_1477 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:'get_field' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addOp' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1478, num_args:2 },
-  ]
-};
-
-block_1478 = {
-  instrs: [
-    { op:'call', ret_to:@block_1479, num_args:2 },
-  ]
-};
-
-block_1479 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1428 = {
-  instrs: [
-    { op:'if_true', then:@block_1429, else:@block_1480 },
-  ]
-};
-
-block_1480 = {
-  instrs: [
-    { op:'jump', to:@block_1481 },
-  ]
-};
-
-block_1481 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'UnOpExpr' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_instOf' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1482, num_args:2 },
-  ]
-};
-
-block_1483 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'op' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1484, num_args:2 },
-  ]
-};
-
-block_1484 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'OP_NOT' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1485, num_args:2 },
-  ]
-};
-
-block_1486 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'expr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1487, num_args:2 },
-  ]
-};
-
-block_1487 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1488, num_args:2 },
-  ]
-};
-
-block_1488 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_not' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'runtimeCall' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1489, num_args:2 },
-  ]
-};
-
-block_1489 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1485 = {
-  instrs: [
-    { op:'if_true', then:@block_1486, else:@block_1490 },
-  ]
-};
-
-block_1490 = {
-  instrs: [
-    { op:'jump', to:@block_1491 },
-  ]
-};
-
-block_1491 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'op' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1492, num_args:2 },
-  ]
-};
-
-block_1492 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'OP_NEG' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1493, num_args:2 },
-  ]
-};
-
-block_1494 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:0 },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addPush' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1495, num_args:2 },
-  ]
-};
-
-block_1495 = {
-  instrs: [
-    { op:'call', ret_to:@block_1496, num_args:2 },
-  ]
-};
-
-block_1496 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'expr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1497, num_args:2 },
-  ]
-};
-
-block_1497 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1498, num_args:2 },
-  ]
-};
-
-block_1498 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_sub' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'runtimeCall' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1499, num_args:2 },
-  ]
-};
-
-block_1499 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1493 = {
-  instrs: [
-    { op:'if_true', then:@block_1494, else:@block_1500 },
-  ]
-};
-
-block_1500 = {
-  instrs: [
-    { op:'jump', to:@block_1501 },
-  ]
-};
-
-block_1501 = {
-  instrs: [
-    { op:'push', val:$false },
-    { op:'if_true', then:@block_1502, else:@block_1503 },
-  ]
-};
-
-block_1502 = {
-  instrs: [
-    { op:'jump', to:@block_1504 },
-  ]
-};
-
-block_1503 = {
-  instrs: [
-    { op:'push', val:'unhandled unary op' },
-    { op:'abort' },
-    { op:'jump', to:@block_1504 },
-  ]
-};
-
-block_1482 = {
-  instrs: [
-    { op:'if_true', then:@block_1483, else:@block_1505 },
-  ]
-};
-
-block_1504 = {
-  instrs: [
-    { op:'jump', to:@block_1506 },
-  ]
-};
-
-block_1505 = {
-  instrs: [
-    { op:'jump', to:@block_1506 },
-  ]
-};
-
-block_1506 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'BinOpExpr' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_instOf' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1507, num_args:2 },
-  ]
-};
-
-block_1508 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'op' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1509, num_args:2 },
-  ]
-};
-
-block_1509 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'OP_ASSIGN' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1510, num_args:2 },
-  ]
-};
-
-block_1511 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'lhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1512, num_args:2 },
-  ]
-};
-
-block_1512 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1513, num_args:2 },
-  ]
-};
-
-block_1513 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genAssign' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1514, num_args:3 },
-  ]
-};
-
-block_1514 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1510 = {
-  instrs: [
-    { op:'if_true', then:@block_1511, else:@block_1515 },
-  ]
-};
-
-block_1515 = {
-  instrs: [
-    { op:'jump', to:@block_1516 },
-  ]
-};
-
-block_1516 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'op' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1517, num_args:2 },
-  ]
-};
-
-block_1517 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'OP_AND' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1518, num_args:2 },
-  ]
-};
-
-block_1519 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'lhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1520, num_args:2 },
-  ]
-};
-
-block_1520 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1521, num_args:2 },
-  ]
-};
-
-block_1521 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genLogicalAnd' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1522, num_args:3 },
-  ]
-};
-
-block_1522 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1518 = {
-  instrs: [
-    { op:'if_true', then:@block_1519, else:@block_1523 },
-  ]
-};
-
-block_1523 = {
-  instrs: [
-    { op:'jump', to:@block_1524 },
-  ]
-};
-
-block_1524 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'op' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1525, num_args:2 },
-  ]
-};
-
-block_1525 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'OP_OR' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1526, num_args:2 },
-  ]
-};
-
-block_1527 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'lhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1528, num_args:2 },
-  ]
-};
-
-block_1528 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1529, num_args:2 },
-  ]
-};
-
-block_1529 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genLogicalOr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1530, num_args:3 },
-  ]
-};
-
-block_1530 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1526 = {
-  instrs: [
-    { op:'if_true', then:@block_1527, else:@block_1531 },
-  ]
-};
-
-block_1531 = {
-  instrs: [
-    { op:'jump', to:@block_1532 },
-  ]
-};
-
-block_1532 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'op' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1533, num_args:2 },
-  ]
-};
-
-block_1533 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'OP_EQ' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1534, num_args:2 },
-  ]
-};
-
-block_1535 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'lhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1536, num_args:2 },
-  ]
-};
-
-block_1536 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'UnOpExpr' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_instOf' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1537, num_args:2 },
-  ]
-};
-
-block_1538 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'lhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1539, num_args:2 },
-  ]
-};
-
-block_1539 = {
-  instrs: [
-    { op:'push', val:'op' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1540, num_args:2 },
-  ]
-};
-
-block_1540 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'OP_TYPEOF' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1541, num_args:2 },
-  ]
-};
-
-block_1542 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1543, num_args:2 },
-  ]
-};
-
-block_1543 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'StringExpr' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_instOf' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1544, num_args:2 },
-  ]
-};
-
-block_1545 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1546, num_args:2 },
-  ]
-};
-
-block_1546 = {
-  instrs: [
-    { op:'push', val:'val' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1547, num_args:2 },
-  ]
-};
-
-block_1547 = {
-  instrs: [
-    { op:'set_local', idx:3 },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'lhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1548, num_args:2 },
-  ]
-};
-
-block_1548 = {
-  instrs: [
-    { op:'push', val:'expr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1549, num_args:2 },
-  ]
-};
-
-block_1549 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1550, num_args:2 },
-  ]
-};
-
-block_1550 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:2 },
-    { op:'new_object' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'op' },
-    { op:'push', val:'has_tag' },
-    { op:'set_field' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'tag' },
-    { op:'get_local', idx:3 },
-    { op:'set_field' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addInstr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1551, num_args:2 },
-  ]
-};
-
-block_1551 = {
-  instrs: [
-    { op:'call', ret_to:@block_1552, num_args:2 },
-  ]
-};
-
-block_1552 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1544 = {
-  instrs: [
-    { op:'if_true', then:@block_1545, else:@block_1553 },
-  ]
-};
-
-block_1553 = {
-  instrs: [
-    { op:'jump', to:@block_1554 },
-  ]
-};
-
-block_1541 = {
-  instrs: [
-    { op:'if_true', then:@block_1542, else:@block_1555 },
-  ]
-};
-
-block_1554 = {
-  instrs: [
-    { op:'jump', to:@block_1556 },
-  ]
-};
-
-block_1555 = {
-  instrs: [
-    { op:'jump', to:@block_1556 },
-  ]
-};
-
-block_1537 = {
-  instrs: [
-    { op:'if_true', then:@block_1538, else:@block_1557 },
-  ]
-};
-
-block_1556 = {
-  instrs: [
-    { op:'jump', to:@block_1558 },
-  ]
-};
-
-block_1557 = {
-  instrs: [
-    { op:'jump', to:@block_1558 },
-  ]
-};
-
-block_1558 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'lhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1559, num_args:2 },
-  ]
-};
-
-block_1559 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1560, num_args:2 },
-  ]
-};
-
-block_1560 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1561, num_args:2 },
-  ]
-};
-
-block_1561 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1562, num_args:2 },
-  ]
-};
-
-block_1562 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'runtimeCall' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1563, num_args:2 },
-  ]
-};
-
-block_1563 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1534 = {
-  instrs: [
-    { op:'if_true', then:@block_1535, else:@block_1564 },
-  ]
-};
-
-block_1564 = {
-  instrs: [
-    { op:'jump', to:@block_1565 },
-  ]
-};
-
-block_1565 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'op' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1566, num_args:2 },
-  ]
-};
-
-block_1566 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'OP_NE' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1567, num_args:2 },
-  ]
-};
-
-block_1568 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'lhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1569, num_args:2 },
-  ]
-};
-
-block_1569 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1570, num_args:2 },
-  ]
-};
-
-block_1570 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1571, num_args:2 },
-  ]
-};
-
-block_1571 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1572, num_args:2 },
-  ]
-};
-
-block_1572 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_ne' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'runtimeCall' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1573, num_args:2 },
-  ]
-};
-
-block_1573 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1567 = {
-  instrs: [
-    { op:'if_true', then:@block_1568, else:@block_1574 },
-  ]
-};
-
-block_1574 = {
-  instrs: [
-    { op:'jump', to:@block_1575 },
-  ]
-};
-
-block_1575 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'op' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1576, num_args:2 },
-  ]
-};
-
-block_1576 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'OP_LT' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
     { op:'call', ret_to:@block_1577, num_args:2 },
+  ]
+};
+
+block_1577 = {
+  instrs: [
+    { op:'call', ret_to:@block_1578, num_args:2 },
   ]
 };
 
 block_1578 = {
   instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'lhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1579, num_args:2 },
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1571 = {
+  instrs: [
+    { op:'if_true', then:@block_1572, else:@block_1579 },
   ]
 };
 
 block_1579 = {
   instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1580, num_args:2 },
+    { op:'jump', to:@block_1580 },
   ]
 };
 
 block_1580 = {
   instrs: [
-    { op:'pop' },
     { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:'globalObj' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -14618,8 +14420,10 @@ block_1580 = {
 
 block_1581 = {
   instrs: [
+    { op:'dup', idx:1 },
+    { op:'push', val:'addPush' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
+    { op:'push', val:'rt_getProp' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1582, num_args:2 },
   ]
@@ -14627,48 +14431,47 @@ block_1581 = {
 
 block_1582 = {
   instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:'lt_i32' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addOp' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
     { op:'call', ret_to:@block_1583, num_args:2 },
   ]
 };
 
 block_1583 = {
   instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'name' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
     { op:'call', ret_to:@block_1584, num_args:2 },
   ]
 };
 
 block_1584 = {
   instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1577 = {
-  instrs: [
-    { op:'if_true', then:@block_1578, else:@block_1585 },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addPush' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1585, num_args:2 },
   ]
 };
 
 block_1585 = {
   instrs: [
-    { op:'jump', to:@block_1586 },
+    { op:'call', ret_to:@block_1586, num_args:2 },
   ]
 };
 
 block_1586 = {
   instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'op' },
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:'get_field' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addOp' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -14678,74 +14481,11 @@ block_1586 = {
 
 block_1587 = {
   instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'OP_LE' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
     { op:'call', ret_to:@block_1588, num_args:2 },
   ]
 };
 
-block_1589 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'lhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1590, num_args:2 },
-  ]
-};
-
-block_1590 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1591, num_args:2 },
-  ]
-};
-
-block_1591 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1592, num_args:2 },
-  ]
-};
-
-block_1592 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1593, num_args:2 },
-  ]
-};
-
-block_1593 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_le' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'runtimeCall' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1594, num_args:2 },
-  ]
-};
-
-block_1594 = {
+block_1588 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -14753,24 +14493,70 @@ block_1594 = {
   ]
 };
 
-block_1588 = {
+block_1537 = {
   instrs: [
-    { op:'if_true', then:@block_1589, else:@block_1595 },
+    { op:'if_true', then:@block_1538, else:@block_1589 },
   ]
 };
 
-block_1595 = {
+block_1589 = {
   instrs: [
-    { op:'jump', to:@block_1596 },
+    { op:'jump', to:@block_1590 },
   ]
 };
 
-block_1596 = {
+block_1590 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'UnOpExpr' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_instOf' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1591, num_args:2 },
+  ]
+};
+
+block_1592 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'op' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1593, num_args:2 },
+  ]
+};
+
+block_1593 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'OP_NOT' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1594, num_args:2 },
+  ]
+};
+
+block_1595 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'expr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1596, num_args:2 },
+  ]
+};
+
+block_1596 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1597, num_args:2 },
   ]
@@ -14778,32 +14564,44 @@ block_1596 = {
 
 block_1597 = {
   instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
-    { op:'push', val:'OP_GT' },
+    { op:'push', val:'rt_not' },
     { op:'get_field' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
+    { op:'push', val:'runtimeCall' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1598, num_args:2 },
   ]
 };
 
+block_1598 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1594 = {
+  instrs: [
+    { op:'if_true', then:@block_1595, else:@block_1599 },
+  ]
+};
+
 block_1599 = {
   instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'lhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1600, num_args:2 },
+    { op:'jump', to:@block_1600 },
   ]
 };
 
 block_1600 = {
   instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'op' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
+    { op:'push', val:'rt_getProp' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1601, num_args:2 },
   ]
@@ -14811,33 +14609,22 @@ block_1600 = {
 
 block_1601 = {
   instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'OP_NEG' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1602, num_args:2 },
   ]
 };
 
-block_1602 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1603, num_args:2 },
-  ]
-};
-
 block_1603 = {
   instrs: [
-    { op:'pop' },
     { op:'get_local', idx:0 },
-    { op:'push', val:'gt_i32' },
+    { op:'push', val:0 },
     { op:'dup', idx:1 },
-    { op:'push', val:'addOp' },
+    { op:'push', val:'addPush' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -14854,29 +14641,34 @@ block_1604 = {
 block_1605 = {
   instrs: [
     { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1598 = {
-  instrs: [
-    { op:'if_true', then:@block_1599, else:@block_1606 },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'expr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1606, num_args:2 },
   ]
 };
 
 block_1606 = {
   instrs: [
-    { op:'jump', to:@block_1607 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1607, num_args:2 },
   ]
 };
 
 block_1607 = {
   instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'op' },
+    { op:'pop' },
+    { op:'get_local', idx:0 },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'rt_sub' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'runtimeCall' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1608, num_args:2 },
   ]
@@ -14884,90 +14676,73 @@ block_1607 = {
 
 block_1608 = {
   instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'OP_GE' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1609, num_args:2 },
-  ]
-};
-
-block_1610 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'lhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1611, num_args:2 },
-  ]
-};
-
-block_1611 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1612, num_args:2 },
-  ]
-};
-
-block_1612 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1613, num_args:2 },
-  ]
-};
-
-block_1613 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1614, num_args:2 },
-  ]
-};
-
-block_1614 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_ge' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'runtimeCall' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1615, num_args:2 },
-  ]
-};
-
-block_1615 = {
-  instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-block_1609 = {
+block_1602 = {
   instrs: [
-    { op:'if_true', then:@block_1610, else:@block_1616 },
+    { op:'if_true', then:@block_1603, else:@block_1609 },
   ]
 };
 
-block_1616 = {
+block_1609 = {
   instrs: [
-    { op:'jump', to:@block_1617 },
+    { op:'jump', to:@block_1610 },
+  ]
+};
+
+block_1610 = {
+  instrs: [
+    { op:'push', val:$false },
+    { op:'if_true', then:@block_1611, else:@block_1612 },
+  ]
+};
+
+block_1611 = {
+  instrs: [
+    { op:'jump', to:@block_1613 },
+  ]
+};
+
+block_1612 = {
+  instrs: [
+    { op:'push', val:'unhandled unary op' },
+    { op:'abort' },
+    { op:'jump', to:@block_1613 },
+  ]
+};
+
+block_1591 = {
+  instrs: [
+    { op:'if_true', then:@block_1592, else:@block_1614 },
+  ]
+};
+
+block_1613 = {
+  instrs: [
+    { op:'jump', to:@block_1615 },
+  ]
+};
+
+block_1614 = {
+  instrs: [
+    { op:'jump', to:@block_1615 },
+  ]
+};
+
+block_1615 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'BinOpExpr' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_instOf' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1616, num_args:2 },
   ]
 };
 
@@ -14985,7 +14760,7 @@ block_1617 = {
 block_1618 = {
   instrs: [
     { op:'push', val:@global_obj },
-    { op:'push', val:'OP_IN' },
+    { op:'push', val:'OP_ASSIGN' },
     { op:'get_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
@@ -15008,8 +14783,10 @@ block_1620 = {
 
 block_1621 = {
   instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'rhsExpr' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
+    { op:'push', val:'rt_getProp' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1622, num_args:2 },
   ]
@@ -15017,41 +14794,14 @@ block_1621 = {
 
 block_1622 = {
   instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'genAssign' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1623, num_args:2 },
+    { op:'call', ret_to:@block_1623, num_args:3 },
   ]
 };
 
 block_1623 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1624, num_args:2 },
-  ]
-};
-
-block_1624 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_in' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'runtimeCall' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1625, num_args:2 },
-  ]
-};
-
-block_1625 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -15061,40 +14811,40 @@ block_1625 = {
 
 block_1619 = {
   instrs: [
-    { op:'if_true', then:@block_1620, else:@block_1626 },
+    { op:'if_true', then:@block_1620, else:@block_1624 },
   ]
 };
 
-block_1626 = {
+block_1624 = {
   instrs: [
-    { op:'jump', to:@block_1627 },
+    { op:'jump', to:@block_1625 },
   ]
 };
 
-block_1627 = {
+block_1625 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'op' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1628, num_args:2 },
+    { op:'call', ret_to:@block_1626, num_args:2 },
   ]
 };
 
-block_1628 = {
+block_1626 = {
   instrs: [
     { op:'push', val:@global_obj },
-    { op:'push', val:'OP_ADD' },
+    { op:'push', val:'OP_AND' },
     { op:'get_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1629, num_args:2 },
+    { op:'call', ret_to:@block_1627, num_args:2 },
   ]
 };
 
-block_1630 = {
+block_1628 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
@@ -15102,56 +14852,31 @@ block_1630 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1631, num_args:2 },
+    { op:'call', ret_to:@block_1629, num_args:2 },
   ]
 };
 
-block_1631 = {
+block_1629 = {
   instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1632, num_args:2 },
-  ]
-};
-
-block_1632 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
     { op:'push', val:'rhsExpr' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1633, num_args:2 },
+    { op:'call', ret_to:@block_1630, num_args:2 },
   ]
 };
 
-block_1633 = {
+block_1630 = {
   instrs: [
     { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
+    { op:'push', val:'genLogicalAnd' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1634, num_args:2 },
+    { op:'call', ret_to:@block_1631, num_args:3 },
   ]
 };
 
-block_1634 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_add' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'runtimeCall' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1635, num_args:2 },
-  ]
-};
-
-block_1635 = {
+block_1631 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -15159,22 +14884,57 @@ block_1635 = {
   ]
 };
 
-block_1629 = {
+block_1627 = {
   instrs: [
-    { op:'if_true', then:@block_1630, else:@block_1636 },
+    { op:'if_true', then:@block_1628, else:@block_1632 },
+  ]
+};
+
+block_1632 = {
+  instrs: [
+    { op:'jump', to:@block_1633 },
+  ]
+};
+
+block_1633 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'op' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1634, num_args:2 },
+  ]
+};
+
+block_1634 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'OP_OR' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1635, num_args:2 },
   ]
 };
 
 block_1636 = {
   instrs: [
-    { op:'jump', to:@block_1637 },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'lhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1637, num_args:2 },
   ]
 };
 
 block_1637 = {
   instrs: [
     { op:'get_local', idx:1 },
-    { op:'push', val:'op' },
+    { op:'push', val:'rhsExpr' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -15185,73 +14945,13 @@ block_1637 = {
 block_1638 = {
   instrs: [
     { op:'push', val:@global_obj },
-    { op:'push', val:'OP_SUB' },
+    { op:'push', val:'genLogicalOr' },
     { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1639, num_args:2 },
+    { op:'call', ret_to:@block_1639, num_args:3 },
   ]
 };
 
-block_1640 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'lhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1641, num_args:2 },
-  ]
-};
-
-block_1641 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1642, num_args:2 },
-  ]
-};
-
-block_1642 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1643, num_args:2 },
-  ]
-};
-
-block_1643 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1644, num_args:2 },
-  ]
-};
-
-block_1644 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_sub' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'runtimeCall' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1645, num_args:2 },
-  ]
-};
-
-block_1645 = {
+block_1639 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -15259,22 +14959,68 @@ block_1645 = {
   ]
 };
 
-block_1639 = {
+block_1635 = {
   instrs: [
-    { op:'if_true', then:@block_1640, else:@block_1646 },
+    { op:'if_true', then:@block_1636, else:@block_1640 },
   ]
 };
 
-block_1646 = {
+block_1640 = {
   instrs: [
-    { op:'jump', to:@block_1647 },
+    { op:'jump', to:@block_1641 },
+  ]
+};
+
+block_1641 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'op' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1642, num_args:2 },
+  ]
+};
+
+block_1642 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'OP_EQ' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1643, num_args:2 },
+  ]
+};
+
+block_1644 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'lhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1645, num_args:2 },
+  ]
+};
+
+block_1645 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'UnOpExpr' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_instOf' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1646, num_args:2 },
   ]
 };
 
 block_1647 = {
   instrs: [
     { op:'get_local', idx:1 },
-    { op:'push', val:'op' },
+    { op:'push', val:'lhsExpr' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -15284,32 +15030,32 @@ block_1647 = {
 
 block_1648 = {
   instrs: [
+    { op:'push', val:'op' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'OP_MUL' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
+    { op:'push', val:'rt_getProp' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1649, num_args:2 },
   ]
 };
 
-block_1650 = {
+block_1649 = {
   instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'lhsExpr' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'OP_TYPEOF' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1651, num_args:2 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1650, num_args:2 },
   ]
 };
 
 block_1651 = {
   instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'rhsExpr' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
+    { op:'push', val:'rt_getProp' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1652, num_args:2 },
   ]
@@ -15317,33 +15063,20 @@ block_1651 = {
 
 block_1652 = {
   instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'StringExpr' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_instOf' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1653, num_args:2 },
   ]
 };
 
-block_1653 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1654, num_args:2 },
-  ]
-};
-
 block_1654 = {
   instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:'mul_i32' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addOp' },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'rhsExpr' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -15353,36 +15086,41 @@ block_1654 = {
 
 block_1655 = {
   instrs: [
+    { op:'push', val:'val' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
     { op:'call', ret_to:@block_1656, num_args:2 },
   ]
 };
 
 block_1656 = {
   instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1649 = {
-  instrs: [
-    { op:'if_true', then:@block_1650, else:@block_1657 },
+    { op:'set_local', idx:3 },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'lhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1657, num_args:2 },
   ]
 };
 
 block_1657 = {
   instrs: [
-    { op:'jump', to:@block_1658 },
+    { op:'push', val:'expr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1658, num_args:2 },
   ]
 };
 
 block_1658 = {
   instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'op' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'genExpr' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1659, num_args:2 },
   ]
@@ -15390,155 +15128,34 @@ block_1658 = {
 
 block_1659 = {
   instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'OP_MEMBER' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1660, num_args:2 },
-  ]
-};
-
-block_1661 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'lhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1662, num_args:2 },
-  ]
-};
-
-block_1662 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1663, num_args:2 },
-  ]
-};
-
-block_1663 = {
-  instrs: [
     { op:'pop' },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1664, num_args:2 },
-  ]
-};
-
-block_1664 = {
-  instrs: [
-    { op:'set_local', idx:4 },
-    { op:'get_local', idx:4 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'IdentExpr' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_instOf' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1665, num_args:2 },
-  ]
-};
-
-block_1665 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_not' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1666, num_args:1 },
-  ]
-};
-
-block_1667 = {
-  instrs: [
-    { op:'push', val:$false },
-    { op:'push', val:'invalid rhs in member expression' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'parseError' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1668, num_args:2 },
-  ]
-};
-
-block_1666 = {
-  instrs: [
-    { op:'if_true', then:@block_1667, else:@block_1669 },
-  ]
-};
-
-block_1668 = {
-  instrs: [
-    { op:'pop' },
-    { op:'jump', to:@block_1670 },
-  ]
-};
-
-block_1669 = {
-  instrs: [
-    { op:'jump', to:@block_1670 },
-  ]
-};
-
-block_1670 = {
-  instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:2 },
     { op:'new_object' },
     { op:'dup', idx:0 },
     { op:'push', val:'op' },
-    { op:'push', val:'push' },
+    { op:'push', val:'has_tag' },
     { op:'set_field' },
     { op:'dup', idx:0 },
-    { op:'push', val:'val' },
-    { op:'get_local', idx:4 },
-    { op:'push', val:'name' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1671, num_args:2 },
-  ]
-};
-
-block_1671 = {
-  instrs: [
+    { op:'push', val:'tag' },
+    { op:'get_local', idx:3 },
     { op:'set_field' },
     { op:'dup', idx:1 },
     { op:'push', val:'addInstr' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1672, num_args:2 },
+    { op:'call', ret_to:@block_1660, num_args:2 },
   ]
 };
 
-block_1672 = {
+block_1660 = {
   instrs: [
-    { op:'call', ret_to:@block_1673, num_args:2 },
+    { op:'call', ret_to:@block_1661, num_args:2 },
   ]
 };
 
-block_1673 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'runtimeCall' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1674, num_args:2 },
-  ]
-};
-
-block_1674 = {
+block_1661 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -15546,46 +15163,181 @@ block_1674 = {
   ]
 };
 
-block_1660 = {
+block_1653 = {
   instrs: [
-    { op:'if_true', then:@block_1661, else:@block_1675 },
+    { op:'if_true', then:@block_1654, else:@block_1662 },
   ]
 };
 
-block_1675 = {
+block_1662 = {
   instrs: [
-    { op:'jump', to:@block_1676 },
+    { op:'jump', to:@block_1663 },
   ]
 };
 
-block_1676 = {
+block_1650 = {
+  instrs: [
+    { op:'if_true', then:@block_1651, else:@block_1664 },
+  ]
+};
+
+block_1663 = {
+  instrs: [
+    { op:'jump', to:@block_1665 },
+  ]
+};
+
+block_1664 = {
+  instrs: [
+    { op:'jump', to:@block_1665 },
+  ]
+};
+
+block_1646 = {
+  instrs: [
+    { op:'if_true', then:@block_1647, else:@block_1666 },
+  ]
+};
+
+block_1665 = {
+  instrs: [
+    { op:'jump', to:@block_1667 },
+  ]
+};
+
+block_1666 = {
+  instrs: [
+    { op:'jump', to:@block_1667 },
+  ]
+};
+
+block_1667 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'lhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1668, num_args:2 },
+  ]
+};
+
+block_1668 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1669, num_args:2 },
+  ]
+};
+
+block_1669 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'rhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1670, num_args:2 },
+  ]
+};
+
+block_1670 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1671, num_args:2 },
+  ]
+};
+
+block_1671 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'runtimeCall' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1672, num_args:2 },
+  ]
+};
+
+block_1672 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1643 = {
+  instrs: [
+    { op:'if_true', then:@block_1644, else:@block_1673 },
+  ]
+};
+
+block_1673 = {
+  instrs: [
+    { op:'jump', to:@block_1674 },
+  ]
+};
+
+block_1674 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'op' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1677, num_args:2 },
+    { op:'call', ret_to:@block_1675, num_args:2 },
+  ]
+};
+
+block_1675 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'OP_NE' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1676, num_args:2 },
   ]
 };
 
 block_1677 = {
   instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'lhsExpr' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'OP_INDEX' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
+    { op:'push', val:'rt_getProp' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1678, num_args:2 },
   ]
 };
 
+block_1678 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1679, num_args:2 },
+  ]
+};
+
 block_1679 = {
   instrs: [
+    { op:'pop' },
     { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
-    { op:'push', val:'lhsExpr' },
+    { op:'push', val:'rhsExpr' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -15606,10 +15358,11 @@ block_1681 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'rt_ne' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'runtimeCall' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1682, num_args:2 },
   ]
@@ -15617,72 +15370,72 @@ block_1681 = {
 
 block_1682 = {
   instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1683, num_args:2 },
-  ]
-};
-
-block_1683 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getElem' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'runtimeCall' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1684, num_args:2 },
-  ]
-};
-
-block_1684 = {
-  instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-block_1678 = {
+block_1676 = {
   instrs: [
-    { op:'if_true', then:@block_1679, else:@block_1685 },
+    { op:'if_true', then:@block_1677, else:@block_1683 },
   ]
 };
 
-block_1685 = {
+block_1683 = {
   instrs: [
-    { op:'jump', to:@block_1686 },
+    { op:'jump', to:@block_1684 },
   ]
 };
 
-block_1686 = {
+block_1684 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'op' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1687, num_args:2 },
+    { op:'call', ret_to:@block_1685, num_args:2 },
+  ]
+};
+
+block_1685 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'OP_LT' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1686, num_args:2 },
   ]
 };
 
 block_1687 = {
   instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'lhsExpr' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'OP_OBJ_EXT' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_eq' },
+    { op:'push', val:'rt_getProp' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1688, num_args:2 },
   ]
 };
 
+block_1688 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1689, num_args:2 },
+  ]
+};
+
 block_1689 = {
   instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
     { op:'push', val:'rhsExpr' },
     { op:'push', val:@global_obj },
@@ -15694,11 +15447,8 @@ block_1689 = {
 
 block_1690 = {
   instrs: [
-    { op:'set_local', idx:5 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'genExpr' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1691, num_args:2 },
   ]
@@ -15706,11 +15456,13 @@ block_1690 = {
 
 block_1691 = {
   instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:'lt_i32' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addOp' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'ObjectExpr' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_instOf' },
+    { op:'push', val:'rt_getProp' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1692, num_args:2 },
   ]
@@ -15718,61 +15470,58 @@ block_1691 = {
 
 block_1692 = {
   instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_not' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1693, num_args:1 },
-  ]
-};
-
-block_1694 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'input' },
-    { op:'get_field' },
-    { op:'push', val:'invalid rhs in objext extension expression' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'parseError' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1695, num_args:2 },
+    { op:'call', ret_to:@block_1693, num_args:2 },
   ]
 };
 
 block_1693 = {
   instrs: [
-    { op:'if_true', then:@block_1694, else:@block_1696 },
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1686 = {
+  instrs: [
+    { op:'if_true', then:@block_1687, else:@block_1694 },
+  ]
+};
+
+block_1694 = {
+  instrs: [
+    { op:'jump', to:@block_1695 },
   ]
 };
 
 block_1695 = {
   instrs: [
-    { op:'pop' },
-    { op:'jump', to:@block_1697 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'op' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1696, num_args:2 },
   ]
 };
 
 block_1696 = {
   instrs: [
-    { op:'jump', to:@block_1697 },
-  ]
-};
-
-block_1697 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'lhsExpr' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'OP_LE' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1698, num_args:2 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1697, num_args:2 },
   ]
 };
 
 block_1698 = {
   instrs: [
+    { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
-    { op:'push', val:'rhsExpr' },
+    { op:'push', val:'lhsExpr' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -15783,13 +15532,49 @@ block_1698 = {
 block_1699 = {
   instrs: [
     { op:'push', val:@global_obj },
-    { op:'push', val:'genObjExpr' },
+    { op:'push', val:'genExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1700, num_args:3 },
+    { op:'call', ret_to:@block_1700, num_args:2 },
   ]
 };
 
 block_1700 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'rhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1701, num_args:2 },
+  ]
+};
+
+block_1701 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1702, num_args:2 },
+  ]
+};
+
+block_1702 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_le' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'runtimeCall' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1703, num_args:2 },
+  ]
+};
+
+block_1703 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -15797,33 +15582,22 @@ block_1700 = {
   ]
 };
 
-block_1688 = {
+block_1697 = {
   instrs: [
-    { op:'if_true', then:@block_1689, else:@block_1701 },
-  ]
-};
-
-block_1701 = {
-  instrs: [
-    { op:'jump', to:@block_1702 },
+    { op:'if_true', then:@block_1698, else:@block_1704 },
   ]
 };
 
 block_1704 = {
   instrs: [
-    { op:'push', val:'unhandled binary op ' },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'op' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1705, num_args:2 },
+    { op:'jump', to:@block_1705 },
   ]
 };
 
 block_1705 = {
   instrs: [
-    { op:'push', val:'str' },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'op' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -15834,51 +15608,1106 @@ block_1705 = {
 block_1706 = {
   instrs: [
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_add' },
+    { op:'push', val:'OP_GT' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1707, num_args:2 },
   ]
 };
 
-block_1702 = {
-  instrs: [
-    { op:'push', val:$false },
-    { op:'if_true', then:@block_1703, else:@block_1704 },
-  ]
-};
-
-block_1703 = {
-  instrs: [
-    { op:'jump', to:@block_1708 },
-  ]
-};
-
-block_1707 = {
-  instrs: [
-    { op:'abort' },
-    { op:'jump', to:@block_1708 },
-  ]
-};
-
-block_1507 = {
-  instrs: [
-    { op:'if_true', then:@block_1508, else:@block_1709 },
-  ]
-};
-
 block_1708 = {
   instrs: [
-    { op:'jump', to:@block_1710 },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'lhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1709, num_args:2 },
   ]
 };
 
 block_1709 = {
   instrs: [
-    { op:'jump', to:@block_1710 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1710, num_args:2 },
   ]
 };
 
 block_1710 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'rhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1711, num_args:2 },
+  ]
+};
+
+block_1711 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1712, num_args:2 },
+  ]
+};
+
+block_1712 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:'gt_i32' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addOp' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1713, num_args:2 },
+  ]
+};
+
+block_1713 = {
+  instrs: [
+    { op:'call', ret_to:@block_1714, num_args:2 },
+  ]
+};
+
+block_1714 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1707 = {
+  instrs: [
+    { op:'if_true', then:@block_1708, else:@block_1715 },
+  ]
+};
+
+block_1715 = {
+  instrs: [
+    { op:'jump', to:@block_1716 },
+  ]
+};
+
+block_1716 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'op' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1717, num_args:2 },
+  ]
+};
+
+block_1717 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'OP_GE' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1718, num_args:2 },
+  ]
+};
+
+block_1719 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'lhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1720, num_args:2 },
+  ]
+};
+
+block_1720 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1721, num_args:2 },
+  ]
+};
+
+block_1721 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'rhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1722, num_args:2 },
+  ]
+};
+
+block_1722 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1723, num_args:2 },
+  ]
+};
+
+block_1723 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_ge' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'runtimeCall' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1724, num_args:2 },
+  ]
+};
+
+block_1724 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1718 = {
+  instrs: [
+    { op:'if_true', then:@block_1719, else:@block_1725 },
+  ]
+};
+
+block_1725 = {
+  instrs: [
+    { op:'jump', to:@block_1726 },
+  ]
+};
+
+block_1726 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'op' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1727, num_args:2 },
+  ]
+};
+
+block_1727 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'OP_IN' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1728, num_args:2 },
+  ]
+};
+
+block_1729 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'lhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1730, num_args:2 },
+  ]
+};
+
+block_1730 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1731, num_args:2 },
+  ]
+};
+
+block_1731 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'rhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1732, num_args:2 },
+  ]
+};
+
+block_1732 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1733, num_args:2 },
+  ]
+};
+
+block_1733 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_in' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'runtimeCall' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1734, num_args:2 },
+  ]
+};
+
+block_1734 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1728 = {
+  instrs: [
+    { op:'if_true', then:@block_1729, else:@block_1735 },
+  ]
+};
+
+block_1735 = {
+  instrs: [
+    { op:'jump', to:@block_1736 },
+  ]
+};
+
+block_1736 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'op' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1737, num_args:2 },
+  ]
+};
+
+block_1737 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'OP_ADD' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1738, num_args:2 },
+  ]
+};
+
+block_1739 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'lhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1740, num_args:2 },
+  ]
+};
+
+block_1740 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1741, num_args:2 },
+  ]
+};
+
+block_1741 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'rhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1742, num_args:2 },
+  ]
+};
+
+block_1742 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1743, num_args:2 },
+  ]
+};
+
+block_1743 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_add' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'runtimeCall' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1744, num_args:2 },
+  ]
+};
+
+block_1744 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1738 = {
+  instrs: [
+    { op:'if_true', then:@block_1739, else:@block_1745 },
+  ]
+};
+
+block_1745 = {
+  instrs: [
+    { op:'jump', to:@block_1746 },
+  ]
+};
+
+block_1746 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'op' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1747, num_args:2 },
+  ]
+};
+
+block_1747 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'OP_SUB' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1748, num_args:2 },
+  ]
+};
+
+block_1749 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'lhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1750, num_args:2 },
+  ]
+};
+
+block_1750 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1751, num_args:2 },
+  ]
+};
+
+block_1751 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'rhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1752, num_args:2 },
+  ]
+};
+
+block_1752 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1753, num_args:2 },
+  ]
+};
+
+block_1753 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_sub' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'runtimeCall' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1754, num_args:2 },
+  ]
+};
+
+block_1754 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1748 = {
+  instrs: [
+    { op:'if_true', then:@block_1749, else:@block_1755 },
+  ]
+};
+
+block_1755 = {
+  instrs: [
+    { op:'jump', to:@block_1756 },
+  ]
+};
+
+block_1756 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'op' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1757, num_args:2 },
+  ]
+};
+
+block_1757 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'OP_MUL' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1758, num_args:2 },
+  ]
+};
+
+block_1759 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'lhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1760, num_args:2 },
+  ]
+};
+
+block_1760 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1761, num_args:2 },
+  ]
+};
+
+block_1761 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'rhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1762, num_args:2 },
+  ]
+};
+
+block_1762 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1763, num_args:2 },
+  ]
+};
+
+block_1763 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:'mul_i32' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addOp' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1764, num_args:2 },
+  ]
+};
+
+block_1764 = {
+  instrs: [
+    { op:'call', ret_to:@block_1765, num_args:2 },
+  ]
+};
+
+block_1765 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1758 = {
+  instrs: [
+    { op:'if_true', then:@block_1759, else:@block_1766 },
+  ]
+};
+
+block_1766 = {
+  instrs: [
+    { op:'jump', to:@block_1767 },
+  ]
+};
+
+block_1767 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'op' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1768, num_args:2 },
+  ]
+};
+
+block_1768 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'OP_MEMBER' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1769, num_args:2 },
+  ]
+};
+
+block_1770 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'lhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1771, num_args:2 },
+  ]
+};
+
+block_1771 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1772, num_args:2 },
+  ]
+};
+
+block_1772 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'rhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1773, num_args:2 },
+  ]
+};
+
+block_1773 = {
+  instrs: [
+    { op:'set_local', idx:4 },
+    { op:'get_local', idx:4 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'IdentExpr' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_instOf' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1774, num_args:2 },
+  ]
+};
+
+block_1774 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_not' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1775, num_args:1 },
+  ]
+};
+
+block_1776 = {
+  instrs: [
+    { op:'push', val:$false },
+    { op:'push', val:'invalid rhs in member expression' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'parseError' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1777, num_args:2 },
+  ]
+};
+
+block_1775 = {
+  instrs: [
+    { op:'if_true', then:@block_1776, else:@block_1778 },
+  ]
+};
+
+block_1777 = {
+  instrs: [
+    { op:'pop' },
+    { op:'jump', to:@block_1779 },
+  ]
+};
+
+block_1778 = {
+  instrs: [
+    { op:'jump', to:@block_1779 },
+  ]
+};
+
+block_1779 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:2 },
+    { op:'new_object' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'op' },
+    { op:'push', val:'push' },
+    { op:'set_field' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'val' },
+    { op:'get_local', idx:4 },
+    { op:'push', val:'name' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1780, num_args:2 },
+  ]
+};
+
+block_1780 = {
+  instrs: [
+    { op:'set_field' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addInstr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1781, num_args:2 },
+  ]
+};
+
+block_1781 = {
+  instrs: [
+    { op:'call', ret_to:@block_1782, num_args:2 },
+  ]
+};
+
+block_1782 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'runtimeCall' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1783, num_args:2 },
+  ]
+};
+
+block_1783 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1769 = {
+  instrs: [
+    { op:'if_true', then:@block_1770, else:@block_1784 },
+  ]
+};
+
+block_1784 = {
+  instrs: [
+    { op:'jump', to:@block_1785 },
+  ]
+};
+
+block_1785 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'op' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1786, num_args:2 },
+  ]
+};
+
+block_1786 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'OP_INDEX' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1787, num_args:2 },
+  ]
+};
+
+block_1788 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'lhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1789, num_args:2 },
+  ]
+};
+
+block_1789 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1790, num_args:2 },
+  ]
+};
+
+block_1790 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'rhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1791, num_args:2 },
+  ]
+};
+
+block_1791 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1792, num_args:2 },
+  ]
+};
+
+block_1792 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getElem' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'runtimeCall' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1793, num_args:2 },
+  ]
+};
+
+block_1793 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1787 = {
+  instrs: [
+    { op:'if_true', then:@block_1788, else:@block_1794 },
+  ]
+};
+
+block_1794 = {
+  instrs: [
+    { op:'jump', to:@block_1795 },
+  ]
+};
+
+block_1795 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'op' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1796, num_args:2 },
+  ]
+};
+
+block_1796 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'OP_OBJ_EXT' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_eq' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1797, num_args:2 },
+  ]
+};
+
+block_1798 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'rhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1799, num_args:2 },
+  ]
+};
+
+block_1799 = {
+  instrs: [
+    { op:'set_local', idx:5 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'rhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1800, num_args:2 },
+  ]
+};
+
+block_1800 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'ObjectExpr' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_instOf' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1801, num_args:2 },
+  ]
+};
+
+block_1801 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_not' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1802, num_args:1 },
+  ]
+};
+
+block_1803 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'input' },
+    { op:'get_field' },
+    { op:'push', val:'invalid rhs in objext extension expression' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'parseError' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1804, num_args:2 },
+  ]
+};
+
+block_1802 = {
+  instrs: [
+    { op:'if_true', then:@block_1803, else:@block_1805 },
+  ]
+};
+
+block_1804 = {
+  instrs: [
+    { op:'pop' },
+    { op:'jump', to:@block_1806 },
+  ]
+};
+
+block_1805 = {
+  instrs: [
+    { op:'jump', to:@block_1806 },
+  ]
+};
+
+block_1806 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'lhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1807, num_args:2 },
+  ]
+};
+
+block_1807 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'rhsExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1808, num_args:2 },
+  ]
+};
+
+block_1808 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genObjExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1809, num_args:3 },
+  ]
+};
+
+block_1809 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1797 = {
+  instrs: [
+    { op:'if_true', then:@block_1798, else:@block_1810 },
+  ]
+};
+
+block_1810 = {
+  instrs: [
+    { op:'jump', to:@block_1811 },
+  ]
+};
+
+block_1813 = {
+  instrs: [
+    { op:'push', val:'unhandled binary op ' },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'op' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1814, num_args:2 },
+  ]
+};
+
+block_1814 = {
+  instrs: [
+    { op:'push', val:'str' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1815, num_args:2 },
+  ]
+};
+
+block_1815 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_add' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1816, num_args:2 },
+  ]
+};
+
+block_1811 = {
+  instrs: [
+    { op:'push', val:$false },
+    { op:'if_true', then:@block_1812, else:@block_1813 },
+  ]
+};
+
+block_1812 = {
+  instrs: [
+    { op:'jump', to:@block_1817 },
+  ]
+};
+
+block_1816 = {
+  instrs: [
+    { op:'abort' },
+    { op:'jump', to:@block_1817 },
+  ]
+};
+
+block_1616 = {
+  instrs: [
+    { op:'if_true', then:@block_1617, else:@block_1818 },
+  ]
+};
+
+block_1817 = {
+  instrs: [
+    { op:'jump', to:@block_1819 },
+  ]
+};
+
+block_1818 = {
+  instrs: [
+    { op:'jump', to:@block_1819 },
+  ]
+};
+
+block_1819 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -15887,11 +16716,11 @@ block_1710 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1711, num_args:2 },
+    { op:'call', ret_to:@block_1820, num_args:2 },
   ]
 };
 
-block_1712 = {
+block_1821 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:$false },
@@ -15899,11 +16728,11 @@ block_1712 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'genObjExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1713, num_args:3 },
+    { op:'call', ret_to:@block_1822, num_args:3 },
   ]
 };
 
-block_1713 = {
+block_1822 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -15911,19 +16740,19 @@ block_1713 = {
   ]
 };
 
-block_1711 = {
+block_1820 = {
   instrs: [
-    { op:'if_true', then:@block_1712, else:@block_1714 },
+    { op:'if_true', then:@block_1821, else:@block_1823 },
   ]
 };
 
-block_1714 = {
+block_1823 = {
   instrs: [
-    { op:'jump', to:@block_1715 },
+    { op:'jump', to:@block_1824 },
   ]
 };
 
-block_1715 = {
+block_1824 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -15932,11 +16761,11 @@ block_1715 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1716, num_args:2 },
+    { op:'call', ret_to:@block_1825, num_args:2 },
   ]
 };
 
-block_1717 = {
+block_1826 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:2 },
@@ -15952,21 +16781,21 @@ block_1717 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1718, num_args:2 },
+    { op:'call', ret_to:@block_1827, num_args:2 },
   ]
 };
 
-block_1718 = {
+block_1827 = {
   instrs: [
     { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1719, num_args:2 },
+    { op:'call', ret_to:@block_1828, num_args:2 },
   ]
 };
 
-block_1719 = {
+block_1828 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:1 },
@@ -15974,17 +16803,17 @@ block_1719 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1720, num_args:2 },
+    { op:'call', ret_to:@block_1829, num_args:2 },
   ]
 };
 
-block_1720 = {
+block_1829 = {
   instrs: [
-    { op:'call', ret_to:@block_1721, num_args:2 },
+    { op:'call', ret_to:@block_1830, num_args:2 },
   ]
 };
 
-block_1721 = {
+block_1830 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -15994,26 +16823,26 @@ block_1721 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1722, num_args:2 },
+    { op:'call', ret_to:@block_1831, num_args:2 },
   ]
 };
 
-block_1722 = {
+block_1831 = {
   instrs: [
-    { op:'call', ret_to:@block_1723, num_args:2 },
+    { op:'call', ret_to:@block_1832, num_args:2 },
   ]
 };
 
-block_1723 = {
+block_1832 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:0 },
     { op:'set_local', idx:6 },
-    { op:'jump', to:@block_1724 },
+    { op:'jump', to:@block_1833 },
   ]
 };
 
-block_1724 = {
+block_1833 = {
   instrs: [
     { op:'get_local', idx:6 },
     { op:'get_local', idx:1 },
@@ -16021,28 +16850,36 @@ block_1724 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1728, num_args:2 },
+    { op:'call', ret_to:@block_1837, num_args:2 },
   ]
 };
 
-block_1728 = {
+block_1837 = {
   instrs: [
     { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1729, num_args:2 },
+    { op:'call', ret_to:@block_1838, num_args:2 },
   ]
 };
 
-block_1729 = {
+block_1838 = {
   instrs: [
-    { op:'lt_i32' },
-    { op:'if_true', then:@block_1725, else:@block_1727 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_lt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1839, num_args:2 },
   ]
 };
 
-block_1725 = {
+block_1839 = {
+  instrs: [
+    { op:'if_true', then:@block_1834, else:@block_1836 },
+  ]
+};
+
+block_1834 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:2 },
@@ -16060,17 +16897,17 @@ block_1725 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1730, num_args:2 },
+    { op:'call', ret_to:@block_1840, num_args:2 },
   ]
 };
 
-block_1730 = {
+block_1840 = {
   instrs: [
-    { op:'call', ret_to:@block_1731, num_args:2 },
+    { op:'call', ret_to:@block_1841, num_args:2 },
   ]
 };
 
-block_1731 = {
+block_1841 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -16079,30 +16916,30 @@ block_1731 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1732, num_args:2 },
+    { op:'call', ret_to:@block_1842, num_args:2 },
   ]
 };
 
-block_1732 = {
+block_1842 = {
   instrs: [
     { op:'get_local', idx:6 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getElem' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1733, num_args:2 },
+    { op:'call', ret_to:@block_1843, num_args:2 },
   ]
 };
 
-block_1733 = {
+block_1843 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'genExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1734, num_args:2 },
+    { op:'call', ret_to:@block_1844, num_args:2 },
   ]
 };
 
-block_1734 = {
+block_1844 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -16112,63 +16949,63 @@ block_1734 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1735, num_args:2 },
+    { op:'call', ret_to:@block_1845, num_args:2 },
   ]
 };
 
-block_1735 = {
+block_1845 = {
   instrs: [
-    { op:'call', ret_to:@block_1736, num_args:2 },
+    { op:'call', ret_to:@block_1846, num_args:2 },
   ]
 };
 
-block_1736 = {
+block_1846 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_1726 },
+    { op:'jump', to:@block_1835 },
   ]
 };
 
-block_1726 = {
+block_1835 = {
   instrs: [
     { op:'get_local', idx:6 },
     { op:'push', val:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_add' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1737, num_args:2 },
+    { op:'call', ret_to:@block_1847, num_args:2 },
   ]
 };
 
-block_1737 = {
+block_1847 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'set_local', idx:6 },
     { op:'pop' },
-    { op:'jump', to:@block_1724 },
+    { op:'jump', to:@block_1833 },
   ]
 };
 
-block_1727 = {
+block_1836 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-block_1716 = {
+block_1825 = {
   instrs: [
-    { op:'if_true', then:@block_1717, else:@block_1738 },
+    { op:'if_true', then:@block_1826, else:@block_1848 },
   ]
 };
 
-block_1738 = {
+block_1848 = {
   instrs: [
-    { op:'jump', to:@block_1739 },
+    { op:'jump', to:@block_1849 },
   ]
 };
 
-block_1739 = {
+block_1849 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -16177,11 +17014,11 @@ block_1739 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1740, num_args:2 },
+    { op:'call', ret_to:@block_1850, num_args:2 },
   ]
 };
 
-block_1741 = {
+block_1851 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'Block' },
@@ -16190,17 +17027,17 @@ block_1741 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1742, num_args:2 },
+    { op:'call', ret_to:@block_1852, num_args:2 },
   ]
 };
 
-block_1742 = {
+block_1852 = {
   instrs: [
-    { op:'call', ret_to:@block_1743, num_args:0 },
+    { op:'call', ret_to:@block_1853, num_args:0 },
   ]
 };
 
-block_1743 = {
+block_1853 = {
   instrs: [
     { op:'set_local', idx:7 },
     { op:'get_local', idx:1 },
@@ -16208,21 +17045,21 @@ block_1743 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1744, num_args:2 },
+    { op:'call', ret_to:@block_1854, num_args:2 },
   ]
 };
 
-block_1744 = {
+block_1854 = {
   instrs: [
     { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1745, num_args:2 },
+    { op:'call', ret_to:@block_1855, num_args:2 },
   ]
 };
 
-block_1745 = {
+block_1855 = {
   instrs: [
     { op:'get_local', idx:7 },
     { op:'push', val:@global_obj },
@@ -16232,26 +17069,26 @@ block_1745 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1746, num_args:2 },
+    { op:'call', ret_to:@block_1856, num_args:2 },
   ]
 };
 
-block_1746 = {
+block_1856 = {
   instrs: [
-    { op:'call', ret_to:@block_1747, num_args:2 },
+    { op:'call', ret_to:@block_1857, num_args:2 },
   ]
 };
 
-block_1747 = {
+block_1857 = {
   instrs: [
     { op:'set_local', idx:8 },
     { op:'push', val:0 },
     { op:'set_local', idx:6 },
-    { op:'jump', to:@block_1748 },
+    { op:'jump', to:@block_1858 },
   ]
 };
 
-block_1748 = {
+block_1858 = {
   instrs: [
     { op:'get_local', idx:6 },
     { op:'get_local', idx:1 },
@@ -16259,28 +17096,36 @@ block_1748 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1752, num_args:2 },
+    { op:'call', ret_to:@block_1862, num_args:2 },
   ]
 };
 
-block_1752 = {
+block_1862 = {
   instrs: [
     { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1753, num_args:2 },
+    { op:'call', ret_to:@block_1863, num_args:2 },
   ]
 };
 
-block_1753 = {
+block_1863 = {
   instrs: [
-    { op:'lt_i32' },
-    { op:'if_true', then:@block_1749, else:@block_1751 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_lt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1864, num_args:2 },
   ]
 };
 
-block_1749 = {
+block_1864 = {
+  instrs: [
+    { op:'if_true', then:@block_1859, else:@block_1861 },
+  ]
+};
+
+block_1859 = {
   instrs: [
     { op:'get_local', idx:8 },
     { op:'get_local', idx:1 },
@@ -16288,65 +17133,65 @@ block_1749 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1754, num_args:2 },
+    { op:'call', ret_to:@block_1865, num_args:2 },
   ]
 };
 
-block_1754 = {
+block_1865 = {
   instrs: [
     { op:'get_local', idx:6 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getElem' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1755, num_args:2 },
+    { op:'call', ret_to:@block_1866, num_args:2 },
   ]
 };
 
-block_1755 = {
+block_1866 = {
   instrs: [
     { op:'dup', idx:1 },
     { op:'push', val:'registerDecl' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1756, num_args:2 },
+    { op:'call', ret_to:@block_1867, num_args:2 },
   ]
 };
 
-block_1756 = {
+block_1867 = {
   instrs: [
-    { op:'call', ret_to:@block_1757, num_args:2 },
+    { op:'call', ret_to:@block_1868, num_args:2 },
   ]
 };
 
-block_1757 = {
+block_1868 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_1750 },
+    { op:'jump', to:@block_1860 },
   ]
 };
 
-block_1750 = {
+block_1860 = {
   instrs: [
     { op:'get_local', idx:6 },
     { op:'push', val:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_add' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1758, num_args:2 },
+    { op:'call', ret_to:@block_1869, num_args:2 },
   ]
 };
 
-block_1758 = {
+block_1869 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'set_local', idx:6 },
     { op:'pop' },
-    { op:'jump', to:@block_1748 },
+    { op:'jump', to:@block_1858 },
   ]
 };
 
-block_1751 = {
+block_1861 = {
   instrs: [
     { op:'get_local', idx:8 },
     { op:'get_local', idx:1 },
@@ -16354,21 +17199,21 @@ block_1751 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1759, num_args:2 },
+    { op:'call', ret_to:@block_1870, num_args:2 },
   ]
 };
 
-block_1759 = {
+block_1870 = {
   instrs: [
     { op:'push', val:$false },
     { op:'push', val:@global_obj },
     { op:'push', val:'registerDecls' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1760, num_args:3 },
+    { op:'call', ret_to:@block_1871, num_args:3 },
   ]
 };
 
-block_1760 = {
+block_1871 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -16376,22 +17221,22 @@ block_1760 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1761, num_args:2 },
+    { op:'call', ret_to:@block_1872, num_args:2 },
   ]
 };
 
-block_1761 = {
+block_1872 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'globalObj' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1762, num_args:2 },
+    { op:'call', ret_to:@block_1873, num_args:2 },
   ]
 };
 
-block_1762 = {
+block_1873 = {
   instrs: [
     { op:'get_local', idx:8 },
     { op:'push', val:$false },
@@ -16403,17 +17248,17 @@ block_1762 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1763, num_args:2 },
+    { op:'call', ret_to:@block_1874, num_args:2 },
   ]
 };
 
-block_1763 = {
+block_1874 = {
   instrs: [
-    { op:'call', ret_to:@block_1764, num_args:5 },
+    { op:'call', ret_to:@block_1875, num_args:5 },
   ]
 };
 
-block_1764 = {
+block_1875 = {
   instrs: [
     { op:'set_local', idx:9 },
     { op:'get_local', idx:9 },
@@ -16422,20 +17267,20 @@ block_1764 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1765, num_args:2 },
+    { op:'call', ret_to:@block_1876, num_args:2 },
   ]
 };
 
-block_1765 = {
+block_1876 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'genStmt' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1766, num_args:2 },
+    { op:'call', ret_to:@block_1877, num_args:2 },
   ]
 };
 
-block_1766 = {
+block_1877 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:9 },
@@ -16443,37 +17288,37 @@ block_1766 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1767, num_args:2 },
+    { op:'call', ret_to:@block_1878, num_args:2 },
   ]
 };
 
-block_1767 = {
+block_1878 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'push', val:'hasBranch' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1768, num_args:2 },
+    { op:'call', ret_to:@block_1879, num_args:2 },
   ]
 };
 
-block_1768 = {
+block_1879 = {
   instrs: [
-    { op:'call', ret_to:@block_1769, num_args:1 },
+    { op:'call', ret_to:@block_1880, num_args:1 },
   ]
 };
 
-block_1769 = {
+block_1880 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_not' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1770, num_args:1 },
+    { op:'call', ret_to:@block_1881, num_args:1 },
   ]
 };
 
-block_1771 = {
+block_1882 = {
   instrs: [
     { op:'get_local', idx:9 },
     { op:'push', val:2 },
@@ -16491,17 +17336,17 @@ block_1771 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1772, num_args:2 },
+    { op:'call', ret_to:@block_1883, num_args:2 },
   ]
 };
 
-block_1772 = {
+block_1883 = {
   instrs: [
-    { op:'call', ret_to:@block_1773, num_args:2 },
+    { op:'call', ret_to:@block_1884, num_args:2 },
   ]
 };
 
-block_1773 = {
+block_1884 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:9 },
@@ -16511,36 +17356,36 @@ block_1773 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1774, num_args:2 },
+    { op:'call', ret_to:@block_1885, num_args:2 },
   ]
 };
 
-block_1774 = {
+block_1885 = {
   instrs: [
-    { op:'call', ret_to:@block_1775, num_args:2 },
+    { op:'call', ret_to:@block_1886, num_args:2 },
   ]
 };
 
-block_1770 = {
+block_1881 = {
   instrs: [
-    { op:'if_true', then:@block_1771, else:@block_1776 },
+    { op:'if_true', then:@block_1882, else:@block_1887 },
   ]
 };
 
-block_1775 = {
+block_1886 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_1777 },
+    { op:'jump', to:@block_1888 },
   ]
 };
 
-block_1776 = {
+block_1887 = {
   instrs: [
-    { op:'jump', to:@block_1777 },
+    { op:'jump', to:@block_1888 },
   ]
 };
 
-block_1777 = {
+block_1888 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:2 },
@@ -16558,17 +17403,17 @@ block_1777 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1778, num_args:2 },
+    { op:'call', ret_to:@block_1889, num_args:2 },
   ]
 };
 
-block_1778 = {
+block_1889 = {
   instrs: [
-    { op:'call', ret_to:@block_1779, num_args:2 },
+    { op:'call', ret_to:@block_1890, num_args:2 },
   ]
 };
 
-block_1779 = {
+block_1890 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -16576,19 +17421,19 @@ block_1779 = {
   ]
 };
 
-block_1740 = {
+block_1850 = {
   instrs: [
-    { op:'if_true', then:@block_1741, else:@block_1780 },
+    { op:'if_true', then:@block_1851, else:@block_1891 },
   ]
 };
 
-block_1780 = {
+block_1891 = {
   instrs: [
-    { op:'jump', to:@block_1781 },
+    { op:'jump', to:@block_1892 },
   ]
 };
 
-block_1781 = {
+block_1892 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -16597,31 +17442,31 @@ block_1781 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1782, num_args:2 },
+    { op:'call', ret_to:@block_1893, num_args:2 },
   ]
 };
 
-block_1783 = {
+block_1894 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'argExprs' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1784, num_args:2 },
+    { op:'call', ret_to:@block_1895, num_args:2 },
   ]
 };
 
-block_1784 = {
+block_1895 = {
   instrs: [
     { op:'set_local', idx:10 },
     { op:'push', val:0 },
     { op:'set_local', idx:6 },
-    { op:'jump', to:@block_1785 },
+    { op:'jump', to:@block_1896 },
   ]
 };
 
-block_1785 = {
+block_1896 = {
   instrs: [
     { op:'get_local', idx:6 },
     { op:'get_local', idx:10 },
@@ -16629,18 +17474,26 @@ block_1785 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1789, num_args:2 },
+    { op:'call', ret_to:@block_1900, num_args:2 },
   ]
 };
 
-block_1789 = {
+block_1900 = {
   instrs: [
-    { op:'lt_i32' },
-    { op:'if_true', then:@block_1786, else:@block_1788 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_lt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1901, num_args:2 },
   ]
 };
 
-block_1786 = {
+block_1901 = {
+  instrs: [
+    { op:'if_true', then:@block_1897, else:@block_1899 },
+  ]
+};
+
+block_1897 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:10 },
@@ -16648,47 +17501,47 @@ block_1786 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getElem' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1790, num_args:2 },
+    { op:'call', ret_to:@block_1902, num_args:2 },
   ]
 };
 
-block_1790 = {
+block_1902 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'genExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1791, num_args:2 },
+    { op:'call', ret_to:@block_1903, num_args:2 },
   ]
 };
 
-block_1791 = {
+block_1903 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_1787 },
+    { op:'jump', to:@block_1898 },
   ]
 };
 
-block_1787 = {
+block_1898 = {
   instrs: [
     { op:'get_local', idx:6 },
     { op:'push', val:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_add' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1792, num_args:2 },
+    { op:'call', ret_to:@block_1904, num_args:2 },
   ]
 };
 
-block_1792 = {
+block_1904 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'set_local', idx:6 },
     { op:'pop' },
-    { op:'jump', to:@block_1785 },
+    { op:'jump', to:@block_1896 },
   ]
 };
 
-block_1788 = {
+block_1899 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
@@ -16696,20 +17549,20 @@ block_1788 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1793, num_args:2 },
+    { op:'call', ret_to:@block_1905, num_args:2 },
   ]
 };
 
-block_1793 = {
+block_1905 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'genExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1794, num_args:2 },
+    { op:'call', ret_to:@block_1906, num_args:2 },
   ]
 };
 
-block_1794 = {
+block_1906 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:@global_obj },
@@ -16719,17 +17572,17 @@ block_1794 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1795, num_args:2 },
+    { op:'call', ret_to:@block_1907, num_args:2 },
   ]
 };
 
-block_1795 = {
+block_1907 = {
   instrs: [
-    { op:'call', ret_to:@block_1796, num_args:0 },
+    { op:'call', ret_to:@block_1908, num_args:0 },
   ]
 };
 
-block_1796 = {
+block_1908 = {
   instrs: [
     { op:'set_local', idx:11 },
     { op:'get_local', idx:0 },
@@ -16750,11 +17603,11 @@ block_1796 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1797, num_args:2 },
+    { op:'call', ret_to:@block_1909, num_args:2 },
   ]
 };
 
-block_1797 = {
+block_1909 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:0 },
@@ -16764,11 +17617,11 @@ block_1797 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1798, num_args:2 },
+    { op:'call', ret_to:@block_1910, num_args:2 },
   ]
 };
 
-block_1798 = {
+block_1910 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:1 },
@@ -16776,17 +17629,17 @@ block_1798 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1799, num_args:2 },
+    { op:'call', ret_to:@block_1911, num_args:2 },
   ]
 };
 
-block_1799 = {
+block_1911 = {
   instrs: [
-    { op:'call', ret_to:@block_1800, num_args:2 },
+    { op:'call', ret_to:@block_1912, num_args:2 },
   ]
 };
 
-block_1800 = {
+block_1912 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -16796,17 +17649,17 @@ block_1800 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1801, num_args:2 },
+    { op:'call', ret_to:@block_1913, num_args:2 },
   ]
 };
 
-block_1801 = {
+block_1913 = {
   instrs: [
-    { op:'call', ret_to:@block_1802, num_args:2 },
+    { op:'call', ret_to:@block_1914, num_args:2 },
   ]
 };
 
-block_1802 = {
+block_1914 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -16814,19 +17667,19 @@ block_1802 = {
   ]
 };
 
-block_1782 = {
+block_1893 = {
   instrs: [
-    { op:'if_true', then:@block_1783, else:@block_1803 },
+    { op:'if_true', then:@block_1894, else:@block_1915 },
   ]
 };
 
-block_1803 = {
+block_1915 = {
   instrs: [
-    { op:'jump', to:@block_1804 },
+    { op:'jump', to:@block_1916 },
   ]
 };
 
-block_1804 = {
+block_1916 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -16835,22 +17688,22 @@ block_1804 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1805, num_args:2 },
+    { op:'call', ret_to:@block_1917, num_args:2 },
   ]
 };
 
-block_1806 = {
+block_1918 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'argExprs' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1807, num_args:2 },
+    { op:'call', ret_to:@block_1919, num_args:2 },
   ]
 };
 
-block_1807 = {
+block_1919 = {
   instrs: [
     { op:'set_local', idx:10 },
     { op:'get_local', idx:0 },
@@ -16859,29 +17712,29 @@ block_1807 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1808, num_args:2 },
+    { op:'call', ret_to:@block_1920, num_args:2 },
   ]
 };
 
-block_1808 = {
+block_1920 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'genExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1809, num_args:2 },
+    { op:'call', ret_to:@block_1921, num_args:2 },
   ]
 };
 
-block_1809 = {
+block_1921 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:0 },
     { op:'set_local', idx:6 },
-    { op:'jump', to:@block_1810 },
+    { op:'jump', to:@block_1922 },
   ]
 };
 
-block_1810 = {
+block_1922 = {
   instrs: [
     { op:'get_local', idx:6 },
     { op:'get_local', idx:10 },
@@ -16889,18 +17742,26 @@ block_1810 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1814, num_args:2 },
+    { op:'call', ret_to:@block_1926, num_args:2 },
   ]
 };
 
-block_1814 = {
+block_1926 = {
   instrs: [
-    { op:'lt_i32' },
-    { op:'if_true', then:@block_1811, else:@block_1813 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_lt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1927, num_args:2 },
   ]
 };
 
-block_1811 = {
+block_1927 = {
+  instrs: [
+    { op:'if_true', then:@block_1923, else:@block_1925 },
+  ]
+};
+
+block_1923 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:10 },
@@ -16908,47 +17769,47 @@ block_1811 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getElem' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1815, num_args:2 },
+    { op:'call', ret_to:@block_1928, num_args:2 },
   ]
 };
 
-block_1815 = {
+block_1928 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'genExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1816, num_args:2 },
+    { op:'call', ret_to:@block_1929, num_args:2 },
   ]
 };
 
-block_1816 = {
+block_1929 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_1812 },
+    { op:'jump', to:@block_1924 },
   ]
 };
 
-block_1812 = {
+block_1924 = {
   instrs: [
     { op:'get_local', idx:6 },
     { op:'push', val:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_add' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1817, num_args:2 },
+    { op:'call', ret_to:@block_1930, num_args:2 },
   ]
 };
 
-block_1817 = {
+block_1930 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'set_local', idx:6 },
     { op:'pop' },
-    { op:'jump', to:@block_1810 },
+    { op:'jump', to:@block_1922 },
   ]
 };
 
-block_1813 = {
+block_1925 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:2 },
@@ -16964,11 +17825,11 @@ block_1813 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1818, num_args:2 },
+    { op:'call', ret_to:@block_1931, num_args:2 },
   ]
 };
 
-block_1818 = {
+block_1931 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:1 },
@@ -16976,17 +17837,17 @@ block_1818 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1819, num_args:2 },
+    { op:'call', ret_to:@block_1932, num_args:2 },
   ]
 };
 
-block_1819 = {
+block_1932 = {
   instrs: [
-    { op:'call', ret_to:@block_1820, num_args:2 },
+    { op:'call', ret_to:@block_1933, num_args:2 },
   ]
 };
 
-block_1820 = {
+block_1933 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -17003,11 +17864,11 @@ block_1820 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1821, num_args:2 },
+    { op:'call', ret_to:@block_1934, num_args:2 },
   ]
 };
 
-block_1821 = {
+block_1934 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:1 },
@@ -17015,17 +17876,17 @@ block_1821 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1822, num_args:2 },
+    { op:'call', ret_to:@block_1935, num_args:2 },
   ]
 };
 
-block_1822 = {
+block_1935 = {
   instrs: [
-    { op:'call', ret_to:@block_1823, num_args:2 },
+    { op:'call', ret_to:@block_1936, num_args:2 },
   ]
 };
 
-block_1823 = {
+block_1936 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -17035,11 +17896,11 @@ block_1823 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'runtimeCall' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1824, num_args:2 },
+    { op:'call', ret_to:@block_1937, num_args:2 },
   ]
 };
 
-block_1824 = {
+block_1937 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:@global_obj },
@@ -17049,17 +17910,17 @@ block_1824 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1825, num_args:2 },
+    { op:'call', ret_to:@block_1938, num_args:2 },
   ]
 };
 
-block_1825 = {
+block_1938 = {
   instrs: [
-    { op:'call', ret_to:@block_1826, num_args:0 },
+    { op:'call', ret_to:@block_1939, num_args:0 },
   ]
 };
 
-block_1826 = {
+block_1939 = {
   instrs: [
     { op:'set_local', idx:11 },
     { op:'get_local', idx:0 },
@@ -17080,21 +17941,21 @@ block_1826 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1827, num_args:2 },
+    { op:'call', ret_to:@block_1940, num_args:2 },
   ]
 };
 
-block_1827 = {
+block_1940 = {
   instrs: [
     { op:'push', val:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_add' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1828, num_args:2 },
+    { op:'call', ret_to:@block_1941, num_args:2 },
   ]
 };
 
-block_1828 = {
+block_1941 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:0 },
@@ -17104,1059 +17965,15 @@ block_1828 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1829, num_args:2 },
-  ]
-};
-
-block_1829 = {
-  instrs: [
-    { op:'set_field' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addInstr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1830, num_args:2 },
-  ]
-};
-
-block_1830 = {
-  instrs: [
-    { op:'call', ret_to:@block_1831, num_args:2 },
-  ]
-};
-
-block_1831 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:11 },
-    { op:'dup', idx:1 },
-    { op:'push', val:'merge' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1832, num_args:2 },
-  ]
-};
-
-block_1832 = {
-  instrs: [
-    { op:'call', ret_to:@block_1833, num_args:2 },
-  ]
-};
-
-block_1833 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1805 = {
-  instrs: [
-    { op:'if_true', then:@block_1806, else:@block_1834 },
-  ]
-};
-
-block_1834 = {
-  instrs: [
-    { op:'jump', to:@block_1835 },
-  ]
-};
-
-block_1835 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'IRExpr' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_instOf' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1836, num_args:2 },
-  ]
-};
-
-block_1837 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'argExprs' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1838, num_args:2 },
-  ]
-};
-
-block_1838 = {
-  instrs: [
-    { op:'set_local', idx:10 },
-    { op:'push', val:0 },
-    { op:'set_local', idx:6 },
-    { op:'jump', to:@block_1839 },
-  ]
-};
-
-block_1839 = {
-  instrs: [
-    { op:'get_local', idx:6 },
-    { op:'get_local', idx:10 },
-    { op:'push', val:'length' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1843, num_args:2 },
-  ]
-};
-
-block_1843 = {
-  instrs: [
-    { op:'lt_i32' },
-    { op:'if_true', then:@block_1840, else:@block_1842 },
-  ]
-};
-
-block_1840 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:10 },
-    { op:'get_local', idx:6 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getElem' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1844, num_args:2 },
-  ]
-};
-
-block_1844 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1845, num_args:2 },
-  ]
-};
-
-block_1845 = {
-  instrs: [
-    { op:'pop' },
-    { op:'jump', to:@block_1841 },
-  ]
-};
-
-block_1841 = {
-  instrs: [
-    { op:'get_local', idx:6 },
-    { op:'push', val:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_add' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1846, num_args:2 },
-  ]
-};
-
-block_1846 = {
-  instrs: [
-    { op:'dup', idx:0 },
-    { op:'set_local', idx:6 },
-    { op:'pop' },
-    { op:'jump', to:@block_1839 },
-  ]
-};
-
-block_1842 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'opName' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1847, num_args:2 },
-  ]
-};
-
-block_1847 = {
-  instrs: [
-    { op:'dup', idx:1 },
-    { op:'push', val:'addOp' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1848, num_args:2 },
-  ]
-};
-
-block_1848 = {
-  instrs: [
-    { op:'call', ret_to:@block_1849, num_args:2 },
-  ]
-};
-
-block_1849 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1836 = {
-  instrs: [
-    { op:'if_true', then:@block_1837, else:@block_1850 },
-  ]
-};
-
-block_1850 = {
-  instrs: [
-    { op:'jump', to:@block_1851 },
-  ]
-};
-
-block_1851 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'ImportExpr' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_instOf' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1852, num_args:2 },
-  ]
-};
-
-block_1853 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'pkgName' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1854, num_args:2 },
-  ]
-};
-
-block_1854 = {
-  instrs: [
-    { op:'dup', idx:1 },
-    { op:'push', val:'addPush' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1855, num_args:2 },
-  ]
-};
-
-block_1855 = {
-  instrs: [
-    { op:'call', ret_to:@block_1856, num_args:2 },
-  ]
-};
-
-block_1856 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:'import' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addOp' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1857, num_args:2 },
-  ]
-};
-
-block_1857 = {
-  instrs: [
-    { op:'call', ret_to:@block_1858, num_args:2 },
-  ]
-};
-
-block_1858 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1852 = {
-  instrs: [
-    { op:'if_true', then:@block_1853, else:@block_1859 },
-  ]
-};
-
-block_1859 = {
-  instrs: [
-    { op:'jump', to:@block_1860 },
-  ]
-};
-
-block_1860 = {
-  instrs: [
-    { op:'push', val:$false },
-    { op:'if_true', then:@block_1861, else:@block_1862 },
-  ]
-};
-
-block_1861 = {
-  instrs: [
-    { op:'jump', to:@block_1863 },
-  ]
-};
-
-block_1862 = {
-  instrs: [
-    { op:'push', val:'unknown expression type in genExpr' },
-    { op:'abort' },
-    { op:'jump', to:@block_1863 },
-  ]
-};
-
-block_1863 = {
-  instrs: [
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-fun_1413 = {
-  entry:@block_1412,
-  num_params:2,
-  num_locals:12,
-};
-
-block_1864 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'BlockStmt' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_instOf' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1866, num_args:2 },
-  ]
-};
-
-block_1867 = {
-  instrs: [
-    { op:'push', val:0 },
-    { op:'set_local', idx:2 },
-    { op:'jump', to:@block_1868 },
-  ]
-};
-
-block_1868 = {
-  instrs: [
-    { op:'get_local', idx:2 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'stmts' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1872, num_args:2 },
-  ]
-};
-
-block_1872 = {
-  instrs: [
-    { op:'push', val:'length' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1873, num_args:2 },
-  ]
-};
-
-block_1873 = {
-  instrs: [
-    { op:'lt_i32' },
-    { op:'if_true', then:@block_1869, else:@block_1871 },
-  ]
-};
-
-block_1869 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'stmts' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1874, num_args:2 },
-  ]
-};
-
-block_1874 = {
-  instrs: [
-    { op:'get_local', idx:2 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getElem' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1875, num_args:2 },
-  ]
-};
-
-block_1875 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genStmt' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1876, num_args:2 },
-  ]
-};
-
-block_1876 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:'curBlock' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1877, num_args:2 },
-  ]
-};
-
-block_1877 = {
-  instrs: [
-    { op:'dup', idx:0 },
-    { op:'push', val:'hasBranch' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1878, num_args:2 },
-  ]
-};
-
-block_1878 = {
-  instrs: [
-    { op:'call', ret_to:@block_1879, num_args:1 },
-  ]
-};
-
-block_1880 = {
-  instrs: [
-    { op:'jump', to:@block_1871 },
-  ]
-};
-
-block_1879 = {
-  instrs: [
-    { op:'if_true', then:@block_1880, else:@block_1881 },
-  ]
-};
-
-block_1881 = {
-  instrs: [
-    { op:'jump', to:@block_1882 },
-  ]
-};
-
-block_1882 = {
-  instrs: [
-    { op:'jump', to:@block_1870 },
-  ]
-};
-
-block_1870 = {
-  instrs: [
-    { op:'get_local', idx:2 },
-    { op:'push', val:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_add' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1883, num_args:2 },
-  ]
-};
-
-block_1883 = {
-  instrs: [
-    { op:'dup', idx:0 },
-    { op:'set_local', idx:2 },
-    { op:'pop' },
-    { op:'jump', to:@block_1868 },
-  ]
-};
-
-block_1871 = {
-  instrs: [
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1866 = {
-  instrs: [
-    { op:'if_true', then:@block_1867, else:@block_1884 },
-  ]
-};
-
-block_1884 = {
-  instrs: [
-    { op:'jump', to:@block_1885 },
-  ]
-};
-
-block_1885 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'VarStmt' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_instOf' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1886, num_args:2 },
-  ]
-};
-
-block_1887 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'push', val:'fun' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1888, num_args:2 },
-  ]
-};
-
-block_1888 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'identName' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1889, num_args:2 },
-  ]
-};
-
-block_1889 = {
-  instrs: [
-    { op:'dup', idx:1 },
-    { op:'push', val:'hasLocal' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1890, num_args:2 },
-  ]
-};
-
-block_1890 = {
-  instrs: [
-    { op:'call', ret_to:@block_1891, num_args:2 },
-  ]
-};
-
-block_1892 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'initExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1893, num_args:2 },
-  ]
-};
-
-block_1893 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1894, num_args:2 },
-  ]
-};
-
-block_1894 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:'fun' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1895, num_args:2 },
-  ]
-};
-
-block_1895 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:'identName' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1896, num_args:2 },
-  ]
-};
-
-block_1896 = {
-  instrs: [
-    { op:'dup', idx:1 },
-    { op:'push', val:'getLocalIdx' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1897, num_args:2 },
-  ]
-};
-
-block_1897 = {
-  instrs: [
-    { op:'call', ret_to:@block_1898, num_args:2 },
-  ]
-};
-
-block_1898 = {
-  instrs: [
-    { op:'set_local', idx:3 },
-    { op:'get_local', idx:0 },
-    { op:'push', val:2 },
-    { op:'new_object' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'op' },
-    { op:'push', val:'set_local' },
-    { op:'set_field' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'idx' },
-    { op:'get_local', idx:3 },
-    { op:'set_field' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addInstr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1899, num_args:2 },
-  ]
-};
-
-block_1899 = {
-  instrs: [
-    { op:'call', ret_to:@block_1900, num_args:2 },
-  ]
-};
-
-block_1901 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:0 },
-    { op:'push', val:'globalObj' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1902, num_args:2 },
-  ]
-};
-
-block_1902 = {
-  instrs: [
-    { op:'dup', idx:1 },
-    { op:'push', val:'addPush' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1903, num_args:2 },
-  ]
-};
-
-block_1903 = {
-  instrs: [
-    { op:'call', ret_to:@block_1904, num_args:2 },
-  ]
-};
-
-block_1904 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'identName' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1905, num_args:2 },
-  ]
-};
-
-block_1905 = {
-  instrs: [
-    { op:'dup', idx:1 },
-    { op:'push', val:'addPush' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1906, num_args:2 },
-  ]
-};
-
-block_1906 = {
-  instrs: [
-    { op:'call', ret_to:@block_1907, num_args:2 },
-  ]
-};
-
-block_1907 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'initExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1908, num_args:2 },
-  ]
-};
-
-block_1908 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1909, num_args:2 },
-  ]
-};
-
-block_1909 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:'set_field' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addOp' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1910, num_args:2 },
-  ]
-};
-
-block_1910 = {
-  instrs: [
-    { op:'call', ret_to:@block_1911, num_args:2 },
-  ]
-};
-
-block_1891 = {
-  instrs: [
-    { op:'if_true', then:@block_1892, else:@block_1901 },
-  ]
-};
-
-block_1900 = {
-  instrs: [
-    { op:'pop' },
-    { op:'jump', to:@block_1912 },
-  ]
-};
-
-block_1911 = {
-  instrs: [
-    { op:'pop' },
-    { op:'jump', to:@block_1912 },
-  ]
-};
-
-block_1912 = {
-  instrs: [
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1886 = {
-  instrs: [
-    { op:'if_true', then:@block_1887, else:@block_1913 },
-  ]
-};
-
-block_1913 = {
-  instrs: [
-    { op:'jump', to:@block_1914 },
-  ]
-};
-
-block_1914 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'ReturnStmt' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_instOf' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1915, num_args:2 },
-  ]
-};
-
-block_1916 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'expr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1917, num_args:2 },
-  ]
-};
-
-block_1917 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1918, num_args:2 },
-  ]
-};
-
-block_1918 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:'ret' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addOp' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1919, num_args:2 },
-  ]
-};
-
-block_1919 = {
-  instrs: [
-    { op:'call', ret_to:@block_1920, num_args:2 },
-  ]
-};
-
-block_1920 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1915 = {
-  instrs: [
-    { op:'if_true', then:@block_1916, else:@block_1921 },
-  ]
-};
-
-block_1921 = {
-  instrs: [
-    { op:'jump', to:@block_1922 },
-  ]
-};
-
-block_1922 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'ExprStmt' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_instOf' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1923, num_args:2 },
-  ]
-};
-
-block_1924 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'expr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1925, num_args:2 },
-  ]
-};
-
-block_1925 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1926, num_args:2 },
-  ]
-};
-
-block_1926 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:'pop' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addOp' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1927, num_args:2 },
-  ]
-};
-
-block_1927 = {
-  instrs: [
-    { op:'call', ret_to:@block_1928, num_args:2 },
-  ]
-};
-
-block_1928 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:$undef },
-    { op:'ret' },
-  ]
-};
-
-block_1923 = {
-  instrs: [
-    { op:'if_true', then:@block_1924, else:@block_1929 },
-  ]
-};
-
-block_1929 = {
-  instrs: [
-    { op:'jump', to:@block_1930 },
-  ]
-};
-
-block_1930 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'IfStmt' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_instOf' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1931, num_args:2 },
-  ]
-};
-
-block_1932 = {
-  instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'testExpr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1933, num_args:2 },
-  ]
-};
-
-block_1933 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1934, num_args:2 },
-  ]
-};
-
-block_1934 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'Block' },
-    { op:'get_field' },
-    { op:'push', val:'new' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1935, num_args:2 },
-  ]
-};
-
-block_1935 = {
-  instrs: [
-    { op:'call', ret_to:@block_1936, num_args:0 },
-  ]
-};
-
-block_1936 = {
-  instrs: [
-    { op:'set_local', idx:4 },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:4 },
-    { op:'dup', idx:1 },
-    { op:'push', val:'subCtx' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1937, num_args:2 },
-  ]
-};
-
-block_1937 = {
-  instrs: [
-    { op:'call', ret_to:@block_1938, num_args:2 },
-  ]
-};
-
-block_1938 = {
-  instrs: [
-    { op:'set_local', idx:5 },
-    { op:'get_local', idx:5 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'thenStmt' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1939, num_args:2 },
-  ]
-};
-
-block_1939 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genStmt' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1940, num_args:2 },
-  ]
-};
-
-block_1940 = {
-  instrs: [
-    { op:'pop' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'Block' },
-    { op:'get_field' },
-    { op:'push', val:'new' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1941, num_args:2 },
-  ]
-};
-
-block_1941 = {
-  instrs: [
-    { op:'call', ret_to:@block_1942, num_args:0 },
+    { op:'call', ret_to:@block_1942, num_args:2 },
   ]
 };
 
 block_1942 = {
   instrs: [
-    { op:'set_local', idx:6 },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:6 },
+    { op:'set_field' },
     { op:'dup', idx:1 },
-    { op:'push', val:'subCtx' },
+    { op:'push', val:'addInstr' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -18172,10 +17989,11 @@ block_1943 = {
 
 block_1944 = {
   instrs: [
-    { op:'set_local', idx:7 },
-    { op:'get_local', idx:7 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'elseStmt' },
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:11 },
+    { op:'dup', idx:1 },
+    { op:'push', val:'merge' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -18185,9 +18003,6 @@ block_1944 = {
 
 block_1945 = {
   instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genStmt' },
-    { op:'get_field' },
     { op:'call', ret_to:@block_1946, num_args:2 },
   ]
 };
@@ -18195,63 +18010,40 @@ block_1945 = {
 block_1946 = {
   instrs: [
     { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:3 },
-    { op:'new_object' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'op' },
-    { op:'push', val:'if_true' },
-    { op:'set_field' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'then' },
-    { op:'get_local', idx:4 },
-    { op:'set_field' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'else' },
-    { op:'get_local', idx:6 },
-    { op:'set_field' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addInstr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1947, num_args:2 },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1917 = {
+  instrs: [
+    { op:'if_true', then:@block_1918, else:@block_1947 },
   ]
 };
 
 block_1947 = {
   instrs: [
-    { op:'call', ret_to:@block_1948, num_args:2 },
+    { op:'jump', to:@block_1948 },
   ]
 };
 
 block_1948 = {
   instrs: [
-    { op:'pop' },
+    { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
-    { op:'push', val:'Block' },
+    { op:'push', val:'IRExpr' },
     { op:'get_field' },
-    { op:'push', val:'new' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'rt_instOf' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1949, num_args:2 },
   ]
 };
 
-block_1949 = {
-  instrs: [
-    { op:'call', ret_to:@block_1950, num_args:0 },
-  ]
-};
-
 block_1950 = {
   instrs: [
-    { op:'set_local', idx:8 },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:8 },
-    { op:'dup', idx:1 },
-    { op:'push', val:'merge' },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'argExprs' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -18261,65 +18053,47 @@ block_1950 = {
 
 block_1951 = {
   instrs: [
-    { op:'call', ret_to:@block_1952, num_args:2 },
+    { op:'set_local', idx:10 },
+    { op:'push', val:0 },
+    { op:'set_local', idx:6 },
+    { op:'jump', to:@block_1952 },
   ]
 };
 
 block_1952 = {
   instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:5 },
-    { op:'push', val:'curBlock' },
+    { op:'get_local', idx:6 },
+    { op:'get_local', idx:10 },
+    { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1953, num_args:2 },
+    { op:'call', ret_to:@block_1956, num_args:2 },
   ]
 };
 
-block_1953 = {
-  instrs: [
-    { op:'dup', idx:0 },
-    { op:'push', val:'hasBranch' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1954, num_args:2 },
-  ]
-};
-
-block_1954 = {
-  instrs: [
-    { op:'call', ret_to:@block_1955, num_args:1 },
-  ]
-};
-
-block_1955 = {
+block_1956 = {
   instrs: [
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_not' },
+    { op:'push', val:'rt_lt' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1956, num_args:1 },
+    { op:'call', ret_to:@block_1957, num_args:2 },
   ]
 };
 
 block_1957 = {
   instrs: [
-    { op:'get_local', idx:5 },
-    { op:'push', val:2 },
-    { op:'new_object' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'op' },
-    { op:'push', val:'jump' },
-    { op:'set_field' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'to' },
-    { op:'get_local', idx:8 },
-    { op:'set_field' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addInstr' },
+    { op:'if_true', then:@block_1953, else:@block_1955 },
+  ]
+};
+
+block_1953 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:10 },
+    { op:'get_local', idx:6 },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'rt_getElem' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1958, num_args:2 },
   ]
@@ -18327,33 +18101,56 @@ block_1957 = {
 
 block_1958 = {
   instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
     { op:'call', ret_to:@block_1959, num_args:2 },
-  ]
-};
-
-block_1956 = {
-  instrs: [
-    { op:'if_true', then:@block_1957, else:@block_1960 },
   ]
 };
 
 block_1959 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_1961 },
+    { op:'jump', to:@block_1954 },
+  ]
+};
+
+block_1954 = {
+  instrs: [
+    { op:'get_local', idx:6 },
+    { op:'push', val:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_add' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1960, num_args:2 },
   ]
 };
 
 block_1960 = {
   instrs: [
-    { op:'jump', to:@block_1961 },
+    { op:'dup', idx:0 },
+    { op:'set_local', idx:6 },
+    { op:'pop' },
+    { op:'jump', to:@block_1952 },
+  ]
+};
+
+block_1955 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'opName' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1961, num_args:2 },
   ]
 };
 
 block_1961 = {
   instrs: [
-    { op:'get_local', idx:7 },
-    { op:'push', val:'curBlock' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addOp' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -18363,246 +18160,182 @@ block_1961 = {
 
 block_1962 = {
   instrs: [
-    { op:'dup', idx:0 },
-    { op:'push', val:'hasBranch' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
     { op:'call', ret_to:@block_1963, num_args:2 },
   ]
 };
 
 block_1963 = {
   instrs: [
-    { op:'call', ret_to:@block_1964, num_args:1 },
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1949 = {
+  instrs: [
+    { op:'if_true', then:@block_1950, else:@block_1964 },
   ]
 };
 
 block_1964 = {
   instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_not' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1965, num_args:1 },
-  ]
-};
-
-block_1966 = {
-  instrs: [
-    { op:'get_local', idx:7 },
-    { op:'push', val:2 },
-    { op:'new_object' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'op' },
-    { op:'push', val:'jump' },
-    { op:'set_field' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'to' },
-    { op:'get_local', idx:8 },
-    { op:'set_field' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addInstr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1967, num_args:2 },
-  ]
-};
-
-block_1967 = {
-  instrs: [
-    { op:'call', ret_to:@block_1968, num_args:2 },
+    { op:'jump', to:@block_1965 },
   ]
 };
 
 block_1965 = {
   instrs: [
-    { op:'if_true', then:@block_1966, else:@block_1969 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'ImportExpr' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_instOf' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1966, num_args:2 },
+  ]
+};
+
+block_1967 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'pkgName' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1968, num_args:2 },
   ]
 };
 
 block_1968 = {
   instrs: [
-    { op:'pop' },
-    { op:'jump', to:@block_1970 },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addPush' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1969, num_args:2 },
   ]
 };
 
 block_1969 = {
   instrs: [
-    { op:'jump', to:@block_1970 },
+    { op:'call', ret_to:@block_1970, num_args:2 },
   ]
 };
 
 block_1970 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:'import' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addOp' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_1971, num_args:2 },
+  ]
+};
+
+block_1971 = {
+  instrs: [
+    { op:'call', ret_to:@block_1972, num_args:2 },
+  ]
+};
+
+block_1972 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1966 = {
+  instrs: [
+    { op:'if_true', then:@block_1967, else:@block_1973 },
+  ]
+};
+
+block_1973 = {
+  instrs: [
+    { op:'jump', to:@block_1974 },
+  ]
+};
+
+block_1974 = {
+  instrs: [
+    { op:'push', val:$false },
+    { op:'if_true', then:@block_1975, else:@block_1976 },
+  ]
+};
+
+block_1975 = {
+  instrs: [
+    { op:'jump', to:@block_1977 },
+  ]
+};
+
+block_1976 = {
+  instrs: [
+    { op:'push', val:'unknown expression type in genExpr' },
+    { op:'abort' },
+    { op:'jump', to:@block_1977 },
+  ]
+};
+
+block_1977 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-block_1931 = {
-  instrs: [
-    { op:'if_true', then:@block_1932, else:@block_1971 },
-  ]
-};
-
-block_1971 = {
-  instrs: [
-    { op:'jump', to:@block_1972 },
-  ]
-};
-
-block_1972 = {
-  instrs: [
-    { op:'get_local', idx:1 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'ForStmt' },
-    { op:'get_field' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_instOf' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1973, num_args:2 },
-  ]
-};
-
-block_1974 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'Block' },
-    { op:'get_field' },
-    { op:'push', val:'new' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1975, num_args:2 },
-  ]
-};
-
-block_1975 = {
-  instrs: [
-    { op:'call', ret_to:@block_1976, num_args:0 },
-  ]
-};
-
-block_1976 = {
-  instrs: [
-    { op:'set_local', idx:9 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'Block' },
-    { op:'get_field' },
-    { op:'push', val:'new' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1977, num_args:2 },
-  ]
-};
-
-block_1977 = {
-  instrs: [
-    { op:'call', ret_to:@block_1978, num_args:0 },
-  ]
+fun_1522 = {
+  entry:@block_1521,
+  num_params:2,
+  num_locals:12,
 };
 
 block_1978 = {
   instrs: [
-    { op:'set_local', idx:10 },
+    { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
-    { op:'push', val:'Block' },
+    { op:'push', val:'BlockStmt' },
     { op:'get_field' },
-    { op:'push', val:'new' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1979, num_args:2 },
-  ]
-};
-
-block_1979 = {
-  instrs: [
-    { op:'call', ret_to:@block_1980, num_args:0 },
-  ]
-};
-
-block_1980 = {
-  instrs: [
-    { op:'set_local', idx:11 },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'Block' },
-    { op:'get_field' },
-    { op:'push', val:'new' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1981, num_args:2 },
+    { op:'call', ret_to:@block_1980, num_args:2 },
   ]
 };
 
 block_1981 = {
   instrs: [
-    { op:'call', ret_to:@block_1982, num_args:0 },
+    { op:'push', val:0 },
+    { op:'set_local', idx:2 },
+    { op:'jump', to:@block_1982 },
   ]
 };
 
 block_1982 = {
   instrs: [
-    { op:'set_local', idx:12 },
-    { op:'get_local', idx:0 },
+    { op:'get_local', idx:2 },
     { op:'get_local', idx:1 },
-    { op:'push', val:'initStmt' },
+    { op:'push', val:'stmts' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_1983, num_args:2 },
-  ]
-};
-
-block_1983 = {
-  instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genStmt' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1984, num_args:2 },
-  ]
-};
-
-block_1984 = {
-  instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'push', val:2 },
-    { op:'new_object' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'op' },
-    { op:'push', val:'jump' },
-    { op:'set_field' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'to' },
-    { op:'get_local', idx:9 },
-    { op:'set_field' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addInstr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1985, num_args:2 },
-  ]
-};
-
-block_1985 = {
-  instrs: [
     { op:'call', ret_to:@block_1986, num_args:2 },
   ]
 };
 
 block_1986 = {
   instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:9 },
-    { op:'dup', idx:1 },
-    { op:'push', val:'subCtx' },
+    { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -18612,16 +18345,24 @@ block_1986 = {
 
 block_1987 = {
   instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_lt' },
+    { op:'get_field' },
     { op:'call', ret_to:@block_1988, num_args:2 },
   ]
 };
 
 block_1988 = {
   instrs: [
-    { op:'set_local', idx:13 },
-    { op:'get_local', idx:13 },
+    { op:'if_true', then:@block_1983, else:@block_1985 },
+  ]
+};
+
+block_1983 = {
+  instrs: [
+    { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
-    { op:'push', val:'testExpr' },
+    { op:'push', val:'stmts' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -18631,8 +18372,9 @@ block_1988 = {
 
 block_1989 = {
   instrs: [
+    { op:'get_local', idx:2 },
     { op:'push', val:@global_obj },
-    { op:'push', val:'genExpr' },
+    { op:'push', val:'rt_getElem' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1990, num_args:2 },
   ]
@@ -18640,26 +18382,8 @@ block_1989 = {
 
 block_1990 = {
   instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:13 },
-    { op:'push', val:3 },
-    { op:'new_object' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'op' },
-    { op:'push', val:'if_true' },
-    { op:'set_field' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'then' },
-    { op:'get_local', idx:10 },
-    { op:'set_field' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'else' },
-    { op:'get_local', idx:12 },
-    { op:'set_field' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addInstr' },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'genStmt' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1991, num_args:2 },
   ]
@@ -18667,19 +18391,20 @@ block_1990 = {
 
 block_1991 = {
   instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:'curBlock' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
     { op:'call', ret_to:@block_1992, num_args:2 },
   ]
 };
 
 block_1992 = {
   instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:10 },
-    { op:'get_local', idx:11 },
-    { op:'get_local', idx:12 },
-    { op:'dup', idx:3 },
-    { op:'push', val:'subCtxLoop' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'hasBranch' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -18689,50 +18414,40 @@ block_1992 = {
 
 block_1993 = {
   instrs: [
-    { op:'call', ret_to:@block_1994, num_args:4 },
-  ]
-};
-
-block_1994 = {
-  instrs: [
-    { op:'set_local', idx:14 },
-    { op:'get_local', idx:14 },
-    { op:'get_local', idx:1 },
-    { op:'push', val:'bodyStmt' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1995, num_args:2 },
+    { op:'call', ret_to:@block_1994, num_args:1 },
   ]
 };
 
 block_1995 = {
   instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'genStmt' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1996, num_args:2 },
+    { op:'jump', to:@block_1985 },
+  ]
+};
+
+block_1994 = {
+  instrs: [
+    { op:'if_true', then:@block_1995, else:@block_1996 },
   ]
 };
 
 block_1996 = {
   instrs: [
-    { op:'pop' },
-    { op:'get_local', idx:14 },
-    { op:'push', val:'curBlock' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_1997, num_args:2 },
+    { op:'jump', to:@block_1997 },
   ]
 };
 
 block_1997 = {
   instrs: [
-    { op:'dup', idx:0 },
-    { op:'push', val:'hasBranch' },
+    { op:'jump', to:@block_1984 },
+  ]
+};
+
+block_1984 = {
+  instrs: [
+    { op:'get_local', idx:2 },
+    { op:'push', val:1 },
     { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
+    { op:'push', val:'rt_add' },
     { op:'get_field' },
     { op:'call', ret_to:@block_1998, num_args:2 },
   ]
@@ -18740,91 +18455,89 @@ block_1997 = {
 
 block_1998 = {
   instrs: [
-    { op:'call', ret_to:@block_1999, num_args:1 },
+    { op:'dup', idx:0 },
+    { op:'set_local', idx:2 },
+    { op:'pop' },
+    { op:'jump', to:@block_1982 },
+  ]
+};
+
+block_1985 = {
+  instrs: [
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_1980 = {
+  instrs: [
+    { op:'if_true', then:@block_1981, else:@block_1999 },
   ]
 };
 
 block_1999 = {
   instrs: [
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_not' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_2000, num_args:1 },
-  ]
-};
-
-block_2001 = {
-  instrs: [
-    { op:'get_local', idx:14 },
-    { op:'push', val:2 },
-    { op:'new_object' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'op' },
-    { op:'push', val:'jump' },
-    { op:'set_field' },
-    { op:'dup', idx:0 },
-    { op:'push', val:'to' },
-    { op:'get_local', idx:11 },
-    { op:'set_field' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addInstr' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
-    { op:'call', ret_to:@block_2002, num_args:2 },
-  ]
-};
-
-block_2002 = {
-  instrs: [
-    { op:'call', ret_to:@block_2003, num_args:2 },
+    { op:'jump', to:@block_2000 },
   ]
 };
 
 block_2000 = {
   instrs: [
-    { op:'if_true', then:@block_2001, else:@block_2004 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'VarStmt' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_instOf' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2001, num_args:2 },
+  ]
+};
+
+block_2002 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'push', val:'fun' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2003, num_args:2 },
   ]
 };
 
 block_2003 = {
   instrs: [
-    { op:'pop' },
-    { op:'jump', to:@block_2005 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'identName' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2004, num_args:2 },
   ]
 };
 
 block_2004 = {
   instrs: [
-    { op:'jump', to:@block_2005 },
+    { op:'dup', idx:1 },
+    { op:'push', val:'hasLocal' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2005, num_args:2 },
   ]
 };
 
 block_2005 = {
   instrs: [
-    { op:'get_local', idx:0 },
-    { op:'get_local', idx:11 },
-    { op:'dup', idx:1 },
-    { op:'push', val:'subCtx' },
-    { op:'push', val:@global_obj },
-    { op:'push', val:'rt_getProp' },
-    { op:'get_field' },
     { op:'call', ret_to:@block_2006, num_args:2 },
-  ]
-};
-
-block_2006 = {
-  instrs: [
-    { op:'call', ret_to:@block_2007, num_args:2 },
   ]
 };
 
 block_2007 = {
   instrs: [
-    { op:'set_local', idx:15 },
-    { op:'get_local', idx:15 },
+    { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
-    { op:'push', val:'incrExpr' },
+    { op:'push', val:'initExpr' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -18844,10 +18557,8 @@ block_2008 = {
 block_2009 = {
   instrs: [
     { op:'pop' },
-    { op:'get_local', idx:15 },
-    { op:'push', val:'pop' },
-    { op:'dup', idx:1 },
-    { op:'push', val:'addOp' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:'fun' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
@@ -18857,11 +18568,1177 @@ block_2009 = {
 
 block_2010 = {
   instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:'identName' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
     { op:'call', ret_to:@block_2011, num_args:2 },
   ]
 };
 
 block_2011 = {
+  instrs: [
+    { op:'dup', idx:1 },
+    { op:'push', val:'getLocalIdx' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2012, num_args:2 },
+  ]
+};
+
+block_2012 = {
+  instrs: [
+    { op:'call', ret_to:@block_2013, num_args:2 },
+  ]
+};
+
+block_2013 = {
+  instrs: [
+    { op:'set_local', idx:3 },
+    { op:'get_local', idx:0 },
+    { op:'push', val:2 },
+    { op:'new_object' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'op' },
+    { op:'push', val:'set_local' },
+    { op:'set_field' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'idx' },
+    { op:'get_local', idx:3 },
+    { op:'set_field' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addInstr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2014, num_args:2 },
+  ]
+};
+
+block_2014 = {
+  instrs: [
+    { op:'call', ret_to:@block_2015, num_args:2 },
+  ]
+};
+
+block_2016 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:0 },
+    { op:'push', val:'globalObj' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2017, num_args:2 },
+  ]
+};
+
+block_2017 = {
+  instrs: [
+    { op:'dup', idx:1 },
+    { op:'push', val:'addPush' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2018, num_args:2 },
+  ]
+};
+
+block_2018 = {
+  instrs: [
+    { op:'call', ret_to:@block_2019, num_args:2 },
+  ]
+};
+
+block_2019 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'identName' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2020, num_args:2 },
+  ]
+};
+
+block_2020 = {
+  instrs: [
+    { op:'dup', idx:1 },
+    { op:'push', val:'addPush' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2021, num_args:2 },
+  ]
+};
+
+block_2021 = {
+  instrs: [
+    { op:'call', ret_to:@block_2022, num_args:2 },
+  ]
+};
+
+block_2022 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'initExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2023, num_args:2 },
+  ]
+};
+
+block_2023 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2024, num_args:2 },
+  ]
+};
+
+block_2024 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:'set_field' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addOp' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2025, num_args:2 },
+  ]
+};
+
+block_2025 = {
+  instrs: [
+    { op:'call', ret_to:@block_2026, num_args:2 },
+  ]
+};
+
+block_2006 = {
+  instrs: [
+    { op:'if_true', then:@block_2007, else:@block_2016 },
+  ]
+};
+
+block_2015 = {
+  instrs: [
+    { op:'pop' },
+    { op:'jump', to:@block_2027 },
+  ]
+};
+
+block_2026 = {
+  instrs: [
+    { op:'pop' },
+    { op:'jump', to:@block_2027 },
+  ]
+};
+
+block_2027 = {
+  instrs: [
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_2001 = {
+  instrs: [
+    { op:'if_true', then:@block_2002, else:@block_2028 },
+  ]
+};
+
+block_2028 = {
+  instrs: [
+    { op:'jump', to:@block_2029 },
+  ]
+};
+
+block_2029 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'ReturnStmt' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_instOf' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2030, num_args:2 },
+  ]
+};
+
+block_2031 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'expr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2032, num_args:2 },
+  ]
+};
+
+block_2032 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2033, num_args:2 },
+  ]
+};
+
+block_2033 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:'ret' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addOp' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2034, num_args:2 },
+  ]
+};
+
+block_2034 = {
+  instrs: [
+    { op:'call', ret_to:@block_2035, num_args:2 },
+  ]
+};
+
+block_2035 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_2030 = {
+  instrs: [
+    { op:'if_true', then:@block_2031, else:@block_2036 },
+  ]
+};
+
+block_2036 = {
+  instrs: [
+    { op:'jump', to:@block_2037 },
+  ]
+};
+
+block_2037 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'ExprStmt' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_instOf' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2038, num_args:2 },
+  ]
+};
+
+block_2039 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'expr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2040, num_args:2 },
+  ]
+};
+
+block_2040 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2041, num_args:2 },
+  ]
+};
+
+block_2041 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:'pop' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addOp' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2042, num_args:2 },
+  ]
+};
+
+block_2042 = {
+  instrs: [
+    { op:'call', ret_to:@block_2043, num_args:2 },
+  ]
+};
+
+block_2043 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_2038 = {
+  instrs: [
+    { op:'if_true', then:@block_2039, else:@block_2044 },
+  ]
+};
+
+block_2044 = {
+  instrs: [
+    { op:'jump', to:@block_2045 },
+  ]
+};
+
+block_2045 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'IfStmt' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_instOf' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2046, num_args:2 },
+  ]
+};
+
+block_2047 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'testExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2048, num_args:2 },
+  ]
+};
+
+block_2048 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2049, num_args:2 },
+  ]
+};
+
+block_2049 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'Block' },
+    { op:'get_field' },
+    { op:'push', val:'new' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2050, num_args:2 },
+  ]
+};
+
+block_2050 = {
+  instrs: [
+    { op:'call', ret_to:@block_2051, num_args:0 },
+  ]
+};
+
+block_2051 = {
+  instrs: [
+    { op:'set_local', idx:4 },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:4 },
+    { op:'dup', idx:1 },
+    { op:'push', val:'subCtx' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2052, num_args:2 },
+  ]
+};
+
+block_2052 = {
+  instrs: [
+    { op:'call', ret_to:@block_2053, num_args:2 },
+  ]
+};
+
+block_2053 = {
+  instrs: [
+    { op:'set_local', idx:5 },
+    { op:'get_local', idx:5 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'thenStmt' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2054, num_args:2 },
+  ]
+};
+
+block_2054 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genStmt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2055, num_args:2 },
+  ]
+};
+
+block_2055 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'Block' },
+    { op:'get_field' },
+    { op:'push', val:'new' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2056, num_args:2 },
+  ]
+};
+
+block_2056 = {
+  instrs: [
+    { op:'call', ret_to:@block_2057, num_args:0 },
+  ]
+};
+
+block_2057 = {
+  instrs: [
+    { op:'set_local', idx:6 },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:6 },
+    { op:'dup', idx:1 },
+    { op:'push', val:'subCtx' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2058, num_args:2 },
+  ]
+};
+
+block_2058 = {
+  instrs: [
+    { op:'call', ret_to:@block_2059, num_args:2 },
+  ]
+};
+
+block_2059 = {
+  instrs: [
+    { op:'set_local', idx:7 },
+    { op:'get_local', idx:7 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'elseStmt' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2060, num_args:2 },
+  ]
+};
+
+block_2060 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genStmt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2061, num_args:2 },
+  ]
+};
+
+block_2061 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:3 },
+    { op:'new_object' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'op' },
+    { op:'push', val:'if_true' },
+    { op:'set_field' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'then' },
+    { op:'get_local', idx:4 },
+    { op:'set_field' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'else' },
+    { op:'get_local', idx:6 },
+    { op:'set_field' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addInstr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2062, num_args:2 },
+  ]
+};
+
+block_2062 = {
+  instrs: [
+    { op:'call', ret_to:@block_2063, num_args:2 },
+  ]
+};
+
+block_2063 = {
+  instrs: [
+    { op:'pop' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'Block' },
+    { op:'get_field' },
+    { op:'push', val:'new' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2064, num_args:2 },
+  ]
+};
+
+block_2064 = {
+  instrs: [
+    { op:'call', ret_to:@block_2065, num_args:0 },
+  ]
+};
+
+block_2065 = {
+  instrs: [
+    { op:'set_local', idx:8 },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:8 },
+    { op:'dup', idx:1 },
+    { op:'push', val:'merge' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2066, num_args:2 },
+  ]
+};
+
+block_2066 = {
+  instrs: [
+    { op:'call', ret_to:@block_2067, num_args:2 },
+  ]
+};
+
+block_2067 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:5 },
+    { op:'push', val:'curBlock' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2068, num_args:2 },
+  ]
+};
+
+block_2068 = {
+  instrs: [
+    { op:'dup', idx:0 },
+    { op:'push', val:'hasBranch' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2069, num_args:2 },
+  ]
+};
+
+block_2069 = {
+  instrs: [
+    { op:'call', ret_to:@block_2070, num_args:1 },
+  ]
+};
+
+block_2070 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_not' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2071, num_args:1 },
+  ]
+};
+
+block_2072 = {
+  instrs: [
+    { op:'get_local', idx:5 },
+    { op:'push', val:2 },
+    { op:'new_object' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'op' },
+    { op:'push', val:'jump' },
+    { op:'set_field' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'to' },
+    { op:'get_local', idx:8 },
+    { op:'set_field' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addInstr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2073, num_args:2 },
+  ]
+};
+
+block_2073 = {
+  instrs: [
+    { op:'call', ret_to:@block_2074, num_args:2 },
+  ]
+};
+
+block_2071 = {
+  instrs: [
+    { op:'if_true', then:@block_2072, else:@block_2075 },
+  ]
+};
+
+block_2074 = {
+  instrs: [
+    { op:'pop' },
+    { op:'jump', to:@block_2076 },
+  ]
+};
+
+block_2075 = {
+  instrs: [
+    { op:'jump', to:@block_2076 },
+  ]
+};
+
+block_2076 = {
+  instrs: [
+    { op:'get_local', idx:7 },
+    { op:'push', val:'curBlock' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2077, num_args:2 },
+  ]
+};
+
+block_2077 = {
+  instrs: [
+    { op:'dup', idx:0 },
+    { op:'push', val:'hasBranch' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2078, num_args:2 },
+  ]
+};
+
+block_2078 = {
+  instrs: [
+    { op:'call', ret_to:@block_2079, num_args:1 },
+  ]
+};
+
+block_2079 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_not' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2080, num_args:1 },
+  ]
+};
+
+block_2081 = {
+  instrs: [
+    { op:'get_local', idx:7 },
+    { op:'push', val:2 },
+    { op:'new_object' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'op' },
+    { op:'push', val:'jump' },
+    { op:'set_field' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'to' },
+    { op:'get_local', idx:8 },
+    { op:'set_field' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addInstr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2082, num_args:2 },
+  ]
+};
+
+block_2082 = {
+  instrs: [
+    { op:'call', ret_to:@block_2083, num_args:2 },
+  ]
+};
+
+block_2080 = {
+  instrs: [
+    { op:'if_true', then:@block_2081, else:@block_2084 },
+  ]
+};
+
+block_2083 = {
+  instrs: [
+    { op:'pop' },
+    { op:'jump', to:@block_2085 },
+  ]
+};
+
+block_2084 = {
+  instrs: [
+    { op:'jump', to:@block_2085 },
+  ]
+};
+
+block_2085 = {
+  instrs: [
+    { op:'push', val:$undef },
+    { op:'ret' },
+  ]
+};
+
+block_2046 = {
+  instrs: [
+    { op:'if_true', then:@block_2047, else:@block_2086 },
+  ]
+};
+
+block_2086 = {
+  instrs: [
+    { op:'jump', to:@block_2087 },
+  ]
+};
+
+block_2087 = {
+  instrs: [
+    { op:'get_local', idx:1 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'ForStmt' },
+    { op:'get_field' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_instOf' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2088, num_args:2 },
+  ]
+};
+
+block_2089 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'Block' },
+    { op:'get_field' },
+    { op:'push', val:'new' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2090, num_args:2 },
+  ]
+};
+
+block_2090 = {
+  instrs: [
+    { op:'call', ret_to:@block_2091, num_args:0 },
+  ]
+};
+
+block_2091 = {
+  instrs: [
+    { op:'set_local', idx:9 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'Block' },
+    { op:'get_field' },
+    { op:'push', val:'new' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2092, num_args:2 },
+  ]
+};
+
+block_2092 = {
+  instrs: [
+    { op:'call', ret_to:@block_2093, num_args:0 },
+  ]
+};
+
+block_2093 = {
+  instrs: [
+    { op:'set_local', idx:10 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'Block' },
+    { op:'get_field' },
+    { op:'push', val:'new' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2094, num_args:2 },
+  ]
+};
+
+block_2094 = {
+  instrs: [
+    { op:'call', ret_to:@block_2095, num_args:0 },
+  ]
+};
+
+block_2095 = {
+  instrs: [
+    { op:'set_local', idx:11 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'Block' },
+    { op:'get_field' },
+    { op:'push', val:'new' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2096, num_args:2 },
+  ]
+};
+
+block_2096 = {
+  instrs: [
+    { op:'call', ret_to:@block_2097, num_args:0 },
+  ]
+};
+
+block_2097 = {
+  instrs: [
+    { op:'set_local', idx:12 },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'initStmt' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2098, num_args:2 },
+  ]
+};
+
+block_2098 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genStmt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2099, num_args:2 },
+  ]
+};
+
+block_2099 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'push', val:2 },
+    { op:'new_object' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'op' },
+    { op:'push', val:'jump' },
+    { op:'set_field' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'to' },
+    { op:'get_local', idx:9 },
+    { op:'set_field' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addInstr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2100, num_args:2 },
+  ]
+};
+
+block_2100 = {
+  instrs: [
+    { op:'call', ret_to:@block_2101, num_args:2 },
+  ]
+};
+
+block_2101 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:9 },
+    { op:'dup', idx:1 },
+    { op:'push', val:'subCtx' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2102, num_args:2 },
+  ]
+};
+
+block_2102 = {
+  instrs: [
+    { op:'call', ret_to:@block_2103, num_args:2 },
+  ]
+};
+
+block_2103 = {
+  instrs: [
+    { op:'set_local', idx:13 },
+    { op:'get_local', idx:13 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'testExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2104, num_args:2 },
+  ]
+};
+
+block_2104 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2105, num_args:2 },
+  ]
+};
+
+block_2105 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:13 },
+    { op:'push', val:3 },
+    { op:'new_object' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'op' },
+    { op:'push', val:'if_true' },
+    { op:'set_field' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'then' },
+    { op:'get_local', idx:10 },
+    { op:'set_field' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'else' },
+    { op:'get_local', idx:12 },
+    { op:'set_field' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addInstr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2106, num_args:2 },
+  ]
+};
+
+block_2106 = {
+  instrs: [
+    { op:'call', ret_to:@block_2107, num_args:2 },
+  ]
+};
+
+block_2107 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:10 },
+    { op:'get_local', idx:11 },
+    { op:'get_local', idx:12 },
+    { op:'dup', idx:3 },
+    { op:'push', val:'subCtxLoop' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2108, num_args:2 },
+  ]
+};
+
+block_2108 = {
+  instrs: [
+    { op:'call', ret_to:@block_2109, num_args:4 },
+  ]
+};
+
+block_2109 = {
+  instrs: [
+    { op:'set_local', idx:14 },
+    { op:'get_local', idx:14 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'bodyStmt' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2110, num_args:2 },
+  ]
+};
+
+block_2110 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genStmt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2111, num_args:2 },
+  ]
+};
+
+block_2111 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:14 },
+    { op:'push', val:'curBlock' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2112, num_args:2 },
+  ]
+};
+
+block_2112 = {
+  instrs: [
+    { op:'dup', idx:0 },
+    { op:'push', val:'hasBranch' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2113, num_args:2 },
+  ]
+};
+
+block_2113 = {
+  instrs: [
+    { op:'call', ret_to:@block_2114, num_args:1 },
+  ]
+};
+
+block_2114 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_not' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2115, num_args:1 },
+  ]
+};
+
+block_2116 = {
+  instrs: [
+    { op:'get_local', idx:14 },
+    { op:'push', val:2 },
+    { op:'new_object' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'op' },
+    { op:'push', val:'jump' },
+    { op:'set_field' },
+    { op:'dup', idx:0 },
+    { op:'push', val:'to' },
+    { op:'get_local', idx:11 },
+    { op:'set_field' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addInstr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2117, num_args:2 },
+  ]
+};
+
+block_2117 = {
+  instrs: [
+    { op:'call', ret_to:@block_2118, num_args:2 },
+  ]
+};
+
+block_2115 = {
+  instrs: [
+    { op:'if_true', then:@block_2116, else:@block_2119 },
+  ]
+};
+
+block_2118 = {
+  instrs: [
+    { op:'pop' },
+    { op:'jump', to:@block_2120 },
+  ]
+};
+
+block_2119 = {
+  instrs: [
+    { op:'jump', to:@block_2120 },
+  ]
+};
+
+block_2120 = {
+  instrs: [
+    { op:'get_local', idx:0 },
+    { op:'get_local', idx:11 },
+    { op:'dup', idx:1 },
+    { op:'push', val:'subCtx' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2121, num_args:2 },
+  ]
+};
+
+block_2121 = {
+  instrs: [
+    { op:'call', ret_to:@block_2122, num_args:2 },
+  ]
+};
+
+block_2122 = {
+  instrs: [
+    { op:'set_local', idx:15 },
+    { op:'get_local', idx:15 },
+    { op:'get_local', idx:1 },
+    { op:'push', val:'incrExpr' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2123, num_args:2 },
+  ]
+};
+
+block_2123 = {
+  instrs: [
+    { op:'push', val:@global_obj },
+    { op:'push', val:'genExpr' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2124, num_args:2 },
+  ]
+};
+
+block_2124 = {
+  instrs: [
+    { op:'pop' },
+    { op:'get_local', idx:15 },
+    { op:'push', val:'pop' },
+    { op:'dup', idx:1 },
+    { op:'push', val:'addOp' },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_getProp' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2125, num_args:2 },
+  ]
+};
+
+block_2125 = {
+  instrs: [
+    { op:'call', ret_to:@block_2126, num_args:2 },
+  ]
+};
+
+block_2126 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:15 },
@@ -18880,17 +19757,17 @@ block_2011 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2012, num_args:2 },
+    { op:'call', ret_to:@block_2127, num_args:2 },
   ]
 };
 
-block_2012 = {
+block_2127 = {
   instrs: [
-    { op:'call', ret_to:@block_2013, num_args:2 },
+    { op:'call', ret_to:@block_2128, num_args:2 },
   ]
 };
 
-block_2013 = {
+block_2128 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -18900,17 +19777,17 @@ block_2013 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2014, num_args:2 },
+    { op:'call', ret_to:@block_2129, num_args:2 },
   ]
 };
 
-block_2014 = {
+block_2129 = {
   instrs: [
-    { op:'call', ret_to:@block_2015, num_args:2 },
+    { op:'call', ret_to:@block_2130, num_args:2 },
   ]
 };
 
-block_2015 = {
+block_2130 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -18918,19 +19795,19 @@ block_2015 = {
   ]
 };
 
-block_1973 = {
+block_2088 = {
   instrs: [
-    { op:'if_true', then:@block_1974, else:@block_2016 },
+    { op:'if_true', then:@block_2089, else:@block_2131 },
   ]
 };
 
-block_2016 = {
+block_2131 = {
   instrs: [
-    { op:'jump', to:@block_2017 },
+    { op:'jump', to:@block_2132 },
   ]
 };
 
-block_2017 = {
+block_2132 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -18939,48 +19816,48 @@ block_2017 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2018, num_args:2 },
+    { op:'call', ret_to:@block_2133, num_args:2 },
   ]
 };
 
-block_2019 = {
+block_2134 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'curBlock' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2020, num_args:2 },
+    { op:'call', ret_to:@block_2135, num_args:2 },
   ]
 };
 
-block_2020 = {
+block_2135 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'push', val:'hasBranch' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2021, num_args:2 },
+    { op:'call', ret_to:@block_2136, num_args:2 },
   ]
 };
 
-block_2021 = {
+block_2136 = {
   instrs: [
-    { op:'call', ret_to:@block_2022, num_args:1 },
+    { op:'call', ret_to:@block_2137, num_args:1 },
   ]
 };
 
-block_2022 = {
+block_2137 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_not' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2023, num_args:1 },
+    { op:'call', ret_to:@block_2138, num_args:1 },
   ]
 };
 
-block_2024 = {
+block_2139 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:2 },
@@ -18996,11 +19873,11 @@ block_2024 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2025, num_args:2 },
+    { op:'call', ret_to:@block_2140, num_args:2 },
   ]
 };
 
-block_2025 = {
+block_2140 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:1 },
@@ -19008,55 +19885,55 @@ block_2025 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2026, num_args:2 },
+    { op:'call', ret_to:@block_2141, num_args:2 },
   ]
 };
 
-block_2026 = {
+block_2141 = {
   instrs: [
-    { op:'call', ret_to:@block_2027, num_args:2 },
+    { op:'call', ret_to:@block_2142, num_args:2 },
   ]
 };
 
-block_2023 = {
+block_2138 = {
   instrs: [
-    { op:'if_true', then:@block_2024, else:@block_2028 },
+    { op:'if_true', then:@block_2139, else:@block_2143 },
   ]
 };
 
-block_2027 = {
+block_2142 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_2029 },
+    { op:'jump', to:@block_2144 },
   ]
 };
 
-block_2028 = {
+block_2143 = {
   instrs: [
-    { op:'jump', to:@block_2029 },
+    { op:'jump', to:@block_2144 },
   ]
 };
 
-block_2029 = {
+block_2144 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-block_2018 = {
+block_2133 = {
   instrs: [
-    { op:'if_true', then:@block_2019, else:@block_2030 },
+    { op:'if_true', then:@block_2134, else:@block_2145 },
   ]
 };
 
-block_2030 = {
+block_2145 = {
   instrs: [
-    { op:'jump', to:@block_2031 },
+    { op:'jump', to:@block_2146 },
   ]
 };
 
-block_2031 = {
+block_2146 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -19065,48 +19942,48 @@ block_2031 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2032, num_args:2 },
+    { op:'call', ret_to:@block_2147, num_args:2 },
   ]
 };
 
-block_2033 = {
+block_2148 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'curBlock' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2034, num_args:2 },
+    { op:'call', ret_to:@block_2149, num_args:2 },
   ]
 };
 
-block_2034 = {
+block_2149 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'push', val:'hasBranch' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2035, num_args:2 },
+    { op:'call', ret_to:@block_2150, num_args:2 },
   ]
 };
 
-block_2035 = {
+block_2150 = {
   instrs: [
-    { op:'call', ret_to:@block_2036, num_args:1 },
+    { op:'call', ret_to:@block_2151, num_args:1 },
   ]
 };
 
-block_2036 = {
+block_2151 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_not' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2037, num_args:1 },
+    { op:'call', ret_to:@block_2152, num_args:1 },
   ]
 };
 
-block_2038 = {
+block_2153 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:2 },
@@ -19122,11 +19999,11 @@ block_2038 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2039, num_args:2 },
+    { op:'call', ret_to:@block_2154, num_args:2 },
   ]
 };
 
-block_2039 = {
+block_2154 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:1 },
@@ -19134,55 +20011,55 @@ block_2039 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2040, num_args:2 },
+    { op:'call', ret_to:@block_2155, num_args:2 },
   ]
 };
 
-block_2040 = {
+block_2155 = {
   instrs: [
-    { op:'call', ret_to:@block_2041, num_args:2 },
+    { op:'call', ret_to:@block_2156, num_args:2 },
   ]
 };
 
-block_2037 = {
+block_2152 = {
   instrs: [
-    { op:'if_true', then:@block_2038, else:@block_2042 },
+    { op:'if_true', then:@block_2153, else:@block_2157 },
   ]
 };
 
-block_2041 = {
+block_2156 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_2043 },
+    { op:'jump', to:@block_2158 },
   ]
 };
 
-block_2042 = {
+block_2157 = {
   instrs: [
-    { op:'jump', to:@block_2043 },
+    { op:'jump', to:@block_2158 },
   ]
 };
 
-block_2043 = {
+block_2158 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-block_2032 = {
+block_2147 = {
   instrs: [
-    { op:'if_true', then:@block_2033, else:@block_2044 },
+    { op:'if_true', then:@block_2148, else:@block_2159 },
   ]
 };
 
-block_2044 = {
+block_2159 = {
   instrs: [
-    { op:'jump', to:@block_2045 },
+    { op:'jump', to:@block_2160 },
   ]
 };
 
-block_2045 = {
+block_2160 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -19191,31 +20068,31 @@ block_2045 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2046, num_args:2 },
+    { op:'call', ret_to:@block_2161, num_args:2 },
   ]
 };
 
-block_2047 = {
+block_2162 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'argExprs' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2048, num_args:2 },
+    { op:'call', ret_to:@block_2163, num_args:2 },
   ]
 };
 
-block_2048 = {
+block_2163 = {
   instrs: [
     { op:'set_local', idx:16 },
     { op:'push', val:0 },
     { op:'set_local', idx:2 },
-    { op:'jump', to:@block_2049 },
+    { op:'jump', to:@block_2164 },
   ]
 };
 
-block_2049 = {
+block_2164 = {
   instrs: [
     { op:'get_local', idx:2 },
     { op:'get_local', idx:16 },
@@ -19223,18 +20100,26 @@ block_2049 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2053, num_args:2 },
+    { op:'call', ret_to:@block_2168, num_args:2 },
   ]
 };
 
-block_2053 = {
+block_2168 = {
   instrs: [
-    { op:'lt_i32' },
-    { op:'if_true', then:@block_2050, else:@block_2052 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_lt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2169, num_args:2 },
   ]
 };
 
-block_2050 = {
+block_2169 = {
+  instrs: [
+    { op:'if_true', then:@block_2165, else:@block_2167 },
+  ]
+};
+
+block_2165 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:16 },
@@ -19242,47 +20127,47 @@ block_2050 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getElem' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2054, num_args:2 },
+    { op:'call', ret_to:@block_2170, num_args:2 },
   ]
 };
 
-block_2054 = {
+block_2170 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'genExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2055, num_args:2 },
+    { op:'call', ret_to:@block_2171, num_args:2 },
   ]
 };
 
-block_2055 = {
+block_2171 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_2051 },
+    { op:'jump', to:@block_2166 },
   ]
 };
 
-block_2051 = {
+block_2166 = {
   instrs: [
     { op:'get_local', idx:2 },
     { op:'push', val:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_add' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2056, num_args:2 },
+    { op:'call', ret_to:@block_2172, num_args:2 },
   ]
 };
 
-block_2056 = {
+block_2172 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'set_local', idx:2 },
     { op:'pop' },
-    { op:'jump', to:@block_2049 },
+    { op:'jump', to:@block_2164 },
   ]
 };
 
-block_2052 = {
+block_2167 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:1 },
@@ -19290,28 +20175,28 @@ block_2052 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2057, num_args:2 },
+    { op:'call', ret_to:@block_2173, num_args:2 },
   ]
 };
 
-block_2057 = {
+block_2173 = {
   instrs: [
     { op:'dup', idx:1 },
     { op:'push', val:'addInstr' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2058, num_args:2 },
+    { op:'call', ret_to:@block_2174, num_args:2 },
   ]
 };
 
-block_2058 = {
+block_2174 = {
   instrs: [
-    { op:'call', ret_to:@block_2059, num_args:2 },
+    { op:'call', ret_to:@block_2175, num_args:2 },
   ]
 };
 
-block_2059 = {
+block_2175 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -19319,53 +20204,53 @@ block_2059 = {
   ]
 };
 
-block_2046 = {
+block_2161 = {
   instrs: [
-    { op:'if_true', then:@block_2047, else:@block_2060 },
+    { op:'if_true', then:@block_2162, else:@block_2176 },
   ]
 };
 
-block_2060 = {
+block_2176 = {
   instrs: [
-    { op:'jump', to:@block_2061 },
+    { op:'jump', to:@block_2177 },
   ]
 };
 
-block_2061 = {
+block_2177 = {
   instrs: [
     { op:'push', val:$false },
-    { op:'if_true', then:@block_2062, else:@block_2063 },
+    { op:'if_true', then:@block_2178, else:@block_2179 },
   ]
 };
 
-block_2062 = {
+block_2178 = {
   instrs: [
-    { op:'jump', to:@block_2064 },
+    { op:'jump', to:@block_2180 },
   ]
 };
 
-block_2063 = {
+block_2179 = {
   instrs: [
     { op:'push', val:'unknown statement in genStmt' },
     { op:'abort' },
-    { op:'jump', to:@block_2064 },
+    { op:'jump', to:@block_2180 },
   ]
 };
 
-block_2064 = {
+block_2180 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-fun_1865 = {
-  entry:@block_1864,
+fun_1979 = {
+  entry:@block_1978,
   num_params:2,
   num_locals:17,
 };
 
-block_2065 = {
+block_2181 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'Block' },
@@ -19374,17 +20259,17 @@ block_2065 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2067, num_args:2 },
+    { op:'call', ret_to:@block_2183, num_args:2 },
   ]
 };
 
-block_2067 = {
+block_2183 = {
   instrs: [
-    { op:'call', ret_to:@block_2068, num_args:0 },
+    { op:'call', ret_to:@block_2184, num_args:0 },
   ]
 };
 
-block_2068 = {
+block_2184 = {
   instrs: [
     { op:'set_local', idx:3 },
     { op:'push', val:@global_obj },
@@ -19394,17 +20279,17 @@ block_2068 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2069, num_args:2 },
+    { op:'call', ret_to:@block_2185, num_args:2 },
   ]
 };
 
-block_2069 = {
+block_2185 = {
   instrs: [
-    { op:'call', ret_to:@block_2070, num_args:0 },
+    { op:'call', ret_to:@block_2186, num_args:0 },
   ]
 };
 
-block_2070 = {
+block_2186 = {
   instrs: [
     { op:'set_local', idx:4 },
     { op:'get_local', idx:0 },
@@ -19412,11 +20297,11 @@ block_2070 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'genExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2071, num_args:2 },
+    { op:'call', ret_to:@block_2187, num_args:2 },
   ]
 };
 
-block_2071 = {
+block_2187 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -19435,17 +20320,17 @@ block_2071 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2072, num_args:2 },
+    { op:'call', ret_to:@block_2188, num_args:2 },
   ]
 };
 
-block_2072 = {
+block_2188 = {
   instrs: [
-    { op:'call', ret_to:@block_2073, num_args:2 },
+    { op:'call', ret_to:@block_2189, num_args:2 },
   ]
 };
 
-block_2073 = {
+block_2189 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -19468,17 +20353,17 @@ block_2073 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2074, num_args:2 },
+    { op:'call', ret_to:@block_2190, num_args:2 },
   ]
 };
 
-block_2074 = {
+block_2190 = {
   instrs: [
-    { op:'call', ret_to:@block_2075, num_args:2 },
+    { op:'call', ret_to:@block_2191, num_args:2 },
   ]
 };
 
-block_2075 = {
+block_2191 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -19488,17 +20373,17 @@ block_2075 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2076, num_args:2 },
+    { op:'call', ret_to:@block_2192, num_args:2 },
   ]
 };
 
-block_2076 = {
+block_2192 = {
   instrs: [
-    { op:'call', ret_to:@block_2077, num_args:2 },
+    { op:'call', ret_to:@block_2193, num_args:2 },
   ]
 };
 
-block_2077 = {
+block_2193 = {
   instrs: [
     { op:'set_local', idx:5 },
     { op:'get_local', idx:5 },
@@ -19508,17 +20393,17 @@ block_2077 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2078, num_args:2 },
+    { op:'call', ret_to:@block_2194, num_args:2 },
   ]
 };
 
-block_2078 = {
+block_2194 = {
   instrs: [
-    { op:'call', ret_to:@block_2079, num_args:2 },
+    { op:'call', ret_to:@block_2195, num_args:2 },
   ]
 };
 
-block_2079 = {
+block_2195 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:5 },
@@ -19526,11 +20411,11 @@ block_2079 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'genExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2080, num_args:2 },
+    { op:'call', ret_to:@block_2196, num_args:2 },
   ]
 };
 
-block_2080 = {
+block_2196 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:5 },
@@ -19549,17 +20434,17 @@ block_2080 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2081, num_args:2 },
+    { op:'call', ret_to:@block_2197, num_args:2 },
   ]
 };
 
-block_2081 = {
+block_2197 = {
   instrs: [
-    { op:'call', ret_to:@block_2082, num_args:2 },
+    { op:'call', ret_to:@block_2198, num_args:2 },
   ]
 };
 
-block_2082 = {
+block_2198 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -19569,17 +20454,17 @@ block_2082 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2083, num_args:2 },
+    { op:'call', ret_to:@block_2199, num_args:2 },
   ]
 };
 
-block_2083 = {
+block_2199 = {
   instrs: [
-    { op:'call', ret_to:@block_2084, num_args:2 },
+    { op:'call', ret_to:@block_2200, num_args:2 },
   ]
 };
 
-block_2084 = {
+block_2200 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -19587,13 +20472,13 @@ block_2084 = {
   ]
 };
 
-fun_2066 = {
-  entry:@block_2065,
+fun_2182 = {
+  entry:@block_2181,
   num_params:3,
   num_locals:6,
 };
 
-block_2085 = {
+block_2201 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'Block' },
@@ -19602,17 +20487,17 @@ block_2085 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2087, num_args:2 },
+    { op:'call', ret_to:@block_2203, num_args:2 },
   ]
 };
 
-block_2087 = {
+block_2203 = {
   instrs: [
-    { op:'call', ret_to:@block_2088, num_args:0 },
+    { op:'call', ret_to:@block_2204, num_args:0 },
   ]
 };
 
-block_2088 = {
+block_2204 = {
   instrs: [
     { op:'set_local', idx:3 },
     { op:'push', val:@global_obj },
@@ -19622,17 +20507,17 @@ block_2088 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2089, num_args:2 },
+    { op:'call', ret_to:@block_2205, num_args:2 },
   ]
 };
 
-block_2089 = {
+block_2205 = {
   instrs: [
-    { op:'call', ret_to:@block_2090, num_args:0 },
+    { op:'call', ret_to:@block_2206, num_args:0 },
   ]
 };
 
-block_2090 = {
+block_2206 = {
   instrs: [
     { op:'set_local', idx:4 },
     { op:'get_local', idx:0 },
@@ -19640,11 +20525,11 @@ block_2090 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'genExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2091, num_args:2 },
+    { op:'call', ret_to:@block_2207, num_args:2 },
   ]
 };
 
-block_2091 = {
+block_2207 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -19663,17 +20548,17 @@ block_2091 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2092, num_args:2 },
+    { op:'call', ret_to:@block_2208, num_args:2 },
   ]
 };
 
-block_2092 = {
+block_2208 = {
   instrs: [
-    { op:'call', ret_to:@block_2093, num_args:2 },
+    { op:'call', ret_to:@block_2209, num_args:2 },
   ]
 };
 
-block_2093 = {
+block_2209 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -19696,17 +20581,17 @@ block_2093 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2094, num_args:2 },
+    { op:'call', ret_to:@block_2210, num_args:2 },
   ]
 };
 
-block_2094 = {
+block_2210 = {
   instrs: [
-    { op:'call', ret_to:@block_2095, num_args:2 },
+    { op:'call', ret_to:@block_2211, num_args:2 },
   ]
 };
 
-block_2095 = {
+block_2211 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -19716,17 +20601,17 @@ block_2095 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2096, num_args:2 },
+    { op:'call', ret_to:@block_2212, num_args:2 },
   ]
 };
 
-block_2096 = {
+block_2212 = {
   instrs: [
-    { op:'call', ret_to:@block_2097, num_args:2 },
+    { op:'call', ret_to:@block_2213, num_args:2 },
   ]
 };
 
-block_2097 = {
+block_2213 = {
   instrs: [
     { op:'set_local', idx:5 },
     { op:'get_local', idx:5 },
@@ -19736,17 +20621,17 @@ block_2097 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2098, num_args:2 },
+    { op:'call', ret_to:@block_2214, num_args:2 },
   ]
 };
 
-block_2098 = {
+block_2214 = {
   instrs: [
-    { op:'call', ret_to:@block_2099, num_args:2 },
+    { op:'call', ret_to:@block_2215, num_args:2 },
   ]
 };
 
-block_2099 = {
+block_2215 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:5 },
@@ -19754,11 +20639,11 @@ block_2099 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'genExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2100, num_args:2 },
+    { op:'call', ret_to:@block_2216, num_args:2 },
   ]
 };
 
-block_2100 = {
+block_2216 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:5 },
@@ -19777,17 +20662,17 @@ block_2100 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2101, num_args:2 },
+    { op:'call', ret_to:@block_2217, num_args:2 },
   ]
 };
 
-block_2101 = {
+block_2217 = {
   instrs: [
-    { op:'call', ret_to:@block_2102, num_args:2 },
+    { op:'call', ret_to:@block_2218, num_args:2 },
   ]
 };
 
-block_2102 = {
+block_2218 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -19797,17 +20682,17 @@ block_2102 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2103, num_args:2 },
+    { op:'call', ret_to:@block_2219, num_args:2 },
   ]
 };
 
-block_2103 = {
+block_2219 = {
   instrs: [
-    { op:'call', ret_to:@block_2104, num_args:2 },
+    { op:'call', ret_to:@block_2220, num_args:2 },
   ]
 };
 
-block_2104 = {
+block_2220 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -19815,84 +20700,84 @@ block_2104 = {
   ]
 };
 
-fun_2086 = {
-  entry:@block_2085,
+fun_2202 = {
+  entry:@block_2201,
   num_params:3,
   num_locals:6,
 };
 
-block_2105 = {
+block_2221 = {
   instrs: [
     { op:'get_local', idx:2 },
     { op:'push', val:'names' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2107, num_args:2 },
+    { op:'call', ret_to:@block_2223, num_args:2 },
   ]
 };
 
-block_2107 = {
+block_2223 = {
   instrs: [
     { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2108, num_args:2 },
+    { op:'call', ret_to:@block_2224, num_args:2 },
   ]
 };
 
-block_2108 = {
+block_2224 = {
   instrs: [
     { op:'get_local', idx:2 },
     { op:'push', val:'exprs' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2109, num_args:2 },
+    { op:'call', ret_to:@block_2225, num_args:2 },
   ]
 };
 
-block_2109 = {
+block_2225 = {
   instrs: [
     { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2110, num_args:2 },
+    { op:'call', ret_to:@block_2226, num_args:2 },
   ]
 };
 
-block_2110 = {
+block_2226 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2111, num_args:2 },
+    { op:'call', ret_to:@block_2227, num_args:2 },
   ]
 };
 
-block_2111 = {
+block_2227 = {
   instrs: [
-    { op:'if_true', then:@block_2112, else:@block_2113 },
+    { op:'if_true', then:@block_2228, else:@block_2229 },
   ]
 };
 
-block_2112 = {
+block_2228 = {
   instrs: [
-    { op:'jump', to:@block_2114 },
+    { op:'jump', to:@block_2230 },
   ]
 };
 
-block_2113 = {
+block_2229 = {
   instrs: [
     { op:'push', val:'object property names and init exprs do not match' },
     { op:'abort' },
-    { op:'jump', to:@block_2114 },
+    { op:'jump', to:@block_2230 },
   ]
 };
 
-block_2114 = {
+block_2230 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:2 },
@@ -19908,21 +20793,21 @@ block_2114 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2115, num_args:2 },
+    { op:'call', ret_to:@block_2231, num_args:2 },
   ]
 };
 
-block_2115 = {
+block_2231 = {
   instrs: [
     { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2116, num_args:2 },
+    { op:'call', ret_to:@block_2232, num_args:2 },
   ]
 };
 
-block_2116 = {
+block_2232 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:1 },
@@ -19930,17 +20815,17 @@ block_2116 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2117, num_args:2 },
+    { op:'call', ret_to:@block_2233, num_args:2 },
   ]
 };
 
-block_2117 = {
+block_2233 = {
   instrs: [
-    { op:'call', ret_to:@block_2118, num_args:2 },
+    { op:'call', ret_to:@block_2234, num_args:2 },
   ]
 };
 
-block_2118 = {
+block_2234 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -19950,17 +20835,17 @@ block_2118 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2119, num_args:2 },
+    { op:'call', ret_to:@block_2235, num_args:2 },
   ]
 };
 
-block_2119 = {
+block_2235 = {
   instrs: [
-    { op:'call', ret_to:@block_2120, num_args:2 },
+    { op:'call', ret_to:@block_2236, num_args:2 },
   ]
 };
 
-block_2120 = {
+block_2236 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:1 },
@@ -19968,11 +20853,11 @@ block_2120 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_ne' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2121, num_args:2 },
+    { op:'call', ret_to:@block_2237, num_args:2 },
   ]
 };
 
-block_2122 = {
+block_2238 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:2 },
@@ -19990,17 +20875,17 @@ block_2122 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2123, num_args:2 },
+    { op:'call', ret_to:@block_2239, num_args:2 },
   ]
 };
 
-block_2123 = {
+block_2239 = {
   instrs: [
-    { op:'call', ret_to:@block_2124, num_args:2 },
+    { op:'call', ret_to:@block_2240, num_args:2 },
   ]
 };
 
-block_2124 = {
+block_2240 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -20010,17 +20895,17 @@ block_2124 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2125, num_args:2 },
+    { op:'call', ret_to:@block_2241, num_args:2 },
   ]
 };
 
-block_2125 = {
+block_2241 = {
   instrs: [
-    { op:'call', ret_to:@block_2126, num_args:2 },
+    { op:'call', ret_to:@block_2242, num_args:2 },
   ]
 };
 
-block_2126 = {
+block_2242 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -20028,11 +20913,11 @@ block_2126 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'genExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2127, num_args:2 },
+    { op:'call', ret_to:@block_2243, num_args:2 },
   ]
 };
 
-block_2127 = {
+block_2243 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -20042,44 +20927,44 @@ block_2127 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2128, num_args:2 },
+    { op:'call', ret_to:@block_2244, num_args:2 },
   ]
 };
 
-block_2128 = {
+block_2244 = {
   instrs: [
-    { op:'call', ret_to:@block_2129, num_args:2 },
+    { op:'call', ret_to:@block_2245, num_args:2 },
   ]
 };
 
-block_2121 = {
+block_2237 = {
   instrs: [
-    { op:'if_true', then:@block_2122, else:@block_2130 },
+    { op:'if_true', then:@block_2238, else:@block_2246 },
   ]
 };
 
-block_2129 = {
+block_2245 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_2131 },
+    { op:'jump', to:@block_2247 },
   ]
 };
 
-block_2130 = {
+block_2246 = {
   instrs: [
-    { op:'jump', to:@block_2131 },
+    { op:'jump', to:@block_2247 },
   ]
 };
 
-block_2131 = {
+block_2247 = {
   instrs: [
     { op:'push', val:0 },
     { op:'set_local', idx:3 },
-    { op:'jump', to:@block_2132 },
+    { op:'jump', to:@block_2248 },
   ]
 };
 
-block_2132 = {
+block_2248 = {
   instrs: [
     { op:'get_local', idx:3 },
     { op:'get_local', idx:2 },
@@ -20087,28 +20972,36 @@ block_2132 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2136, num_args:2 },
+    { op:'call', ret_to:@block_2252, num_args:2 },
   ]
 };
 
-block_2136 = {
+block_2252 = {
   instrs: [
     { op:'push', val:'length' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2137, num_args:2 },
+    { op:'call', ret_to:@block_2253, num_args:2 },
   ]
 };
 
-block_2137 = {
+block_2253 = {
   instrs: [
-    { op:'lt_i32' },
-    { op:'if_true', then:@block_2133, else:@block_2135 },
+    { op:'push', val:@global_obj },
+    { op:'push', val:'rt_lt' },
+    { op:'get_field' },
+    { op:'call', ret_to:@block_2254, num_args:2 },
   ]
 };
 
-block_2133 = {
+block_2254 = {
+  instrs: [
+    { op:'if_true', then:@block_2249, else:@block_2251 },
+  ]
+};
+
+block_2249 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:2 },
@@ -20126,17 +21019,17 @@ block_2133 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2138, num_args:2 },
+    { op:'call', ret_to:@block_2255, num_args:2 },
   ]
 };
 
-block_2138 = {
+block_2255 = {
   instrs: [
-    { op:'call', ret_to:@block_2139, num_args:2 },
+    { op:'call', ret_to:@block_2256, num_args:2 },
   ]
 };
 
-block_2139 = {
+block_2256 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -20153,21 +21046,21 @@ block_2139 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2140, num_args:2 },
+    { op:'call', ret_to:@block_2257, num_args:2 },
   ]
 };
 
-block_2140 = {
+block_2257 = {
   instrs: [
     { op:'get_local', idx:3 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getElem' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2141, num_args:2 },
+    { op:'call', ret_to:@block_2258, num_args:2 },
   ]
 };
 
-block_2141 = {
+block_2258 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:1 },
@@ -20175,17 +21068,17 @@ block_2141 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2142, num_args:2 },
+    { op:'call', ret_to:@block_2259, num_args:2 },
   ]
 };
 
-block_2142 = {
+block_2259 = {
   instrs: [
-    { op:'call', ret_to:@block_2143, num_args:2 },
+    { op:'call', ret_to:@block_2260, num_args:2 },
   ]
 };
 
-block_2143 = {
+block_2260 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -20194,30 +21087,30 @@ block_2143 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2144, num_args:2 },
+    { op:'call', ret_to:@block_2261, num_args:2 },
   ]
 };
 
-block_2144 = {
+block_2261 = {
   instrs: [
     { op:'get_local', idx:3 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getElem' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2145, num_args:2 },
+    { op:'call', ret_to:@block_2262, num_args:2 },
   ]
 };
 
-block_2145 = {
+block_2262 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'genExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2146, num_args:2 },
+    { op:'call', ret_to:@block_2263, num_args:2 },
   ]
 };
 
-block_2146 = {
+block_2263 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -20227,57 +21120,57 @@ block_2146 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2147, num_args:2 },
+    { op:'call', ret_to:@block_2264, num_args:2 },
   ]
 };
 
-block_2147 = {
+block_2264 = {
   instrs: [
-    { op:'call', ret_to:@block_2148, num_args:2 },
+    { op:'call', ret_to:@block_2265, num_args:2 },
   ]
 };
 
-block_2148 = {
+block_2265 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_2134 },
+    { op:'jump', to:@block_2250 },
   ]
 };
 
-block_2134 = {
+block_2250 = {
   instrs: [
     { op:'get_local', idx:3 },
     { op:'push', val:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_add' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2149, num_args:2 },
+    { op:'call', ret_to:@block_2266, num_args:2 },
   ]
 };
 
-block_2149 = {
+block_2266 = {
   instrs: [
     { op:'dup', idx:0 },
     { op:'set_local', idx:3 },
     { op:'pop' },
-    { op:'jump', to:@block_2132 },
+    { op:'jump', to:@block_2248 },
   ]
 };
 
-block_2135 = {
+block_2251 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-fun_2106 = {
-  entry:@block_2105,
+fun_2222 = {
+  entry:@block_2221,
   num_params:3,
   num_locals:4,
 };
 
-block_2150 = {
+block_2267 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -20286,140 +21179,140 @@ block_2150 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2152, num_args:2 },
+    { op:'call', ret_to:@block_2269, num_args:2 },
   ]
 };
 
-block_2153 = {
+block_2270 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'name' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2154, num_args:2 },
+    { op:'call', ret_to:@block_2271, num_args:2 },
   ]
 };
 
-block_2154 = {
+block_2271 = {
   instrs: [
     { op:'push', val:'exports' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2155, num_args:2 },
+    { op:'call', ret_to:@block_2272, num_args:2 },
   ]
 };
 
-block_2156 = {
+block_2273 = {
   instrs: [
     { op:'push', val:$false },
     { op:'push', val:'cannot assign to exports variable' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseError' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2157, num_args:2 },
+    { op:'call', ret_to:@block_2274, num_args:2 },
   ]
 };
 
-block_2155 = {
+block_2272 = {
   instrs: [
-    { op:'if_true', then:@block_2156, else:@block_2158 },
+    { op:'if_true', then:@block_2273, else:@block_2275 },
   ]
 };
 
-block_2157 = {
+block_2274 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_2159 },
+    { op:'jump', to:@block_2276 },
   ]
 };
 
-block_2158 = {
+block_2275 = {
   instrs: [
-    { op:'jump', to:@block_2159 },
+    { op:'jump', to:@block_2276 },
   ]
 };
 
-block_2159 = {
+block_2276 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'fun' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2160, num_args:2 },
+    { op:'call', ret_to:@block_2277, num_args:2 },
   ]
 };
 
-block_2160 = {
+block_2277 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'name' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2161, num_args:2 },
+    { op:'call', ret_to:@block_2278, num_args:2 },
   ]
 };
 
-block_2161 = {
+block_2278 = {
   instrs: [
     { op:'dup', idx:1 },
     { op:'push', val:'hasLocal' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2162, num_args:2 },
+    { op:'call', ret_to:@block_2279, num_args:2 },
   ]
 };
 
-block_2162 = {
+block_2279 = {
   instrs: [
-    { op:'call', ret_to:@block_2163, num_args:2 },
+    { op:'call', ret_to:@block_2280, num_args:2 },
   ]
 };
 
-block_2164 = {
+block_2281 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'push', val:'fun' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2165, num_args:2 },
+    { op:'call', ret_to:@block_2282, num_args:2 },
   ]
 };
 
-block_2165 = {
+block_2282 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'name' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2166, num_args:2 },
+    { op:'call', ret_to:@block_2283, num_args:2 },
   ]
 };
 
-block_2166 = {
+block_2283 = {
   instrs: [
     { op:'dup', idx:1 },
     { op:'push', val:'getLocalIdx' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2167, num_args:2 },
+    { op:'call', ret_to:@block_2284, num_args:2 },
   ]
 };
 
-block_2167 = {
+block_2284 = {
   instrs: [
-    { op:'call', ret_to:@block_2168, num_args:2 },
+    { op:'call', ret_to:@block_2285, num_args:2 },
   ]
 };
 
-block_2168 = {
+block_2285 = {
   instrs: [
     { op:'set_local', idx:3 },
     { op:'get_local', idx:0 },
@@ -20427,11 +21320,11 @@ block_2168 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'genExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2169, num_args:2 },
+    { op:'call', ret_to:@block_2286, num_args:2 },
   ]
 };
 
-block_2169 = {
+block_2286 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -20450,17 +21343,17 @@ block_2169 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2170, num_args:2 },
+    { op:'call', ret_to:@block_2287, num_args:2 },
   ]
 };
 
-block_2170 = {
+block_2287 = {
   instrs: [
-    { op:'call', ret_to:@block_2171, num_args:2 },
+    { op:'call', ret_to:@block_2288, num_args:2 },
   ]
 };
 
-block_2171 = {
+block_2288 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -20479,28 +21372,28 @@ block_2171 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2172, num_args:2 },
+    { op:'call', ret_to:@block_2289, num_args:2 },
   ]
 };
 
-block_2172 = {
+block_2289 = {
   instrs: [
-    { op:'call', ret_to:@block_2173, num_args:2 },
+    { op:'call', ret_to:@block_2290, num_args:2 },
   ]
 };
 
-block_2174 = {
+block_2291 = {
   instrs: [
     { op:'get_local', idx:0 },
     { op:'get_local', idx:2 },
     { op:'push', val:@global_obj },
     { op:'push', val:'genExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2175, num_args:2 },
+    { op:'call', ret_to:@block_2292, num_args:2 },
   ]
 };
 
-block_2175 = {
+block_2292 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -20509,28 +21402,28 @@ block_2175 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2176, num_args:2 },
+    { op:'call', ret_to:@block_2293, num_args:2 },
   ]
 };
 
-block_2176 = {
+block_2293 = {
   instrs: [
     { op:'dup', idx:1 },
     { op:'push', val:'addPush' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2177, num_args:2 },
+    { op:'call', ret_to:@block_2294, num_args:2 },
   ]
 };
 
-block_2177 = {
+block_2294 = {
   instrs: [
-    { op:'call', ret_to:@block_2178, num_args:2 },
+    { op:'call', ret_to:@block_2295, num_args:2 },
   ]
 };
 
-block_2178 = {
+block_2295 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -20539,28 +21432,28 @@ block_2178 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2179, num_args:2 },
+    { op:'call', ret_to:@block_2296, num_args:2 },
   ]
 };
 
-block_2179 = {
+block_2296 = {
   instrs: [
     { op:'dup', idx:1 },
     { op:'push', val:'addPush' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2180, num_args:2 },
+    { op:'call', ret_to:@block_2297, num_args:2 },
   ]
 };
 
-block_2180 = {
+block_2297 = {
   instrs: [
-    { op:'call', ret_to:@block_2181, num_args:2 },
+    { op:'call', ret_to:@block_2298, num_args:2 },
   ]
 };
 
-block_2181 = {
+block_2298 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -20579,17 +21472,17 @@ block_2181 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2182, num_args:2 },
+    { op:'call', ret_to:@block_2299, num_args:2 },
   ]
 };
 
-block_2182 = {
+block_2299 = {
   instrs: [
-    { op:'call', ret_to:@block_2183, num_args:2 },
+    { op:'call', ret_to:@block_2300, num_args:2 },
   ]
 };
 
-block_2183 = {
+block_2300 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -20599,56 +21492,56 @@ block_2183 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2184, num_args:2 },
+    { op:'call', ret_to:@block_2301, num_args:2 },
   ]
 };
 
-block_2184 = {
+block_2301 = {
   instrs: [
-    { op:'call', ret_to:@block_2185, num_args:2 },
+    { op:'call', ret_to:@block_2302, num_args:2 },
   ]
 };
 
-block_2163 = {
+block_2280 = {
   instrs: [
-    { op:'if_true', then:@block_2164, else:@block_2174 },
+    { op:'if_true', then:@block_2281, else:@block_2291 },
   ]
 };
 
-block_2173 = {
-  instrs: [
-    { op:'pop' },
-    { op:'jump', to:@block_2186 },
-  ]
-};
-
-block_2185 = {
+block_2290 = {
   instrs: [
     { op:'pop' },
-    { op:'jump', to:@block_2186 },
+    { op:'jump', to:@block_2303 },
   ]
 };
 
-block_2186 = {
+block_2302 = {
+  instrs: [
+    { op:'pop' },
+    { op:'jump', to:@block_2303 },
+  ]
+};
+
+block_2303 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-block_2152 = {
+block_2269 = {
   instrs: [
-    { op:'if_true', then:@block_2153, else:@block_2187 },
+    { op:'if_true', then:@block_2270, else:@block_2304 },
   ]
 };
 
-block_2187 = {
+block_2304 = {
   instrs: [
-    { op:'jump', to:@block_2188 },
+    { op:'jump', to:@block_2305 },
   ]
 };
 
-block_2188 = {
+block_2305 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
@@ -20657,22 +21550,22 @@ block_2188 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_instOf' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2189, num_args:2 },
+    { op:'call', ret_to:@block_2306, num_args:2 },
   ]
 };
 
-block_2190 = {
+block_2307 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'push', val:'op' },
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2191, num_args:2 },
+    { op:'call', ret_to:@block_2308, num_args:2 },
   ]
 };
 
-block_2191 = {
+block_2308 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'OP_MEMBER' },
@@ -20680,11 +21573,11 @@ block_2191 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_eq' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2192, num_args:2 },
+    { op:'call', ret_to:@block_2309, num_args:2 },
   ]
 };
 
-block_2193 = {
+block_2310 = {
   instrs: [
     { op:'get_local', idx:1 },
     { op:'set_local', idx:4 },
@@ -20693,11 +21586,11 @@ block_2193 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2194, num_args:2 },
+    { op:'call', ret_to:@block_2311, num_args:2 },
   ]
 };
 
-block_2194 = {
+block_2311 = {
   instrs: [
     { op:'set_local', idx:5 },
     { op:'get_local', idx:0 },
@@ -20705,11 +21598,11 @@ block_2194 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'genExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2195, num_args:2 },
+    { op:'call', ret_to:@block_2312, num_args:2 },
   ]
 };
 
-block_2195 = {
+block_2312 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -20718,20 +21611,20 @@ block_2195 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2196, num_args:2 },
+    { op:'call', ret_to:@block_2313, num_args:2 },
   ]
 };
 
-block_2196 = {
+block_2313 = {
   instrs: [
     { op:'push', val:@global_obj },
     { op:'push', val:'genExpr' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2197, num_args:2 },
+    { op:'call', ret_to:@block_2314, num_args:2 },
   ]
 };
 
-block_2197 = {
+block_2314 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -20748,11 +21641,11 @@ block_2197 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2198, num_args:2 },
+    { op:'call', ret_to:@block_2315, num_args:2 },
   ]
 };
 
-block_2198 = {
+block_2315 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:1 },
@@ -20760,17 +21653,17 @@ block_2198 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2199, num_args:2 },
+    { op:'call', ret_to:@block_2316, num_args:2 },
   ]
 };
 
-block_2199 = {
+block_2316 = {
   instrs: [
-    { op:'call', ret_to:@block_2200, num_args:2 },
+    { op:'call', ret_to:@block_2317, num_args:2 },
   ]
 };
 
-block_2200 = {
+block_2317 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -20789,17 +21682,17 @@ block_2200 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2201, num_args:2 },
+    { op:'call', ret_to:@block_2318, num_args:2 },
   ]
 };
 
-block_2201 = {
+block_2318 = {
   instrs: [
-    { op:'call', ret_to:@block_2202, num_args:2 },
+    { op:'call', ret_to:@block_2319, num_args:2 },
   ]
 };
 
-block_2202 = {
+block_2319 = {
   instrs: [
     { op:'pop' },
     { op:'get_local', idx:0 },
@@ -20809,17 +21702,17 @@ block_2202 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2203, num_args:2 },
+    { op:'call', ret_to:@block_2320, num_args:2 },
   ]
 };
 
-block_2203 = {
+block_2320 = {
   instrs: [
-    { op:'call', ret_to:@block_2204, num_args:2 },
+    { op:'call', ret_to:@block_2321, num_args:2 },
   ]
 };
 
-block_2204 = {
+block_2321 = {
   instrs: [
     { op:'pop' },
     { op:'push', val:$undef },
@@ -20827,92 +21720,92 @@ block_2204 = {
   ]
 };
 
-block_2192 = {
+block_2309 = {
   instrs: [
-    { op:'if_true', then:@block_2193, else:@block_2205 },
+    { op:'if_true', then:@block_2310, else:@block_2322 },
   ]
 };
 
-block_2205 = {
+block_2322 = {
   instrs: [
-    { op:'jump', to:@block_2206 },
+    { op:'jump', to:@block_2323 },
   ]
 };
 
-block_2206 = {
+block_2323 = {
   instrs: [
     { op:'push', val:$false },
-    { op:'if_true', then:@block_2207, else:@block_2208 },
+    { op:'if_true', then:@block_2324, else:@block_2325 },
   ]
 };
 
-block_2207 = {
+block_2324 = {
   instrs: [
-    { op:'jump', to:@block_2209 },
+    { op:'jump', to:@block_2326 },
   ]
 };
 
-block_2208 = {
+block_2325 = {
   instrs: [
     { op:'push', val:'assertion failed' },
     { op:'abort' },
-    { op:'jump', to:@block_2209 },
+    { op:'jump', to:@block_2326 },
   ]
 };
 
-block_2189 = {
+block_2306 = {
   instrs: [
-    { op:'if_true', then:@block_2190, else:@block_2210 },
+    { op:'if_true', then:@block_2307, else:@block_2327 },
   ]
 };
 
-block_2209 = {
+block_2326 = {
   instrs: [
-    { op:'jump', to:@block_2211 },
+    { op:'jump', to:@block_2328 },
   ]
 };
 
-block_2210 = {
+block_2327 = {
   instrs: [
-    { op:'jump', to:@block_2211 },
+    { op:'jump', to:@block_2328 },
   ]
 };
 
-block_2211 = {
+block_2328 = {
   instrs: [
     { op:'push', val:$false },
-    { op:'if_true', then:@block_2212, else:@block_2213 },
+    { op:'if_true', then:@block_2329, else:@block_2330 },
   ]
 };
 
-block_2212 = {
+block_2329 = {
   instrs: [
-    { op:'jump', to:@block_2214 },
+    { op:'jump', to:@block_2331 },
   ]
 };
 
-block_2213 = {
+block_2330 = {
   instrs: [
     { op:'push', val:'unhandled expression type in genAssign' },
     { op:'abort' },
-    { op:'jump', to:@block_2214 },
+    { op:'jump', to:@block_2331 },
   ]
 };
 
-block_2214 = {
+block_2331 = {
   instrs: [
     { op:'push', val:$undef },
     { op:'ret' },
   ]
 };
 
-fun_2151 = {
-  entry:@block_2150,
+fun_2268 = {
+  entry:@block_2267,
   num_params:3,
   num_locals:6,
 };
 
-block_2215 = {
+block_2332 = {
   instrs: [
     { op:'push', val:5 },
     { op:'new_object' },
@@ -20929,11 +21822,11 @@ block_2215 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2217, num_args:2 },
+    { op:'call', ret_to:@block_2334, num_args:2 },
   ]
 };
 
-block_2217 = {
+block_2334 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:0 },
@@ -20943,11 +21836,11 @@ block_2217 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2218, num_args:2 },
+    { op:'call', ret_to:@block_2335, num_args:2 },
   ]
 };
 
-block_2218 = {
+block_2335 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:0 },
@@ -20957,11 +21850,11 @@ block_2218 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2219, num_args:2 },
+    { op:'call', ret_to:@block_2336, num_args:2 },
   ]
 };
 
-block_2219 = {
+block_2336 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:0 },
@@ -20971,11 +21864,11 @@ block_2219 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2220, num_args:2 },
+    { op:'call', ret_to:@block_2337, num_args:2 },
   ]
 };
 
-block_2220 = {
+block_2337 = {
   instrs: [
     { op:'set_field' },
     { op:'dup', idx:0 },
@@ -20985,11 +21878,11 @@ block_2220 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'rt_getProp' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2221, num_args:2 },
+    { op:'call', ret_to:@block_2338, num_args:2 },
   ]
 };
 
-block_2221 = {
+block_2338 = {
   instrs: [
     { op:'set_field' },
     { op:'set_local', idx:0 },
@@ -20997,22 +21890,22 @@ block_2221 = {
     { op:'push', val:@global_obj },
     { op:'push', val:'parseUnit' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2222, num_args:1 },
+    { op:'call', ret_to:@block_2339, num_args:1 },
   ]
 };
 
-block_2222 = {
+block_2339 = {
   instrs: [
     { op:'set_local', idx:1 },
     { op:'get_local', idx:1 },
     { op:'push', val:@global_obj },
     { op:'push', val:'genUnit' },
     { op:'get_field' },
-    { op:'call', ret_to:@block_2223, num_args:1 },
+    { op:'call', ret_to:@block_2340, num_args:1 },
   ]
 };
 
-block_2223 = {
+block_2340 = {
   instrs: [
     { op:'set_local', idx:2 },
     { op:'get_local', idx:2 },
@@ -21020,13 +21913,13 @@ block_2223 = {
   ]
 };
 
-fun_2216 = {
-  entry:@block_2215,
+fun_2333 = {
+  entry:@block_2332,
   num_params:1,
   num_locals:3,
 };
 
-block_336 = {
+block_434 = {
   instrs: [
     { op:'set_field' },
     { op:'push', val:@global_obj },
@@ -21136,23 +22029,23 @@ block_336 = {
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseError' },
-    { op:'push', val:@fun_338 },
+    { op:'push', val:@fun_436 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'isSpace' },
-    { op:'push', val:@fun_357 },
+    { op:'push', val:@fun_455 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'isDigit' },
-    { op:'push', val:@fun_366 },
+    { op:'push', val:@fun_464 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'isAlpha' },
-    { op:'push', val:@fun_372 },
+    { op:'push', val:@fun_470 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'isAlnum' },
-    { op:'push', val:@fun_384 },
+    { op:'push', val:@fun_482 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'Input' },
@@ -21179,7 +22072,7 @@ block_336 = {
     { op:'push', val:1 },
     { op:'set_field' },
     { op:'set_field' },
-    { op:'push', val:@fun_402 },
+    { op:'push', val:@fun_500 },
     { op:'push', val:@global_obj },
     { op:'push', val:'Input' },
     { op:'get_field' },
@@ -21187,7 +22080,7 @@ block_336 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_407 },
+    { op:'push', val:@fun_505 },
     { op:'push', val:@global_obj },
     { op:'push', val:'Input' },
     { op:'get_field' },
@@ -21195,7 +22088,7 @@ block_336 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_419 },
+    { op:'push', val:@fun_517 },
     { op:'push', val:@global_obj },
     { op:'push', val:'Input' },
     { op:'get_field' },
@@ -21203,7 +22096,7 @@ block_336 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_456 },
+    { op:'push', val:@fun_554 },
     { op:'push', val:@global_obj },
     { op:'push', val:'Input' },
     { op:'get_field' },
@@ -21211,7 +22104,7 @@ block_336 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_461 },
+    { op:'push', val:@fun_559 },
     { op:'push', val:@global_obj },
     { op:'push', val:'Input' },
     { op:'get_field' },
@@ -21219,7 +22112,7 @@ block_336 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_486 },
+    { op:'push', val:@fun_585 },
     { op:'push', val:@global_obj },
     { op:'push', val:'Input' },
     { op:'get_field' },
@@ -21227,7 +22120,7 @@ block_336 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_505 },
+    { op:'push', val:@fun_606 },
     { op:'push', val:@global_obj },
     { op:'push', val:'Input' },
     { op:'get_field' },
@@ -21235,7 +22128,7 @@ block_336 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_516 },
+    { op:'push', val:@fun_617 },
     { op:'push', val:@global_obj },
     { op:'push', val:'Input' },
     { op:'get_field' },
@@ -21243,7 +22136,7 @@ block_336 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_580 },
+    { op:'push', val:@fun_681 },
     { op:'push', val:@global_obj },
     { op:'push', val:'Input' },
     { op:'get_field' },
@@ -21251,7 +22144,7 @@ block_336 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_586 },
+    { op:'push', val:@fun_687 },
     { op:'push', val:@global_obj },
     { op:'push', val:'Input' },
     { op:'get_field' },
@@ -21259,7 +22152,7 @@ block_336 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_592 },
+    { op:'push', val:@fun_693 },
     { op:'push', val:@global_obj },
     { op:'push', val:'Input' },
     { op:'get_field' },
@@ -21269,82 +22162,82 @@ block_336 = {
     { op:'pop' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseInt' },
-    { op:'push', val:@fun_598 },
+    { op:'push', val:@fun_699 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseEscSeq' },
-    { op:'push', val:@fun_643 },
+    { op:'push', val:@fun_745 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseStringLit' },
-    { op:'push', val:@fun_679 },
+    { op:'push', val:@fun_781 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseIdentStr' },
-    { op:'push', val:@fun_711 },
+    { op:'push', val:@fun_813 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseIfStmt' },
-    { op:'push', val:@fun_747 },
+    { op:'push', val:@fun_849 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseForStmt' },
-    { op:'push', val:@fun_761 },
+    { op:'push', val:@fun_863 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExprList' },
-    { op:'push', val:@fun_788 },
+    { op:'push', val:@fun_890 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseObjExpr' },
-    { op:'push', val:@fun_809 },
+    { op:'push', val:@fun_911 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseFunExpr' },
-    { op:'push', val:@fun_835 },
+    { op:'push', val:@fun_937 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'matchOp' },
-    { op:'push', val:@fun_868 },
+    { op:'push', val:@fun_970 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseAtom' },
-    { op:'push', val:@fun_919 },
+    { op:'push', val:@fun_1024 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExprPrec' },
-    { op:'push', val:@fun_1005 },
+    { op:'push', val:@fun_1110 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseExpr' },
-    { op:'push', val:@fun_1084 },
+    { op:'push', val:@fun_1191 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseBlockStmt' },
-    { op:'push', val:@fun_1087 },
+    { op:'push', val:@fun_1194 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseStmt' },
-    { op:'push', val:@fun_1113 },
+    { op:'push', val:@fun_1220 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseUnit' },
-    { op:'push', val:@fun_1200 },
+    { op:'push', val:@fun_1307 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseString' },
-    { op:'push', val:@fun_1203 },
+    { op:'push', val:@fun_1310 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'parseFile' },
-    { op:'push', val:@fun_1206 },
+    { op:'push', val:@fun_1313 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'Block' },
     { op:'push', val:0 },
     { op:'new_object' },
     { op:'set_field' },
-    { op:'push', val:@fun_1210 },
+    { op:'push', val:@fun_1317 },
     { op:'push', val:@global_obj },
     { op:'push', val:'Block' },
     { op:'get_field' },
@@ -21352,7 +22245,7 @@ block_336 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_1212 },
+    { op:'push', val:@fun_1319 },
     { op:'push', val:@global_obj },
     { op:'push', val:'Block' },
     { op:'get_field' },
@@ -21360,7 +22253,7 @@ block_336 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_1233 },
+    { op:'push', val:@fun_1340 },
     { op:'push', val:@global_obj },
     { op:'push', val:'Block' },
     { op:'get_field' },
@@ -21373,7 +22266,7 @@ block_336 = {
     { op:'push', val:0 },
     { op:'new_object' },
     { op:'set_field' },
-    { op:'push', val:@fun_1238 },
+    { op:'push', val:@fun_1345 },
     { op:'push', val:@global_obj },
     { op:'push', val:'Function' },
     { op:'get_field' },
@@ -21381,7 +22274,7 @@ block_336 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_1240 },
+    { op:'push', val:@fun_1347 },
     { op:'push', val:@global_obj },
     { op:'push', val:'Function' },
     { op:'get_field' },
@@ -21389,7 +22282,7 @@ block_336 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_1253 },
+    { op:'push', val:@fun_1360 },
     { op:'push', val:@global_obj },
     { op:'push', val:'Function' },
     { op:'get_field' },
@@ -21397,7 +22290,7 @@ block_336 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_1259 },
+    { op:'push', val:@fun_1366 },
     { op:'push', val:@global_obj },
     { op:'push', val:'Function' },
     { op:'get_field' },
@@ -21410,7 +22303,7 @@ block_336 = {
     { op:'push', val:0 },
     { op:'new_object' },
     { op:'set_field' },
-    { op:'push', val:@fun_1275 },
+    { op:'push', val:@fun_1383 },
     { op:'push', val:@global_obj },
     { op:'push', val:'CodeGenCtx' },
     { op:'get_field' },
@@ -21418,7 +22311,7 @@ block_336 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_1277 },
+    { op:'push', val:@fun_1385 },
     { op:'push', val:@global_obj },
     { op:'push', val:'CodeGenCtx' },
     { op:'get_field' },
@@ -21426,7 +22319,7 @@ block_336 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_1285 },
+    { op:'push', val:@fun_1393 },
     { op:'push', val:@global_obj },
     { op:'push', val:'CodeGenCtx' },
     { op:'get_field' },
@@ -21434,7 +22327,7 @@ block_336 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_1291 },
+    { op:'push', val:@fun_1399 },
     { op:'push', val:@global_obj },
     { op:'push', val:'CodeGenCtx' },
     { op:'get_field' },
@@ -21442,7 +22335,7 @@ block_336 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_1293 },
+    { op:'push', val:@fun_1401 },
     { op:'push', val:@global_obj },
     { op:'push', val:'CodeGenCtx' },
     { op:'get_field' },
@@ -21450,7 +22343,7 @@ block_336 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_1303 },
+    { op:'push', val:@fun_1411 },
     { op:'push', val:@global_obj },
     { op:'push', val:'CodeGenCtx' },
     { op:'get_field' },
@@ -21458,7 +22351,7 @@ block_336 = {
     { op:'dup', idx:2 },
     { op:'set_field' },
     { op:'pop' },
-    { op:'push', val:@fun_1308 },
+    { op:'push', val:@fun_1416 },
     { op:'push', val:@global_obj },
     { op:'push', val:'CodeGenCtx' },
     { op:'get_field' },
@@ -21468,41 +22361,41 @@ block_336 = {
     { op:'pop' },
     { op:'push', val:@global_obj },
     { op:'push', val:'registerDecls' },
-    { op:'push', val:@fun_1313 },
+    { op:'push', val:@fun_1421 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'genUnit' },
-    { op:'push', val:@fun_1379 },
+    { op:'push', val:@fun_1488 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'runtimeCall' },
-    { op:'push', val:@fun_1402 },
+    { op:'push', val:@fun_1511 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'genExpr' },
-    { op:'push', val:@fun_1413 },
+    { op:'push', val:@fun_1522 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'genStmt' },
-    { op:'push', val:@fun_1865 },
+    { op:'push', val:@fun_1979 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'genLogicalAnd' },
-    { op:'push', val:@fun_2066 },
+    { op:'push', val:@fun_2182 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'genLogicalOr' },
-    { op:'push', val:@fun_2086 },
+    { op:'push', val:@fun_2202 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'genObjExpr' },
-    { op:'push', val:@fun_2106 },
+    { op:'push', val:@fun_2222 },
     { op:'set_field' },
     { op:'push', val:@global_obj },
     { op:'push', val:'genAssign' },
-    { op:'push', val:@fun_2151 },
+    { op:'push', val:@fun_2268 },
     { op:'set_field' },
-    { op:'push', val:@fun_2216 },
+    { op:'push', val:@fun_2333 },
     { op:'push', val:@global_obj },
     { op:'push', val:'exports' },
     { op:'get_field' },

--- a/plush/codegen.cpp
+++ b/plush/codegen.cpp
@@ -543,7 +543,7 @@ void genExpr(CodeGenCtx& ctx, ASTExpr* expr)
         {
             genExpr(ctx, binOp->lhsExpr);
             genExpr(ctx, binOp->rhsExpr);
-            ctx.addOp("lt_i32");
+            runtimeCall(ctx, "lt", 2);
             return;
         }
 
@@ -559,7 +559,7 @@ void genExpr(CodeGenCtx& ctx, ASTExpr* expr)
         {
             genExpr(ctx, binOp->lhsExpr);
             genExpr(ctx, binOp->rhsExpr);
-            ctx.addOp("gt_i32");
+            runtimeCall(ctx, "gt", 2);
             return;
         }
 

--- a/plush/parser.cpp
+++ b/plush/parser.cpp
@@ -292,9 +292,7 @@ BlockStmt* parseBlockStmt(Input& input, std::string endStr);
 Parse a number
 */
 
-FloatExpr* parseFloatingPart(Input& input, bool neg, int64_t val) {
-    char literal[64] = {0};
-    sprintf(literal, "%" PRId64, val);
+FloatExpr* parseFloatingPart(Input& input, bool neg, char literal[64]) {
     int length = strlen(literal);
     for (int i = 0;;i++)
     {
@@ -316,9 +314,9 @@ FloatExpr* parseFloatingPart(Input& input, bool neg, int64_t val) {
 
 ASTExpr* parseNum(Input& input, bool neg)
 {
-    int64_t intVal = 0;
+    char literal[64] = {0};
 
-    for (;;)
+    for (int i = 0;;i++)
     {
         // Peek at the next character
         char ch = input.readCh();
@@ -326,8 +324,7 @@ ASTExpr* parseNum(Input& input, bool neg)
         if (!isdigit(ch))
             throw ParseError(input, "expected digit");
 
-        int64_t digit = ch - '0';
-        intVal = 10 * intVal + digit;
+        literal[i] = ch;
 
         // If the next character is not a digit, stop
         if (!isdigit(input.peekCh()))
@@ -335,9 +332,9 @@ ASTExpr* parseNum(Input& input, bool neg)
     }
 
     if (input.peekCh() == '.' || input.peekCh() == 'e') {
-        return parseFloatingPart(input, neg, intVal);
+        return parseFloatingPart(input, neg, literal);
     }
-
+    int intVal = atoi(literal);
     // If the value is negative
     if (neg)
     {

--- a/plush/runtime.pls
+++ b/plush/runtime.pls
@@ -148,9 +148,22 @@ var rt_eq = function (x, y)
 {
     if (typeof x == "int32")
     {
+        if (typeof y == "float32") {
+            return $eq_f32($i32_to_f32(x), y);
+        }
         if (typeof y == "int32")
         {
             return $eq_i32(x, y);
+        }
+    }
+
+    if (typeof x == "float32")
+    {
+        if (typeof y == "float32") {
+            return $eq_f32(x, y);
+        }
+        if (typeof y == "int32") {
+            return $eq_f32(x, $i32_to_f32(y));
         }
     }
 
@@ -209,14 +222,51 @@ var rt_ne = function (x, y)
         return true;
 };
 
+var rt_lt = function(x, y)
+{
+    if (typeof x == "int32")
+    {
+        if (typeof y == "float32") {
+            return $lt_f32($i32_to_f32(x), y);
+        }
+        if (typeof y == "int32")
+        {
+            return $lt_i32(x, y);
+        }
+    }
+
+    if (typeof x == "float32")
+    {
+        if (typeof y == "float32") {
+            return $lt_f32(x, y);
+        }
+        if (typeof y == "int32") {
+            return $lt_f32(x, $i32_to_f32(y));
+        }
+    }
+};
+
 /// Less than or equal comparison
 var rt_le = function (x, y)
 {
     if (typeof x == "int32")
     {
+        if (typeof y == "float32") {
+            return $le_f32($i32_to_f32(x), y);
+        }
         if (typeof y == "int32")
         {
             return $le_i32(x, y);
+        }
+    }
+
+    if (typeof x == "float32")
+    {
+        if (typeof y == "float32") {
+            return $le_f32(x, y);
+        }
+        if (typeof y == "int32") {
+            return $le_f32(x, $i32_to_f32(y));
         }
     }
 
@@ -237,14 +287,51 @@ var rt_le = function (x, y)
     );
 };
 
+var rt_gt = function(x, y)
+{
+    if (typeof x == "int32")
+    {
+        if (typeof y == "float32") {
+            return $gt_f32($i32_to_f32(x), y);
+        }
+        if (typeof y == "int32")
+        {
+            return $gt_i32(x, y);
+        }
+    }
+
+    if (typeof x == "float32")
+    {
+        if (typeof y == "float32") {
+            return $gt_f32(x, y);
+        }
+        if (typeof y == "int32") {
+            return $gt_f32(x, $i32_to_f32(y));
+        }
+    }
+};
+
 /// Greater than or equal comparison
 var rt_ge = function (x, y)
 {
     if (typeof x == "int32")
     {
+        if (typeof y == "float32") {
+            return $ge_f32($i32_to_f32(x), y);
+        }
         if (typeof y == "int32")
         {
             return $ge_i32(x, y);
+        }
+    }
+
+    if (typeof x == "float32")
+    {
+        if (typeof y == "float32") {
+            return $ge_f32(x, y);
+        }
+        if (typeof y == "int32") {
+            return $ge_f32(x, $i32_to_f32(y));
         }
     }
 
@@ -421,6 +508,44 @@ var output = function (x)
     assert (
         false,
         "unhandled type in output function"
+    );
+};
+
+var sin = function (x)
+{
+
+    if (typeof x == "int32")
+    {
+        return $sin_f32($i32_to_f32(x));
+    }
+
+    if (typeof x == "float32") 
+    {
+        return $sin_f32(x);
+    }
+
+    assert(
+        false,
+        "unhandled type in sin function"
+    );
+};
+
+var sqrt = function (x)
+{
+
+    if (typeof x == "int32")
+    {
+        return $sqrt_f32($i32_to_f32(x));
+    }
+
+    if (typeof x == "float32") 
+    {
+        return $sqrt_f32(x);
+    }
+
+    assert(
+        false,
+        "unhandled type in sin function"
     );
 };
 

--- a/tests/plush/floats.pls
+++ b/tests/plush/floats.pls
@@ -1,0 +1,36 @@
+// assigning floats;
+x = 1.0;
+y = 1e2;
+
+// arithmetic
+
+x = 1.0 + 3.5;
+y = 5.5 - 2.8;
+w = 9.0 / 3.0;
+z = 4.4 * 3.3;
+
+// automatic type casting
+
+x = 3 + 4.5 * 5.4 / 3;
+
+//sin and sqrt
+
+x = sin(50.8);
+y = sqrt(30.8);
+
+// comparisons
+
+assert(1.0 < 4.0);
+assert(1.0 <= 4.0);
+assert(4.0 > 1.0);
+assert(4.0 >= 1.0);
+assert(2.2 > 2.1);
+assert(1.11 < 1.12);
+assert(-1.1 < 2.0);
+assert(10000 > -0.0004);
+assert(0.005 > 0.0005);
+assert(0.0004 <= 0.0005);
+
+x = 1.0 == 1.0;
+assert(typeof x == "bool");
+assert(1.0 == 1.0);

--- a/tests/plush/floats.pls
+++ b/tests/plush/floats.pls
@@ -34,3 +34,13 @@ assert(0.0004 <= 0.0005);
 x = 1.0 == 1.0;
 assert(typeof x == "bool");
 assert(1.0 == 1.0);
+
+//float-string conversion
+
+x = $str_to_f32("1.0");
+assert(typeof x == "float32");
+print(x);
+
+y = $f32_to_str(1.0);
+print(y);
+assert(y == "1.000000");

--- a/tests/plush/floats.pls
+++ b/tests/plush/floats.pls
@@ -1,3 +1,12 @@
+fp_assert = function (xVal, xExpect, errMsg)
+{
+    var err = xVal - xExpect;
+    if (err < 0)
+        err = -err;
+
+    assert (err < 0.001, errMsg);
+};
+
 // assigning floats;
 x = 1.0;
 y = 1e2;
@@ -5,18 +14,25 @@ y = 1e2;
 // arithmetic
 
 x = 1.0 + 3.5;
+fp_assert(x, 4.5, "float addition doesn't work");
 y = 5.5 - 2.8;
+fp_assert(y, 2.7, "float substraction doesn't work");
 w = 9.0 / 3.0;
+fp_assert(w, 3.0, "float division doesn't work");
 z = 4.4 * 3.3;
+fp_assert(z, 14.52, "float multiplication doesn't work");
 
 // automatic type casting
 
-x = 3 + 4.5 * 5.4 / 3;
+x = 4.5 * 5.4 / 3 + 3 - 2.5;
 
+fp_assert(x, 8.6, "float auto casting and arithmetic doesn't work");
 //sin and sqrt
 
 x = sin(50.8);
+fp_assert(x, 0.50942, "sin for float doesn't work");
 y = sqrt(30.8);
+fp_assert(y, 5.54977, "sqrt for float doesn't work");
 
 // comparisons
 
@@ -35,10 +51,10 @@ x = 1.0 == 1.0;
 assert(typeof x == "bool");
 assert(1.0 == 1.0);
 
-//float-string conversion
+// float-string conversion
 
 x = $str_to_f32("1.0");
-assert(typeof x == "float32");
+fp_assert(x, 1.0, "string to float doesn't work");
 print(x);
 
 y = $f32_to_str(1.0);

--- a/vm/interp.cpp
+++ b/vm/interp.cpp
@@ -996,9 +996,7 @@ __attribute__((always_inline)) void hostCall(
         break;
 
         case 3:
-        {
-            retVal = hostFn->call3(*args, *(args - 1), *(args - 2));
-        }
+        retVal = hostFn->call3(*args, *(args - 1), *(args - 2));
         break;
 
         default:

--- a/vm/interp.cpp
+++ b/vm/interp.cpp
@@ -46,6 +46,8 @@ enum Opcode : uint16_t
     // Conversion operations
     I32_TO_F32,
     F32_TO_I32,
+    F32_TO_STR,
+    STR_TO_F32,
 
     // Miscellaneous
     EQ_BOOL,
@@ -596,6 +598,18 @@ void compile(BlockVersion* version)
         if (op == "f32_to_i32")
         {
             writeCode(F32_TO_I32);
+            continue;
+        }
+
+        if (op == "f32_to_str")
+        {
+            writeCode(F32_TO_STR);
+            continue;
+        }
+
+        if (op == "str_to_f32")
+        {
+            writeCode(STR_TO_F32);
             continue;
         }
 
@@ -1251,6 +1265,21 @@ Value execCode()
             {
                 auto arg0 = popFloat32();
                 pushVal(Value::int32(arg0));
+            }
+            break;
+
+            case F32_TO_STR:
+            {
+                auto arg0 = popFloat32();
+                String str = std::to_string(arg0);
+                pushVal(str);
+            }
+            break;
+
+            case STR_TO_F32:
+            {
+                auto arg0 = popStr();
+                pushVal(Value::float32(std::stof(arg0)));
             }
             break;
 

--- a/vm/interp.cpp
+++ b/vm/interp.cpp
@@ -988,15 +988,17 @@ __attribute__((always_inline)) void hostCall(
         break;
 
         case 1:
-        retVal = hostFn->call1(args[0]);
+        retVal = hostFn->call1(*args);
         break;
 
         case 2:
-        retVal = hostFn->call2(args[0], args[1]);
+        retVal = hostFn->call2(*args, *(args - 1));
         break;
 
         case 3:
-        retVal = hostFn->call3(args[0], args[1], args[2]);
+        {
+            retVal = hostFn->call3(*args, *(args - 1), *(args - 2));
+        }
         break;
 
         default:

--- a/vm/interp.cpp
+++ b/vm/interp.cpp
@@ -19,7 +19,7 @@ enum Opcode : uint16_t
     DUP,
     SWAP,
 
-    // 64-bit integer operations
+    // 32-bit integer operations
     ADD_I32,
     SUB_I32,
     MUL_I32,
@@ -34,6 +34,11 @@ enum Opcode : uint16_t
     SUB_F32,
     MUL_F32,
     DIV_F32,
+    LT_F32,
+    LE_F32,
+    GT_F32,
+    GE_F32,
+    EQ_F32,
     SIN_F32,
     COS_F32,
     SQRT_F32,
@@ -527,6 +532,36 @@ void compile(BlockVersion* version)
         if (op == "div_f32")
         {
             writeCode(DIV_F32);
+            continue;
+        }
+
+        if (op == "lt_f32")
+        {
+            writeCode(LT_F32);
+            continue;
+        }
+
+        if (op == "le_f32")
+        {
+            writeCode(LE_F32);
+            continue;
+        }
+
+        if (op == "gt_f32")
+        {
+            writeCode(GT_F32);
+            continue;
+        }
+
+        if (op == "ge_f32")
+        {
+            writeCode(GE_F32);
+            continue;
+        }
+
+        if (op == "eq_f32")
+        {
+            writeCode(EQ_F32);
             continue;
         }
 
@@ -1137,6 +1172,46 @@ Value execCode()
                 auto arg1 = popFloat32();
                 auto arg0 = popFloat32();
                 pushVal(Value::float32(arg0 / arg1));
+            }
+            break;
+
+            case LT_F32:
+            {
+                auto arg1 = popFloat32();
+                auto arg0 = popFloat32();
+                pushBool(arg0 < arg1);
+            }
+            break;
+
+            case LE_F32:
+            {
+                auto arg1 = popFloat32();
+                auto arg0 = popFloat32();
+                pushBool(arg0 <= arg1);
+            }
+            break;
+
+            case GT_F32:
+            {
+                auto arg1 = popFloat32();
+                auto arg0 = popFloat32();
+                pushBool(arg0 > arg1);
+            }
+            break;
+
+            case GE_F32:
+            {
+                auto arg1 = popFloat32();
+                auto arg0 = popFloat32();
+                pushBool(arg0 >= arg1);
+            }
+            break;
+
+            case EQ_F32:
+            {
+                auto arg1 = popFloat32();
+                auto arg0 = popFloat32();
+                pushBool(arg0 == arg1);
             }
             break;
 

--- a/vm/parser.cpp
+++ b/vm/parser.cpp
@@ -221,16 +221,16 @@ void Input::eatWS()
 // Forward declaration
 Value parseExpr(Input& input);
 
-Value parseFloatingPart(Input& input, bool neg, int64_t val);
+Value parseFloatingPart(Input& input, bool neg, char literal[64]);
 
 /**
 Parse a decimal integer
 */
 Value parseNum(Input& input, bool neg)
 {
-    int32_t intVal = 0;
+    char literal[64] = {0};
 
-    for (;;)
+    for (int i = 0;;i++)
     {
         // Peek at the next character
         char ch = input.readCh();
@@ -238,8 +238,7 @@ Value parseNum(Input& input, bool neg)
         if (!isdigit(ch))
             throw ParseError(input, "expected digit");
 
-        int32_t digit = ch - '0';
-        intVal = 10 * intVal + digit;
+        literal[i] = ch;
 
         // If the next character is not a digit, stop
         if (!isdigit(input.peek()))
@@ -249,9 +248,9 @@ Value parseNum(Input& input, bool neg)
     char next = input.peek();
     if (next == '.' || next == 'e')
     {
-        return parseFloatingPart(input, neg, intVal);
+        return parseFloatingPart(input, neg, literal);
     }
-
+    int intVal = atoi(literal);
     // If the value is negative
     if (neg)
     {
@@ -261,10 +260,8 @@ Value parseNum(Input& input, bool neg)
     return Value::int32(intVal);
 }
 
-Value parseFloatingPart(Input& input, bool neg, int64_t val)
+Value parseFloatingPart(Input& input, bool neg, char literal[64])
 {
-    char literal[64] = {0};
-    sprintf(literal, "%" PRId64, val);
     int length = strlen(literal);
     for (int i = 0;;i++)
     {


### PR DESCRIPTION
I've added comparisons operations to floats (both in zeta and plush).

I've also added conversion operations for floats-strings to zeta, but I'm not sure how you want to implement them for plush. 

I've added a new test file written in plush for floats. 