### PR TITLE
Now scheme compiles on Linux.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,35 @@
 # More up to date Ubuntu distribution
 dist: trusty
 
+matrix:
+  include:
+
+    # works on Trusty
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-4.0
+          packages:
+            - clang-4.0
+      env:
+        - MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0"
+        
+    # works on Precise and Trusty
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
+      env:
+         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+
+
+before_install:
+    - eval "${MATRIX_EVAL}"
+
 language: cpp
 
 compiler:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ matrix:
   include:
     # works on Trusty
     - os: linux
+      compiler: clang
       addons:
         apt:
           sources:
@@ -16,6 +17,7 @@ matrix:
         
     # works on Precise and Trusty
     - os: linux
+      compiler: gcc
       addons:
         apt:
           sources:
@@ -33,5 +35,3 @@ language: cpp
 
 script: ./configure && make && make test
 
-os:
-    - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
             - clang-4.0
       env:
         - MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0"
-        
+
     # works on Precise and Trusty
     - os: linux
       addons:
@@ -30,11 +30,7 @@ matrix:
 before_install:
     - eval "${MATRIX_EVAL}"
 
-language: cpp
-
-compiler:
-    - clang
-    - gcc
+script: ./configure && make && make test
 
 os:
     - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: trusty
 
 matrix:
   include:
-
     # works on Trusty
     - os: linux
       addons:
@@ -14,7 +13,7 @@ matrix:
             - clang-4.0
       env:
         - MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0"
-
+        
     # works on Precise and Trusty
     - os: linux
       addons:
@@ -29,6 +28,8 @@ matrix:
 
 before_install:
     - eval "${MATRIX_EVAL}"
+
+language: cpp
 
 script: ./configure && make && make test
 

--- a/scheme/parser.h
+++ b/scheme/parser.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <memory>
 #include <vector>
 #include <unordered_map>
 


### PR DESCRIPTION
As stated here: http://en.cppreference.com/w/cpp/memory/unique_ptr std::unique_ptr is declared in the memory header. I'm not sure why this is an error in Linux and not on macOS. 

This should solve the issue anyway. Or at least it solves it on my machine. 